### PR TITLE
 windows mount  fix

### DIFF
--- a/core/commands2/mount_windows.go
+++ b/core/commands2/mount_windows.go
@@ -6,7 +6,7 @@ import (
 	cmds "github.com/jbenet/go-ipfs/commands"
 )
 
-var ipfsMount = &cmds.Command{
+var mountCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline:          "Not yet implemented on Windows",
 		ShortDescription: "Not yet implemented on Windows. :(",


### PR DESCRIPTION
# github.com/jbenet/go-ipfs/core/commands2

....\core\commands2\root.go:69: undefined: mountCmd
