### PR TITLE
Fix "configurationx" typo.

### DIFF
--- a/cmd/ipfs/README.md
+++ b/cmd/ipfs/README.md
@@ -10,7 +10,7 @@ ipfs - global versioned p2p merkledag file system
 
 Basic commands:
 
-    init          Initialize ipfs local configurationx
+    init          Initialize ipfs local configuration
     add <path>    Add an object to ipfs
     cat <ref>     Show ipfs object data
     ls <ref>      List links from an object

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -21,7 +21,7 @@ ipfs [<flags>] <command> [<arg>] ...
 		ShortDescription: `
 Basic commands:
 
-    init          Initialize ipfs local configurationx
+    init          Initialize ipfs local configuration
     add <path>    Add an object to ipfs
     cat <ref>     Show ipfs object data
     ls <ref>      List links from an object


### PR DESCRIPTION
Is "configurationx" a typo or am I missing something? If the former, this fixes it.
