### PR TITLE
dagwriter: fix reuse of buffers problem.

### DIFF
--- a/unixfs/io/dagwriter.go
+++ b/unixfs/io/dagwriter.go
@@ -97,8 +97,10 @@ func (dw *DagWriter) Write(b []byte) (int, error) {
 	if dw.seterr != nil {
 		return 0, dw.seterr
 	}
-	dw.splChan <- b
-	return len(b), nil
+	cpy := make([]byte, len(b))
+	copy(cpy, b)
+	dw.splChan <- cpy
+	return len(cpy), nil
 }
 
 // Close the splitters input channel and wait for it to finish

--- a/unixfs/io/dagwriter_test.go
+++ b/unixfs/io/dagwriter_test.go
@@ -58,7 +58,7 @@ func TestDagWriter(t *testing.T) {
 	dag := mdag.NewDAGService(bserv)
 	dw := dagio.NewDagWriter(dag, &chunk.SizeSplitter{Size: 4096})
 
-	nbytes := int64(1024 * 1024 * 2)
+	nbytes := int64(1024 * 1024 * 1000)
 	n, err := io.CopyN(dw, &datasource{}, nbytes)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The buffers from the client were getting reused (not copied)
and so the data got duplicated internally. The tests don't
catch this!! I tested manually by adding a large text (aeneid).
We should make a test for it.

And, FWIW, tried making the channel sync (i.e. dagwriter
splChan not be buffered), which may be the right way to fix
the problem, but didnt work.
