### PR TITLE
feat: make ls only work for directories

### DIFF
--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -160,9 +160,6 @@ func (api *UnixfsAPI) Ls(ctx context.Context, p coreiface.Path, opts ...options.
 	}
 
 	dir, err := uio.NewDirectoryFromNode(ses.dag, dagnode)
-	if err == uio.ErrNotADir {
-		return uses.lsFromLinks(ctx, dagnode.Links(), settings)
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/ipfs/go-unixfs v0.0.1
 	github.com/ipfs/go-verifcid v0.0.1
 	github.com/ipfs/hang-fds v0.0.1
-	github.com/ipfs/interface-go-ipfs-core v0.0.2
+	github.com/ipfs/interface-go-ipfs-core v0.0.3-0.20190308172547-2674e8850ede
 	github.com/ipfs/iptb v1.4.0
 	github.com/ipfs/iptb-plugins v0.0.1
 	github.com/jbenet/go-is-domain v0.0.0-20160119110217-ba9815c809e0

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/ipfs/interface-go-ipfs-core v0.0.1 h1:IlAKkUPyw77UECt25WymL72A4KO+BGC
 github.com/ipfs/interface-go-ipfs-core v0.0.1/go.mod h1:CbFOGVGV8B4NCA0fAO2VVZ1Jt/ZQYE3FzTC6nLVqiAE=
 github.com/ipfs/interface-go-ipfs-core v0.0.2 h1:Qe6pzIQYEFLC2/YmfH3L7uWzcYVG12173BhRJKwplPk=
 github.com/ipfs/interface-go-ipfs-core v0.0.2/go.mod h1:CbFOGVGV8B4NCA0fAO2VVZ1Jt/ZQYE3FzTC6nLVqiAE=
+github.com/ipfs/interface-go-ipfs-core v0.0.3-0.20190308172547-2674e8850ede h1:VasTnOMhgVbPU80lsrHXUGW7WUfJeb+qRh5WD94JB2I=
+github.com/ipfs/interface-go-ipfs-core v0.0.3-0.20190308172547-2674e8850ede/go.mod h1:CbFOGVGV8B4NCA0fAO2VVZ1Jt/ZQYE3FzTC6nLVqiAE=
 github.com/ipfs/iptb v1.4.0 h1:YFYTrCkLMRwk/35IMyC6+yjoQSHTEcNcefBStLJzgvo=
 github.com/ipfs/iptb v1.4.0/go.mod h1:1rzHpCYtNp87/+hTxG5TfCVn/yMY3dKnLn8tBiMfdmg=
 github.com/ipfs/iptb-plugins v0.0.1 h1:aUHbQ4y8/lKIBX/FN0KXe3c4NldPLsq7VyW2CcFXbhE=

--- a/package.json
+++ b/package.json
@@ -608,9 +608,9 @@
     },
     {
       "author": "magik6k",
-      "hash": "QmY1veddRDFZZBUFp2Mysw7mf2sSmbx1ZGH5v11tTMCYN5",
+      "hash": "QmVXwuvGiZdGs11NQr6hhe5XxnHrV4f3aNewbQ5NkQoqnz",
       "name": "interface-go-ipfs-core",
-      "version": "0.1.12"
+      "version": "0.1.13"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
Long ago, `ls` was the _object_ (merkledag) level listing tool. That's no longer
the case.

This is a [breaking change] but I don't think anyone will object.

This is a start on all the "merge `ls` and `file ls` issues.