### PR TITLE
fix(bitswap) don't let receiver close channel

### DIFF
--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -105,7 +105,6 @@ func (bs *BitSwap) GetBlock(k u.Key, timeout time.Duration) (
 
 	select {
 	case blkdata := <-valchan:
-		close(valchan)
 		return blocks.NewBlock(blkdata)
 	case <-after:
 		return nil, u.ErrTimeout


### PR DESCRIPTION
sender will panic when attempting to send on closed channel

https://groups.google.com/forum/#!msg/golang-nuts/pZwdYRGxCIk/qpbHxRRPJdUJ

Conflicts:
    bitswap/bitswap.go
