### PR TITLE
feat(docker) build a daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
 FROM golang:1.3
 MAINTAINER Brian Tiger Chow <btc@perfmode.com>
 
-RUN apt-get update
-RUN apt-get install -y fuse
-
 COPY . /go/src/github.com/jbenet/go-ipfs
-
 RUN cd /go/src/github.com/jbenet/go-ipfs/cmd/ipfs && go install
 RUN ipfs init
 RUN ipfs config Identity.Address "/ip4/0.0.0.0/tcp/4001"
-RUN mkdir /ipfs
 
 EXPOSE 4001
 
-CMD ["ipfs", "mount", "/ipfs"]
+CMD ["ipfs", "run"]
 
 # build:    docker build -t go-ipfs .
 # run:      docker run --privileged=true -i -t go-ipfs:latest


### PR DESCRIPTION
@jbenet Quick change.

The default Docker build now creates a daemon without mounting.

TODO allow bootstrap node to be overridden at runtime (perhaps with an
environment variable), so we can use custom topologies in test
environments. NB: We still want the default behavior to connect to Mars.

TODO create a docker image that mounts (and uses shared volume to make
that mount accessible on the host).
