### PR TITLE
Godeps: update dependency for go-msgio

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -123,7 +123,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-msgio",
-			"Rev": "281b085dc602c4f0377438e20331f45a91bcdf9c"
+			"Rev": "5e7289d3a0cd046a5bee30b187cc844c31f54dce"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-multiaddr",


### PR DESCRIPTION
Otherwise there is the following failure when running godep restore:

fatal: reference is not a tree: 281b085dc602c4f0377438e20331f45a91bcdf9c
godep: restore: exit status 128

License: MIT
Signed-off-by: Christian Couder chriscool@tuxfamily.org
