### PR TITLE
Remove dot and slash before files in cmd/ipfs/.gitignore

### DIFF
--- a/cmd/ipfs/.gitignore
+++ b/cmd/ipfs/.gitignore
@@ -1,2 +1,2 @@
-./ipfs
-./ipfs.exe
+ipfs
+ipfs.exe


### PR DESCRIPTION
It looks like files are not ignored when they are listed
starting with ./ in a .gitignore file.

At least this is true for me on Linux for the "ipfs"
binary in "cmd/ipfs/.gitignore".

License: MIT
Signed-off-by: Christian Couder chriscool@tuxfamily.org
