### PR TITLE
Simplify install + Note for git and hg.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ Please put all issues regarding go IPFS _implementation_ in [this repo](https://
 [Install Go](http://golang.org/doc/install). Then:
 
 ```
-git clone https://github.com/jbenet/go-ipfs
-cd go-ipfs/cmd/ipfs
-go get ./...
-go install
+go get github.com/jbenet/go-ipfs/cmd/ipfs
 ```
+
+NOTE: `git` and mercurial (`hg`) are required in order for `go get` to fetch all dependencies.
 
 ## Usage
 


### PR DESCRIPTION
Simpler, long-term aware installation of `ipfs` cmd.

Updating is just as simple as:
`go get -u github.com/jbenet/go-ipfs/cmd/ipfs`

The entire repo is cloned and all its dependencies there's no need for explicit git clone, cd'ing into folders and such.
