### PR TITLE
Add test_expensive target to the main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,16 @@ install:
 
 test: test_go test_sharness
 
+test_expensive: test_go_expensive test_sharness_expensive
+
 test_go:
+	go test -test.short ./...
+
+test_go_expensive:
 	go test ./...
 
 test_sharness:
 	cd test/ && make
+
+test_sharness_expensive:
+	cd test/ && make TEST_EXPENSIVE=1


### PR DESCRIPTION
Now 'make test' will run the go tests with option -test.short
and the sharness tests without any option.

And 'make test_expensive' will run the go tests without any
option and the sharness tests with option TEST_EXPENSIVE=1.

This should help fix the first part of issue #283.

License: MIT
Signed-off-by: Christian Couder chriscool@tuxfamily.org
