### PR TITLE
fix(epictest) generate data before starting benchmark

### DIFF
--- a/epictest/bench_test.go
+++ b/epictest/bench_test.go
@@ -2,10 +2,15 @@ package epictest
 
 import "testing"
 
-func benchmarkAddCat(conf Config, b *testing.B) {
-	b.SetBytes(conf.DataAmountBytes)
+func benchmarkAddCat(numBytes int64, conf Config, b *testing.B) {
+
+	b.StopTimer()
+	b.SetBytes(numBytes)
+	data := RandomBytes(numBytes) // we don't want to measure the time it takes to generate this data
+	b.StartTimer()
+
 	for n := 0; n < b.N; n++ {
-		if err := AddCatBytes(conf); err != nil {
+		if err := AddCatBytes(data, conf); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -13,45 +18,45 @@ func benchmarkAddCat(conf Config, b *testing.B) {
 
 var instant = Config{}.All_Instantaneous()
 
-func BenchmarkInstantaneousAddCat1MB(b *testing.B)   { benchmarkAddCat(instant.Megabytes(1), b) }
-func BenchmarkInstantaneousAddCat2MB(b *testing.B)   { benchmarkAddCat(instant.Megabytes(2), b) }
-func BenchmarkInstantaneousAddCat4MB(b *testing.B)   { benchmarkAddCat(instant.Megabytes(4), b) }
-func BenchmarkInstantaneousAddCat8MB(b *testing.B)   { benchmarkAddCat(instant.Megabytes(8), b) }
-func BenchmarkInstantaneousAddCat16MB(b *testing.B)  { benchmarkAddCat(instant.Megabytes(16), b) }
-func BenchmarkInstantaneousAddCat32MB(b *testing.B)  { benchmarkAddCat(instant.Megabytes(32), b) }
-func BenchmarkInstantaneousAddCat64MB(b *testing.B)  { benchmarkAddCat(instant.Megabytes(64), b) }
-func BenchmarkInstantaneousAddCat128MB(b *testing.B) { benchmarkAddCat(instant.Megabytes(128), b) }
-func BenchmarkInstantaneousAddCat256MB(b *testing.B) { benchmarkAddCat(instant.Megabytes(256), b) }
+func BenchmarkInstantaneousAddCat1MB(b *testing.B)   { benchmarkAddCat(1*MB, instant, b) }
+func BenchmarkInstantaneousAddCat2MB(b *testing.B)   { benchmarkAddCat(2*MB, instant, b) }
+func BenchmarkInstantaneousAddCat4MB(b *testing.B)   { benchmarkAddCat(4*MB, instant, b) }
+func BenchmarkInstantaneousAddCat8MB(b *testing.B)   { benchmarkAddCat(8*MB, instant, b) }
+func BenchmarkInstantaneousAddCat16MB(b *testing.B)  { benchmarkAddCat(16*MB, instant, b) }
+func BenchmarkInstantaneousAddCat32MB(b *testing.B)  { benchmarkAddCat(32*MB, instant, b) }
+func BenchmarkInstantaneousAddCat64MB(b *testing.B)  { benchmarkAddCat(64*MB, instant, b) }
+func BenchmarkInstantaneousAddCat128MB(b *testing.B) { benchmarkAddCat(128*MB, instant, b) }
+func BenchmarkInstantaneousAddCat256MB(b *testing.B) { benchmarkAddCat(256*MB, instant, b) }
 
 var routing = Config{}.Routing_Slow()
 
-func BenchmarkRoutingSlowAddCat1MB(b *testing.B)  { benchmarkAddCat(routing.Megabytes(1), b) }
-func BenchmarkRoutingSlowAddCat2MB(b *testing.B)  { benchmarkAddCat(routing.Megabytes(2), b) }
-func BenchmarkRoutingSlowAddCat4MB(b *testing.B)  { benchmarkAddCat(routing.Megabytes(4), b) }
-func BenchmarkRoutingSlowAddCat8MB(b *testing.B)  { benchmarkAddCat(routing.Megabytes(8), b) }
-func BenchmarkRoutingSlowAddCat16MB(b *testing.B) { benchmarkAddCat(routing.Megabytes(16), b) }
-func BenchmarkRoutingSlowAddCat32MB(b *testing.B) { benchmarkAddCat(routing.Megabytes(32), b) }
+func BenchmarkRoutingSlowAddCat1MB(b *testing.B)  { benchmarkAddCat(1*MB, routing, b) }
+func BenchmarkRoutingSlowAddCat2MB(b *testing.B)  { benchmarkAddCat(2*MB, routing, b) }
+func BenchmarkRoutingSlowAddCat4MB(b *testing.B)  { benchmarkAddCat(4*MB, routing, b) }
+func BenchmarkRoutingSlowAddCat8MB(b *testing.B)  { benchmarkAddCat(8*MB, routing, b) }
+func BenchmarkRoutingSlowAddCat16MB(b *testing.B) { benchmarkAddCat(16*MB, routing, b) }
+func BenchmarkRoutingSlowAddCat32MB(b *testing.B) { benchmarkAddCat(32*MB, routing, b) }
 
 var network = Config{}.Network_NYtoSF()
 
-func BenchmarkNetworkSlowAddCat1MB(b *testing.B)   { benchmarkAddCat(network.Megabytes(1), b) }
-func BenchmarkNetworkSlowAddCat2MB(b *testing.B)   { benchmarkAddCat(network.Megabytes(2), b) }
-func BenchmarkNetworkSlowAddCat4MB(b *testing.B)   { benchmarkAddCat(network.Megabytes(4), b) }
-func BenchmarkNetworkSlowAddCat8MB(b *testing.B)   { benchmarkAddCat(network.Megabytes(8), b) }
-func BenchmarkNetworkSlowAddCat16MB(b *testing.B)  { benchmarkAddCat(network.Megabytes(16), b) }
-func BenchmarkNetworkSlowAddCat32MB(b *testing.B)  { benchmarkAddCat(network.Megabytes(32), b) }
-func BenchmarkNetworkSlowAddCat64MB(b *testing.B)  { benchmarkAddCat(network.Megabytes(64), b) }
-func BenchmarkNetworkSlowAddCat128MB(b *testing.B) { benchmarkAddCat(network.Megabytes(128), b) }
-func BenchmarkNetworkSlowAddCat256MB(b *testing.B) { benchmarkAddCat(network.Megabytes(256), b) }
+func BenchmarkNetworkSlowAddCat1MB(b *testing.B)   { benchmarkAddCat(1*MB, network, b) }
+func BenchmarkNetworkSlowAddCat2MB(b *testing.B)   { benchmarkAddCat(2*MB, network, b) }
+func BenchmarkNetworkSlowAddCat4MB(b *testing.B)   { benchmarkAddCat(4*MB, network, b) }
+func BenchmarkNetworkSlowAddCat8MB(b *testing.B)   { benchmarkAddCat(8*MB, network, b) }
+func BenchmarkNetworkSlowAddCat16MB(b *testing.B)  { benchmarkAddCat(16*MB, network, b) }
+func BenchmarkNetworkSlowAddCat32MB(b *testing.B)  { benchmarkAddCat(32*MB, network, b) }
+func BenchmarkNetworkSlowAddCat64MB(b *testing.B)  { benchmarkAddCat(64*MB, network, b) }
+func BenchmarkNetworkSlowAddCat128MB(b *testing.B) { benchmarkAddCat(128*MB, network, b) }
+func BenchmarkNetworkSlowAddCat256MB(b *testing.B) { benchmarkAddCat(256*MB, network, b) }
 
 var blockstore = Config{}.Blockstore_7200RPM()
 
-func BenchmarkBlockstoreSlowAddCat1MB(b *testing.B)   { benchmarkAddCat(blockstore.Megabytes(1), b) }
-func BenchmarkBlockstoreSlowAddCat2MB(b *testing.B)   { benchmarkAddCat(blockstore.Megabytes(2), b) }
-func BenchmarkBlockstoreSlowAddCat4MB(b *testing.B)   { benchmarkAddCat(blockstore.Megabytes(4), b) }
-func BenchmarkBlockstoreSlowAddCat8MB(b *testing.B)   { benchmarkAddCat(blockstore.Megabytes(8), b) }
-func BenchmarkBlockstoreSlowAddCat16MB(b *testing.B)  { benchmarkAddCat(blockstore.Megabytes(16), b) }
-func BenchmarkBlockstoreSlowAddCat32MB(b *testing.B)  { benchmarkAddCat(blockstore.Megabytes(32), b) }
-func BenchmarkBlockstoreSlowAddCat64MB(b *testing.B)  { benchmarkAddCat(blockstore.Megabytes(64), b) }
-func BenchmarkBlockstoreSlowAddCat128MB(b *testing.B) { benchmarkAddCat(blockstore.Megabytes(128), b) }
-func BenchmarkBlockstoreSlowAddCat256MB(b *testing.B) { benchmarkAddCat(blockstore.Megabytes(256), b) }
+func BenchmarkBlockstoreSlowAddCat1MB(b *testing.B)   { benchmarkAddCat(1*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat2MB(b *testing.B)   { benchmarkAddCat(2*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat4MB(b *testing.B)   { benchmarkAddCat(4*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat8MB(b *testing.B)   { benchmarkAddCat(8*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat16MB(b *testing.B)  { benchmarkAddCat(16*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat32MB(b *testing.B)  { benchmarkAddCat(32*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat64MB(b *testing.B)  { benchmarkAddCat(64*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat128MB(b *testing.B) { benchmarkAddCat(128*MB, blockstore, b) }
+func BenchmarkBlockstoreSlowAddCat256MB(b *testing.B) { benchmarkAddCat(256*MB, blockstore, b) }

--- a/epictest/test_config.go
+++ b/epictest/test_config.go
@@ -6,7 +6,6 @@ type Config struct {
 	BlockstoreLatency time.Duration
 	NetworkLatency    time.Duration
 	RoutingLatency    time.Duration
-	DataAmountBytes   int64
 }
 
 func (c Config) All_Instantaneous() Config {
@@ -45,11 +44,5 @@ func (c Config) Blockstore_7200RPM() Config {
 
 func (c Config) Routing_Slow() Config {
 	c.BlockstoreLatency = 200 * time.Millisecond
-	return c
-}
-
-// Megabytes is a convenience method to set DataAmountBytes
-func (c Config) Megabytes(mb int64) Config {
-	c.DataAmountBytes = mb * 1024 * 1024
 	return c
 }

--- a/epictest/unit.go
+++ b/epictest/unit.go
@@ -1,0 +1,11 @@
+package epictest
+
+const (
+	_  = iota // ignore first value by assigning to blank identifier
+	KB = 1 << (10 * iota)
+	MB
+	GB
+	TB
+	PB
+	EB
+)

--- a/epictest/unit_test.go
+++ b/epictest/unit_test.go
@@ -1,0 +1,26 @@
+package epictest
+
+import "testing"
+
+// and the award for most meta goes to...
+
+func TestByteSizeUnit(t *testing.T) {
+	if 1*KB != 1*1024 {
+		t.Fatal(1 * KB)
+	}
+	if 1*MB != 1*1024*1024 {
+		t.Fail()
+	}
+	if 1*GB != 1*1024*1024*1024 {
+		t.Fail()
+	}
+	if 1*TB != 1*1024*1024*1024*1024 {
+		t.Fail()
+	}
+	if 1*PB != 1*1024*1024*1024*1024*1024 {
+		t.Fail()
+	}
+	if 1*EB != 1*1024*1024*1024*1024*1024*1024 {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
for faster, more accurate benchmark results

```
+ go test ./... -bench=. -v -run=Bench
PASS
BenchmarkInstantaneousAddCat1MB       50      20434373 ns/op      51.31 MB/s
BenchmarkInstantaneousAddCat2MB      100      26463847 ns/op      79.25 MB/s
BenchmarkInstantaneousAddCat4MB       50      52444540 ns/op      79.98 MB/s
BenchmarkInstantaneousAddCat8MB       20     125603062 ns/op      66.79 MB/s
BenchmarkInstantaneousAddCat16MB           5     285122576 ns/op      58.84 MB/s
BenchmarkInstantaneousAddCat32MB           5     577644364 ns/op      58.09 MB/s
BenchmarkInstantaneousAddCat64MB           1    1469263280 ns/op      45.68 MB/s
BenchmarkInstantaneousAddCat128MB          1    2174235476 ns/op      61.73 MB/s
BenchmarkInstantaneousAddCat256MB          1    4819592739 ns/op      55.70 MB/s
BenchmarkRoutingSlowAddCat1MB          1    2617028905 ns/op       0.40 MB/s
BenchmarkRoutingSlowAddCat2MB          1    4652568963 ns/op       0.45 MB/s
BenchmarkRoutingSlowAddCat4MB          1    7460396361 ns/op       0.56 MB/s
BenchmarkRoutingSlowAddCat8MB          1    12527218436 ns/op      0.67 MB/s
BenchmarkRoutingSlowAddCat16MB         1    18445741866 ns/op      0.91 MB/s
BenchmarkRoutingSlowAddCat32MB         1    36389865187 ns/op      0.92 MB/s
BenchmarkNetworkSlowAddCat1MB         20     112103824 ns/op       9.35 MB/s
BenchmarkNetworkSlowAddCat2MB         10     131731348 ns/op      15.92 MB/s
BenchmarkNetworkSlowAddCat4MB         10     188635880 ns/op      22.23 MB/s
BenchmarkNetworkSlowAddCat8MB          5     275349889 ns/op      30.47 MB/s
BenchmarkNetworkSlowAddCat16MB         5     328141138 ns/op      51.13 MB/s
BenchmarkNetworkSlowAddCat32MB         5     454094845 ns/op      73.89 MB/s
BenchmarkNetworkSlowAddCat64MB         2     801813609 ns/op      83.70 MB/s
BenchmarkNetworkSlowAddCat128MB        1    1793868067 ns/op      74.82 MB/s
BenchmarkNetworkSlowAddCat256MB        1    3586404768 ns/op      74.85 MB/s
BenchmarkBlockstoreSlowAddCat1MB          20     123439675 ns/op       8.49 MB/s
BenchmarkBlockstoreSlowAddCat2MB          10     211015893 ns/op       9.94 MB/s
BenchmarkBlockstoreSlowAddCat4MB           5     398302066 ns/op      10.53 MB/s
BenchmarkBlockstoreSlowAddCat8MB           2     845097118 ns/op       9.93 MB/s
BenchmarkBlockstoreSlowAddCat16MB          1    1707422430 ns/op       9.83 MB/s
BenchmarkBlockstoreSlowAddCat32MB          1    3319987644 ns/op      10.11 MB/s
BenchmarkBlockstoreSlowAddCat64MB          1    5960528012 ns/op      11.26 MB/s
BenchmarkBlockstoreSlowAddCat128MB         1    11982092666 ns/op     11.20 MB/s
BenchmarkBlockstoreSlowAddCat256MB         1    19802131338 ns/op     13.56 MB/s
ok      github.com/jbenet/go-ipfs/epictest  215.045s
```
