### PR TITLE
disable mount command on windows for now

### DIFF
--- a/cmd/ipfs/mount_unix.go
+++ b/cmd/ipfs/mount_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux darwin freebsd
 
 package main
 

--- a/cmd/ipfs/mount_windows.go
+++ b/cmd/ipfs/mount_windows.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"github.com/gonuts/flag"
 	"github.com/jbenet/commander"
 )
@@ -15,7 +15,5 @@ var cmdIpfsMount = &commander.Command{
 }
 
 func mountCmd(c *commander.Command, inp []string) error {
-	fmt.Printf("not implemented yet\n")
-
-	return nil
+	return errors.New("mount not yet implemented on windows")
 }

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -1,6 +1,6 @@
 // A Go mirror of libfuse's hello.c
 
-// +build !windows
+// +build linux darwin freebsd
 
 package readonly
 


### PR DESCRIPTION
Since mount depends on fuse this pull request disables the command on windows so go-ipfs can be compiled.
