### PR TITLE
Implement XDG base directory specification (issue #120)

### DIFF
--- a/cmd/ipfs/add.go
+++ b/cmd/ipfs/add.go
@@ -45,7 +45,7 @@ func addCmd(c *commander.Command, inp []string) error {
 	err := daemon.SendCommand(cmd, "localhost:12345")
 	if err != nil {
 		// Do locally
-		conf, err := getConfigDir(c.Parent)
+		conf, err := getConfigFlag(c.Parent)
 		if err != nil {
 			return err
 		}

--- a/cmd/ipfs/cat.go
+++ b/cmd/ipfs/cat.go
@@ -34,7 +34,7 @@ func catCmd(c *commander.Command, inp []string) error {
 
 	err := daemon.SendCommand(com, "localhost:12345")
 	if err != nil {
-		conf, err := getConfigDir(c.Parent)
+		conf, err := getConfigFlag(c.Parent)
 		if err != nil {
 			return err
 		}

--- a/cmd/ipfs/ipfs.go
+++ b/cmd/ipfs/ipfs.go
@@ -53,7 +53,7 @@ Use "ipfs help <command>" for more information about a command.
 }
 
 func init() {
-	CmdIpfs.Flag.String("c", config.DefaultPathRoot, "specify config directory")
+	CmdIpfs.Flag.String("c", "", "specify config file")
 }
 
 func ipfsCmd(c *commander.Command, args []string) error {
@@ -73,8 +73,8 @@ func main() {
 	return
 }
 
-func localNode(confdir string, online bool) (*core.IpfsNode, error) {
-	cfg, err := config.Load(confdir + "/config")
+func localNode(confFile string, online bool) (*core.IpfsNode, error) {
+	cfg, err := config.Load(confFile)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func localNode(confdir string, online bool) (*core.IpfsNode, error) {
 
 // Gets the config "-c" flag from the command, or returns
 // the empty string
-func getConfigDir(c *commander.Command) (string, error) {
+func getConfigFlag(c *commander.Command) (string, error) {
 	conf := c.Flag.Lookup("c").Value.Get()
 	if conf == nil {
 		return "", nil

--- a/cmd/ipfs/ls.go
+++ b/cmd/ipfs/ls.go
@@ -36,7 +36,7 @@ func lsCmd(c *commander.Command, inp []string) error {
 	com.Args = inp
 	err := daemon.SendCommand(com, "localhost:12345")
 	if err != nil {
-		conf, err := getConfigDir(c.Parent)
+		conf, err := getConfigFlag(c.Parent)
 		if err != nil {
 			return err
 		}

--- a/cmd/ipfs/mount_unix.go
+++ b/cmd/ipfs/mount_unix.go
@@ -35,7 +35,7 @@ func mountCmd(c *commander.Command, inp []string) error {
 		return nil
 	}
 
-	conf, err := getConfigDir(c.Parent)
+	conf, err := getConfigFlag(c.Parent)
 	if err != nil {
 		return err
 	}

--- a/cmd/ipfs/refs.go
+++ b/cmd/ipfs/refs.go
@@ -46,7 +46,7 @@ func refCmd(c *commander.Command, inp []string) error {
 	err := daemon.SendCommand(cmd, "localhost:12345")
 	if err != nil {
 		// Do locally
-		conf, err := getConfigDir(c.Parent)
+		conf, err := getConfigFlag(c.Parent)
 		if err != nil {
 			return err
 		}

--- a/core/datastore.go
+++ b/core/datastore.go
@@ -24,9 +24,14 @@ func makeDatastore(cfg config.Datastore) (ds.Datastore, error) {
 }
 
 func makeLevelDBDatastore(cfg config.Datastore) (ds.Datastore, error) {
-	if len(cfg.Path) == 0 {
+	path, err := cfg.GetPath()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(path) == 0 {
 		return nil, fmt.Errorf("config datastore.path required for leveldb")
 	}
 
-	return lds.NewDatastore(cfg.Path, nil)
+	return lds.NewDatastore(path, nil)
 }


### PR DESCRIPTION
This is how it has been implemented:
- Unless specified using the `-c` command line option, the configuration is generally found at `~/.config/go-ipfs/config`
- The `-c` command line option now specifies the configuration file itself (and not its directory)
- During `ipfs init` it is possible to specify the database location using the `-d` option.
- The database location generally defaults to `~/.local/share/go-ipfs/datastore`
- If a relative path is found in the configuration file for the database location, this file is relative to the XDG Data directories.

What might be missing is transition code to move/read files already in `~/.go-ipfs`
