### PR TITLE
Hotfix: return parsed options if argument parsing failed

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -54,13 +54,13 @@ func Parse(input []string, stdin *os.File, root *cmds.Command) (cmds.Request, *c
 	if recursiveOpt != nil && recursiveOpt.Definition() == cmds.OptionRecursivePath {
 		recursive, _, err = recursiveOpt.Bool()
 		if err != nil {
-			return nil, nil, nil, u.ErrCast()
+			return req, nil, nil, u.ErrCast()
 		}
 	}
 
 	stringArgs, fileArgs, err := parseArgs(stringVals, stdin, cmd.Arguments, recursive)
 	if err != nil {
-		return nil, cmd, path, err
+		return req, cmd, path, err
 	}
 	req.SetArguments(stringArgs)
 


### PR DESCRIPTION
This fixes [#373](https://github.com/jbenet/go-ipfs/issues/373).

The reason it was failing is that Parse() func even when `req` instance was intialized correctly it was not returned if there was an argument parsing exception. 

`Request.options` contains mention of `--help` flag (within `request.options` as `map[string]string{`help`:"",}`) that is used to check if the help option was called.
