### PR TITLE
Fix ID command lookups of unconnected nodes

### DIFF
--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -66,7 +66,6 @@ if no peer is specified, prints out local peers info.
 
 		p, err := node.Routing.FindPeer(ctx, id)
 		if err == kb.ErrLookupFailure {
-			log.Error("what? no.")
 			return nil, errors.New(offlineIdErrorMessage)
 		}
 		if err != nil {


### PR DESCRIPTION
A `FindNode` RPC wont retrieve the peers public key, this change makes the GetID command not print out public keys when they are not there (as opposed to erroring out).
