### PR TITLE
Ipfs Performance Tweaks

### DIFF
--- a/net/mux/mux.go
+++ b/net/mux/mux.go
@@ -175,7 +175,7 @@ func (m *Muxer) handleOutgoingMessages(pid pb.ProtocolID, proto Protocol) {
 				return
 			}
 			m.Children().Add(1)
-			go m.handleOutgoingMessage(pid, msg)
+			m.handleOutgoingMessage(pid, msg)
 
 		case <-m.Closing():
 			return


### PR DESCRIPTION
This PR will be the staging ground for ipfs performance fixes. It will be nice to have all of these changes in a single place so we can easily test performance of this branch against master.
My list of hopeful features is:
- [ ] Blockstore agent
  - A blockstore agent would act to serialize access to the datastore, avoiding the lockdeath weve seen from leveldb
- [X] make `handleOutgoingMessage` not a goroutine
  - Or gate the number of goroutines with a semaphore
- [ ] make an agent for the muxers bandwidth accounting
  - instead of locking around the bandwidth variables, send updates over a channel to a receiver loop that keeps track of them.
- [ ] Batch up bitswap wantlist sends
  - send wanted blocks in order, N blocks at a time, this will make streaming more likely to happen
  - example: if 100 blocks are requested, only add 10 to the wantlist at a time, so that blocks are received in a general order so that we can stream. Otherwise we run the risk of receiving the blocks in (worst case) reverse order and cannot stream.
- [ ] msgio fixes
  - [X] sink Pool into Reader (no max size, preallocated buffers issue)
  - [ ] fix `func (rw *ReadWriter_) Close()`
  - [ ] r&w threadsafety
- [ ] take a look at levelDB's performance
  - Compare to other K/V store databases.
- [ ] profile for number of active goroutines at any given time
