### PR TITLE
fix(core) bootstrap panic

### DIFF
--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	inet "github.com/jbenet/go-ipfs/net"
 	peer "github.com/jbenet/go-ipfs/peer"
 	dht "github.com/jbenet/go-ipfs/routing/dht"
+	math2 "github.com/jbenet/go-ipfs/util/math2"
 )
 
 const (
@@ -68,10 +69,7 @@ func bootstrap(ctx context.Context,
 		}
 	}
 
-	var randomSubset []peer.Peer
-	for _, val := range rand.Perm(numCxnsToCreate) {
-		randomSubset = append(randomSubset, notConnected[val])
-	}
+	var randomSubset = randomSubsetOfPeers(notConnected, numCxnsToCreate)
 	if err := connect(ctx, r, randomSubset); err != nil {
 		return err
 	}
@@ -118,4 +116,13 @@ func toPeer(ps peer.Peerstore, bootstrap *config.BootstrapPeer) (peer.Peer, erro
 	}
 	p.AddAddress(maddr)
 	return p, nil
+}
+
+func randomSubsetOfPeers(in []peer.Peer, max int) []peer.Peer {
+	n := math2.IntMin(max, len(in))
+	var out []peer.Peer
+	for _, val := range rand.Perm(n) {
+		out = append(out, in[val])
+	}
+	return out
 }

--- a/core/bootstrap_test.go
+++ b/core/bootstrap_test.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"testing"
+
+	peer "github.com/jbenet/go-ipfs/peer"
+	testutil "github.com/jbenet/go-ipfs/util/testutil"
+)
+
+func TestSubsetWhenMaxIsGreaterThanLengthOfSlice(t *testing.T) {
+	var ps []peer.Peer
+	sizeofSlice := 100
+	for i := 0; i < sizeofSlice; i++ {
+		ps = append(ps, testutil.RandPeer())
+	}
+	out := randomSubsetOfPeers(ps, 2*sizeofSlice)
+	if len(out) != len(ps) {
+		t.Fail()
+	}
+}

--- a/util/math2/math2.go
+++ b/util/math2/math2.go
@@ -1,0 +1,9 @@
+package math2
+
+// IntMin returns the smaller of x or y.
+func IntMin(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}


### PR DESCRIPTION
panic occurred because I made a false assumption that the bootstrap list is greater than the boostrap threshold. This is not true for older clients (that have one bootstrap node) and clients that have manually modified the bootstrap config. Now, a `min` is taken to index safely.

@jbenet @mappum @whyrusleeping 
