### PR TITLE
Use a FUSE prerequisite to skip mount tests

### DIFF
--- a/test/t0030-mount.sh
+++ b/test/t0030-mount.sh
@@ -9,10 +9,10 @@ test_description="Test mount command"
 . ./test-lib.sh
 
 # if in travis CI, dont test mount (no fuse)
-if test "$TEST_NO_FUSE" = 1; then
-  skip_all='skipping mount tests, fuse not available'
+if ! test_have_prereq FUSE; then
+	skip_all='skipping mount tests, fuse not available'
 
-  test_done
+	test_done
 fi
 
 test_launch_ipfs_mount

--- a/test/t0040-add-and-cat.sh
+++ b/test/t0040-add-and-cat.sh
@@ -30,11 +30,11 @@ test_expect_success "ipfs cat output looks good" '
 	test_cmp expected actual
 '
 
-test_expect_success "cat ipfs/stuff succeeds" '
+test_expect_success FUSE "cat ipfs/stuff succeeds" '
 	cat ipfs/$HASH >actual
 '
 
-test_expect_success "cat ipfs/stuff looks good" '
+test_expect_success FUSE "cat ipfs/stuff looks good" '
 	test_cmp expected actual
 '
 
@@ -71,11 +71,11 @@ test_expect_success "ipfs cat output looks good" '
 	test_cmp sha1_expected sha1_actual
 '
 
-test_expect_success "cat ipfs/bigfile succeeds" '
+test_expect_success FUSE "cat ipfs/bigfile succeeds" '
 	cat ipfs/$HASH | sha1sum >sha1_actual
 '
 
-test_expect_success "cat ipfs/bigfile looks good" '
+test_expect_success FUSE "cat ipfs/bigfile looks good" '
 	test_cmp sha1_expected sha1_actual
 '
 

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -16,6 +16,8 @@ SHARNESS_LIB="./sharness.sh"
 
 # Please put go-ipfs specific shell functions below
 
+test "$TEST_NO_FUSE" != 1 && test_set_prereq FUSE
+
 test_cmp_repeat_10_sec() {
 	for i in 1 2 3 4 5 6 7 8 9 10
 	do
@@ -38,11 +40,11 @@ test_launch_ipfs_mount() {
 		ipfs config Mounts.IPNS "$(pwd)/ipns"
 	'
 
-	test_expect_success "ipfs mount succeeds" '
+	test_expect_success FUSE "ipfs mount succeeds" '
 		ipfs mount mountdir >actual &
 	'
 
-	test_expect_success "ipfs mount output looks good" '
+	test_expect_success FUSE "ipfs mount output looks good" '
 		IPFS_PID=$! &&
 		echo "mounting ipfs at $(pwd)/ipfs" >expected &&
 		echo "mounting ipns at $(pwd)/ipns" >>expected &&
@@ -52,11 +54,11 @@ test_launch_ipfs_mount() {
 
 test_kill_ipfs_mount() {
 
-	test_expect_success "ipfs mount is still running" '
+	test_expect_success FUSE "ipfs mount is still running" '
 		kill -0 $IPFS_PID
 	'
 
-	test_expect_success "ipfs mount can be killed" '
+	test_expect_success FUSE "ipfs mount can be killed" '
 		kill $IPFS_PID &&
 		sleep 1 &&
 		! kill -0 $IPFS_PID 2>/dev/null


### PR DESCRIPTION
When there is no fuse we should skip all mount
tests and using a FUSE prerequisite is a good
way to do that.
