### PR TITLE
Fix #1 build errors + gofmt

### DIFF
--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -1,18 +1,18 @@
 package bitswap
 
 import (
-  "github.com/jbenet/go-ipfs/blocks"
-  "github.com/jbenet/go-multihash"
+	"github.com/jbenet/go-ipfs/blocks"
+	"github.com/jbenet/go-multihash"
 )
 
 // aliases
 
 type Ledger struct {
-  // todo
+	// todo
 }
 
 type BitSwap struct {
-  Ledgers  map[string]*Ledger
-  HaveList map[string]*blocks.Block
-  WantList []*multihash.Multihash
+	Ledgers  map[string]*Ledger
+	HaveList map[string]*blocks.Block
+	WantList []*multihash.Multihash
 }

--- a/netmux/interface.go
+++ b/netmux/interface.go
@@ -1,7 +1,7 @@
 package netmux
 
 import (
-  "net"
+	"net"
 )
 
 // An interface is the module connecting netmux
@@ -9,88 +9,88 @@ import (
 // It keeps the relevant connections open.
 type Interface struct {
 
-  // Interface network (e.g. udp4, tcp6)
-  Network string
+	// Interface network (e.g. udp4, tcp6)
+	Network string
 
-  // Own network address
-  Address         string
-  ResolvedAddress *net.UDPAddr
+	// Own network address
+	Address         string
+	ResolvedAddress *net.UDPAddr
 
-  // Connection
-  conn net.Conn
+	// Connection
+	conn net.Conn
 
-  // next packets + close control channels
-  Input  chan *Packet
-  Output chan *Packet
-  Closed chan bool
-  Errors chan error
+	// next packets + close control channels
+	Input  chan *Packet
+	Output chan *Packet
+	Closed chan bool
+	Errors chan error
 }
 
 func NewUDPInterface(network, addr string) (*Interface, error) {
-  raddr, err := net.ResolveUDPAddr(network, addr)
-  if err != nil {
-    return nil, err
-  }
+	raddr, err := net.ResolveUDPAddr(network, addr)
+	if err != nil {
+		return nil, err
+	}
 
-  conn, err := net.ListenUDP(network, raddr)
-  if err != nil {
-    return nil, err
-  }
+	conn, err := net.ListenUDP(network, raddr)
+	if err != nil {
+		return nil, err
+	}
 
-  i := &Interface{
-    Network: network,
-    Address: addr,
-    ResolvedAddress: raddr,
-    conn: conn,
-  }
+	i := &Interface{
+		Network:         network,
+		Address:         addr,
+		ResolvedAddress: raddr,
+		conn:            conn,
+	}
 
-  go i.processUDPInput()
-  go i.processOutput()
-  return i, nil
+	go i.processUDPInput()
+	go i.processOutput()
+	return i, nil
 }
 
 func (i *Interface) processOutput() {
-  for {
-    select {
-    case <-i.Closed:
-      break
+	for {
+		select {
+		case <-i.Closed:
+			break
 
-    case buffer := <-i.Output:
-      i.conn.Write([]byte(buffer.Data))
-    }
-  }
+		case buffer := <-i.Output:
+			i.conn.Write([]byte(buffer.Data))
+		}
+	}
 }
 
 func (i *Interface) processUDPInput() {
-  for {
-    select {
-    case <-i.Closed:
-      break
+	for {
+		select {
+		case <-i.Closed:
+			break
 
-    }
-  }
+		}
+	}
 }
 
 func (i *Interface) Read(buffer []byte) bool {
-  _, err := i.conn.Read(buffer)
-  if err != nil {
-    i.Errors <- err
-    i.Close()
-    return false
-  }
-  return true
+	_, err := i.conn.Read(buffer)
+	if err != nil {
+		i.Errors <- err
+		i.Close()
+		return false
+	}
+	return true
 }
 
 func (i *Interface) Close() {
-  // closing net connection
-  err := i.conn.Close()
-  if err != nil {
-    i.Errors <- err
-  }
+	// closing net connection
+	err := i.conn.Close()
+	if err != nil {
+		i.Errors <- err
+	}
 
-  // closing channels
-  close(i.Input)
-  close(i.Output)
-  close(i.Closed)
-  close(i.Errors)
+	// closing channels
+	close(i.Input)
+	close(i.Output)
+	close(i.Closed)
+	close(i.Errors)
 }

--- a/netmux/netmux.go
+++ b/netmux/netmux.go
@@ -6,41 +6,41 @@ package netmux
 // and multiplex everything over one interface.
 
 type Netmux struct {
-  // the list of NetMux interfaces
-  Interfaces []*Interface
+	// the list of NetMux interfaces
+	Interfaces []*Interface
 
-  // The channels to send/recv from
-  Incoming <-chan *Packet
-  Outgoing chan<- *Packet
+	// The channels to send/recv from
+	Incoming <-chan *Packet
+	Outgoing chan<- *Packet
 
-  // internally managed other side of channels
-  incomingSrc chan<- *Packet
-  outgoingSrc <-chan *Packet
+	// internally managed other side of channels
+	incomingSrc chan<- *Packet
+	outgoingSrc <-chan *Packet
 }
 
 // Warning: will probably change to adopt multiaddr format
 type Packet struct {
-  // the network addresses to send to
-  // e.g. tcp4://127.0.0.1:12345
-  NetAddrTo string
+	// the network addresses to send to
+	// e.g. tcp4://127.0.0.1:12345
+	NetAddrTo string
 
-  // the network addresses to recv from
-  // e.g. tcp4://127.0.0.1:12345
-  // may be left blank to select one automatically.
-  NetAddrFrom string
+	// the network addresses to recv from
+	// e.g. tcp4://127.0.0.1:12345
+	// may be left blank to select one automatically.
+	NetAddrFrom string
 
-  // the data to send.
-  Data []byte
+	// the data to send.
+	Data []byte
 }
 
 func NewNetmux() *Netmux {
-  n := &Netmux{}
+	n := &Netmux{}
 
-  // setup channels
-  och := make(chan *Packet)
-  ich := make(chan *Packet)
-  n.Incoming, n.incomingSrc = ich, ich
-  n.Outgoing, n.outgoingSrc = och, och
+	// setup channels
+	och := make(chan *Packet)
+	ich := make(chan *Packet)
+	n.Incoming, n.incomingSrc = ich, ich
+	n.Outgoing, n.outgoingSrc = och, och
 
-  return n
+	return n
 }


### PR DESCRIPTION
Both `Ledgers` and `HaveList` should call `Multihash.HexString()` in order to set elements of maps because type Multihash has `[]byte` as underlying type (instead of struct) and can't be used as map key.

``` go
type BitSwap struct {
    Ledgers  map[string]*Ledger
    HaveList map[string]*blocks.Block
    WantList []*multihash.Multihash
}
```

EDIT: Do you want me to split this into two commits. One for type changes and another one for gofmt?
