### PR TITLE
Update README.md to state that Go 1.3+ is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please put all issues regarding go IPFS _implementation_ in [this repo](https://
 
 ## Install
 
-[Install Go 1.2+](http://golang.org/doc/install). Then:
+[Install Go 1.3+](http://golang.org/doc/install). Then:
 
 ```
 go get github.com/jbenet/go-ipfs/cmd/ipfs


### PR DESCRIPTION
We don't suport Go 1.2 according to:

https://github.com/jbenet/go-ipfs/commit/634d89f1b0e06afc17b6f42b5224972866146c16
