### PR TITLE
fix(Dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ MAINTAINER Brian Tiger Chow <btc@perfmode.com>
 
 COPY . /go/src/github.com/jbenet/go-ipfs
 RUN cd /go/src/github.com/jbenet/go-ipfs/cmd/ipfs && go install
-RUN ipfs init
-RUN ipfs config Identity.Address "/ip4/0.0.0.0/tcp/4001"
 
 EXPOSE 4001
 


### PR DESCRIPTION
removed `ipfs init` (so that the image ships no longer ships with an identity)

TODO Maybe allow an init flag `ipfs --init run`?  It's important to keep the initialization process simple. Open to alternatives. It would be nice to be able to ship an image that users can pull and execute in one command.
