### PR TITLE
refactor(bitswap:message) add wrapper for proto

### DIFF
--- a/bitswap/message.go
+++ b/bitswap/message.go
@@ -1,0 +1,38 @@
+package bitswap
+
+import (
+	blocks "github.com/jbenet/go-ipfs/blocks"
+	peer "github.com/jbenet/go-ipfs/peer"
+	swarm "github.com/jbenet/go-ipfs/swarm"
+	u "github.com/jbenet/go-ipfs/util"
+)
+
+// message wraps a proto message for convenience
+type message struct {
+	pb PBMessage
+}
+
+func newMessageFromProto(pb PBMessage) *message {
+	return &message{pb: pb}
+}
+
+func newMessage() *message {
+	return new(message)
+}
+
+func (m *message) AppendWanted(k u.Key) {
+	m.pb.Wantlist = append(m.pb.Wantlist, string(k))
+}
+
+func (m *message) AppendBlock(b *blocks.Block) {
+	m.pb.Blocks = append(m.pb.Blocks, b.Data)
+}
+
+func (m *message) ToProto() *PBMessage {
+	cp := m.pb
+	return &cp
+}
+
+func (m *message) ToSwarm(p *peer.Peer) *swarm.Message {
+	return swarm.NewMessage(p, m.ToProto())
+}

--- a/bitswap/message_test.go
+++ b/bitswap/message_test.go
@@ -1,0 +1,75 @@
+package bitswap
+
+import (
+	"bytes"
+	"testing"
+
+	blocks "github.com/jbenet/go-ipfs/blocks"
+	u "github.com/jbenet/go-ipfs/util"
+)
+
+func TestAppendWanted(t *testing.T) {
+	const str = "foo"
+	m := newMessage()
+	m.AppendWanted(u.Key(str))
+
+	if !contains(m.ToProto().GetWantlist(), str) {
+		t.Fail()
+	}
+}
+
+func TestNewMessageFromProto(t *testing.T) {
+	const str = "a_key"
+	protoMessage := new(PBMessage)
+	protoMessage.Wantlist = []string{string(str)}
+	if !contains(protoMessage.Wantlist, str) {
+		t.Fail()
+	}
+	m := newMessageFromProto(*protoMessage)
+	if !contains(m.ToProto().GetWantlist(), str) {
+		t.Fail()
+	}
+}
+
+func TestAppendBlock(t *testing.T) {
+
+	strs := make([]string, 2)
+	strs = append(strs, "Celeritas")
+	strs = append(strs, "Incendia")
+
+	m := newMessage()
+	for _, str := range strs {
+		block, err := blocks.NewBlock([]byte(str))
+		if err != nil {
+			t.Fail()
+		}
+		m.AppendBlock(block)
+	}
+
+	// assert strings are in proto message
+	for _, blockbytes := range m.ToProto().GetBlocks() {
+		s := bytes.NewBuffer(blockbytes).String()
+		if !contains(strs, s) {
+			t.Fail()
+		}
+	}
+}
+
+func TestCopyProtoByValue(t *testing.T) {
+	const str = "foo"
+	m := newMessage()
+	protoBeforeAppend := m.ToProto()
+	m.AppendWanted(u.Key(str))
+	if contains(protoBeforeAppend.GetWantlist(), str) {
+		t.Fail()
+	}
+}
+
+func contains(s []string, x string) bool {
+	for _, a := range s {
+		if a == x {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR adds a wrapper for the Proto.

Design Goals:
- allow bitswap subsystem to deal with keys and blocks rather than strings and bytes
- centralize message packaging logic
- reduce conceptual overhead in large bitswap methods
