### PR TITLE
Revert "perf(mux) use RWMutex"

### DIFF
--- a/net/mux/mux.go
+++ b/net/mux/mux.go
@@ -41,10 +41,10 @@ type Muxer struct {
 	// Protocols are the multiplexed services.
 	Protocols ProtocolMap
 
-	bwiLock sync.RWMutex
+	bwiLock sync.Mutex
 	bwIn    uint64
 
-	bwoLock sync.RWMutex
+	bwoLock sync.Mutex
 	bwOut   uint64
 
 	*msg.Pipe
@@ -76,13 +76,13 @@ func (m *Muxer) GetPipe() *msg.Pipe {
 
 // GetBandwidthTotals return the in/out bandwidth measured over this muxer.
 func (m *Muxer) GetBandwidthTotals() (in uint64, out uint64) {
-	m.bwiLock.RLock()
+	m.bwiLock.Lock()
 	in = m.bwIn
-	m.bwiLock.RUnlock()
+	m.bwiLock.Unlock()
 
-	m.bwoLock.RLock()
+	m.bwoLock.Lock()
 	out = m.bwOut
-	m.bwoLock.RUnlock()
+	m.bwoLock.Unlock()
 	return
 }
 


### PR DESCRIPTION
Reverts jbenet/go-ipfs#218

@whyrusleeping points out

> RWMutexes Standard lock operation takes twice as long as a normal mutex. The only proper use case for it is frequent reads with infrequent writes, GetBandwidth will be called rather infrequently.
