### PR TITLE
move CircleCI sharness tests into a separate container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,20 +122,33 @@ jobs:
     steps:
     - run: sudo apt install socat
     - checkout
+    - setup_remote_docker:
+        version: "18.09.3"
     - *make_out_dirs
-    - *restore_gomod
-
-    - run: make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
-
+    # - *restore_gomod
     - run:
-        when: always
-        command: bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile
+        name: Build sharness Docker image
+        command: |
+          docker build -t ipfs/go-ipfs-sharness -f ./Dockerfile.sharness .
+    - run:
+        name: Run sharness container
+        command: docker run \
+                --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts \
+                --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace \
+                --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results \
+                -ti ipfs/go-ipfs-sharness
 
-    - run: mv "test/sharness/test-results/sharness.xml" /tmp/circleci-test-results/sharness
+#     - run: make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
+
+#     - run:
+#         when: always
+#         command: bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile
+
+#     - run: mv "test/sharness/test-results/sharness.xml" /tmp/circleci-test-results/sharness
     # make sure we fail if there are test failures
-    - run: find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'
+#     - run: find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'
 
-    - *store_gomod
+    # - *store_gomod
 
     - store_test_results:
         path: /tmp/circleci-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,8 @@ jobs:
           docker build -t ipfs/go-ipfs-sharness -f ./Dockerfile.sharness .
     - run:
         name: Run sharness container
-        command: docker run \
+        command: |
+          docker run \
                 --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts \
                 --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace \
                 --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,8 @@ jobs:
     - run:
         name: Run sharness container
         command: |
-          docker run --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness
+        mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness && \
+        docker run --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness
 
 #     - run: make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,9 +131,12 @@ jobs:
         command: |
           docker build -t ipfs/go-ipfs-sharness -f ./Dockerfile.sharness .
     - run:
+        name: Prepare result directories
+        command: |
+        mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
+    - run:
         name: Run sharness container
         command: |
-        mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness && \
         docker run --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness
 
 #     - run: make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,11 +133,7 @@ jobs:
     - run:
         name: Run sharness container
         command: |
-          docker run \
-                --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts \
-                --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace \
-                --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results \
-                -ti ipfs/go-ipfs-sharness
+          docker run --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness
 
 #     - run: make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,11 +133,11 @@ jobs:
     - run:
         name: Prepare result directories
         command: |
-        mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
+                mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
     - run:
         name: Run sharness container
         command: |
-        docker run --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness
+                docker run --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness
 
 #     - run: make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
     - run:
         name: Run sharness container
         command: |
-                docker run --name sharness_container --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness && \
+                docker run --name sharness_container -ti ipfs/go-ipfs-sharness && \
                 docker cp sharness_container:/go-ipfs/coverage/sharness_tests.coverprofile ./ && \
                 docker cp sharness_container:/go-ipfs/test/sharness/test-results/sharness.xml /tmp/circleci-test-results/sharness/ && \
                 docker cp sharness_container:/go-ipfs/test ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
                 mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
     - run:
         name: Run sharness container
+        no_output_timeout: 30m
         command: |
                 docker run --name sharness_container -ti ipfs/go-ipfs-sharness && \
                 docker cp sharness_container:/go-ipfs/coverage/sharness_tests.coverprofile ./ && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,17 +137,21 @@ jobs:
     - run:
         name: Run sharness container
         command: |
-                docker run --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness
+                docker run --name sharness_container --mount type=bind,source=/tmp/circleci-artifacts,target=/tmp/circleci-artifacts --mount type=bind,source=/tmp/circleci-workspace,target=/tmp/circleci-workspace --mount type=bind,source=/tmp/circleci-test-results,target=/tmp/circleci-test-results -ti ipfs/go-ipfs-sharness && \
+                docker cp sharness_container:/go-ipfs/coverage/sharness_tests.coverprofile ./ && \
+                docker cp sharness_container:/go-ipfs/test/sharness/test-results/sharness.xml /tmp/circleci-test-results/sharness/ && \
+                docker cp sharness_container:/go-ipfs/test ./
 
 #     - run: make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
 
-#     - run:
-#         when: always
-#         command: bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile
+    - run:
+        when: always
+        command: bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f sharness_tests.coverprofile
 
-#     - run: mv "test/sharness/test-results/sharness.xml" /tmp/circleci-test-results/sharness
+    - run: mv "test/sharness/test-results/sharness.xml" /tmp/circleci-test-results/sharness
+
     # make sure we fail if there are test failures
-#     - run: find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'
+    - run: find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'
 
     # - *store_gomod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
     - store_artifacts:
         path: /tmp/circleci-test-results
   sharness:
-    resource_class: xlarge
+    resource_class: 2xlarge
     executor: golang
     steps:
     - run: sudo apt install socat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
         name: Run sharness container
         no_output_timeout: 30m
         command: |
-                docker run --cpus=36 --memory=30g --name sharness_container -ti ipfs/go-ipfs-sharness && \
+                docker run --cpus=2 --memory=30g --name sharness_container -ti ipfs/go-ipfs-sharness && \
                 docker cp sharness_container:/go-ipfs/coverage/sharness_tests.coverprofile ./ && \
                 docker cp sharness_container:/go-ipfs/test/sharness/test-results/sharness.xml /tmp/circleci-test-results/sharness/ && \
                 docker cp sharness_container:/go-ipfs/test ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
     - store_artifacts:
         path: /tmp/circleci-test-results
   sharness:
+    resource_class: xlarge
     executor: golang
     steps:
     - run: sudo apt install socat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
         name: Run sharness container
         no_output_timeout: 30m
         command: |
-                docker run --name sharness_container -ti ipfs/go-ipfs-sharness && \
+                docker run --cpus=36 --memory=30g --name sharness_container -ti ipfs/go-ipfs-sharness && \
                 docker cp sharness_container:/go-ipfs/coverage/sharness_tests.coverprofile ./ && \
                 docker cp sharness_container:/go-ipfs/test/sharness/test-results/sharness.xml /tmp/circleci-test-results/sharness/ && \
                 docker cp sharness_container:/go-ipfs/test ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,9 @@ executors:
       TEST_NO_FUSE: 1
       GOPATH: /home/circleci/go
       TEST_VERBOSE: 1
+  golang_mach:
+    machine:
+      - image: ubuntu-1604:202007-01
   node:
     docker:
       - image: circleci/node:12
@@ -119,7 +122,7 @@ jobs:
         path: /tmp/circleci-test-results
   sharness:
     resource_class: 2xlarge
-    executor: golang
+    executor: golang_mach
     steps:
     - run: sudo apt install socat
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,8 @@ jobs:
     steps:
     - run: sudo apt install socat
     - checkout
-    - setup_remote_docker:
-        version: "18.09.3"
+#     - setup_remote_docker:
+#         version: "18.09.3"
     - *make_out_dirs
     # - *restore_gomod
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,6 @@ executors:
       TEST_NO_FUSE: 1
       GOPATH: /home/circleci/go
       TEST_VERBOSE: 1
-  golang_mach:
-    machine:
-      - image: ubuntu-1604:202007-01
   node:
     docker:
       - image: circleci/node:12
@@ -122,7 +119,9 @@ jobs:
         path: /tmp/circleci-test-results
   sharness:
     resource_class: 2xlarge
-    executor: golang_mach
+#     executor: golang
+    machine:
+        image: ubuntu-1604:202007-01
     steps:
     - run: sudo apt install socat
     - checkout

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -21,6 +21,13 @@ RUN mkdir /ipfs /ipns \
 
 ENV SRC_DIR /go-ipfs
 
+# make output directories.
+VOLUME /tmp/circleci-artifacts
+VOLUME /tmp/circleci-workspace
+VOLUME /tmp/circleci-test-results
+RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
+RUN chown tester:tester -R /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results
+
 # proceed as tester
 USER tester
 
@@ -30,12 +37,6 @@ RUN cd $SRC_DIR && \
         go mod download
 
 COPY --chown=tester:tester . $SRC_DIR
-
-# make output directories.
-VOLUME /tmp/circleci-artifacts
-VOLUME /tmp/circleci-workspace
-VOLUME /tmp/circleci-test-results
-RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
 
 ENV GO111MODULE "on"
 ENV TEST_NO_DOCKER 1

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -12,10 +12,14 @@ RUN apt-get update && apt-get install -y \
   ca-certificates \
   fuse
 
-ENV SRC_DIR /go-ipfs
+# Add suid bit on fusermount so it will run properly
+RUN chmod 4755 /bin/fusermount
 
-# with write accesss to /tmp
-# RUN chown -R tester:tester /tmp
+# Create mount points for `ipfs mount` command
+RUN mkdir /ipfs /ipns \
+  && chown tester:tester /ipfs /ipns
+
+ENV SRC_DIR /go-ipfs
 
 # proceed as tester
 USER tester
@@ -30,4 +34,9 @@ COPY --chown=tester:tester . $SRC_DIR
 # make output directories.
 RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
 
-CMD ["/go-ipfs/run_sharness.sh"]
+ENV GO111MODULE "on"
+ENV TEST_NO_DOCKER 1
+ENV TEST_NO_FUSE 1
+ENV TEST_VERBOSE 1
+
+CMD /go-ipfs/run_sharness.sh

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -32,6 +32,9 @@ RUN cd $SRC_DIR && \
 COPY --chown=tester:tester . $SRC_DIR
 
 # make output directories.
+VOLUME /tmp/circleci-artifacts
+VOLUME /tmp/circleci-workspace
+VOLUME /tmp/circleci-test-results
 RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
 
 ENV GO111MODULE "on"

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -43,4 +43,6 @@ ENV TEST_NO_DOCKER 1
 ENV TEST_NO_FUSE 1
 ENV TEST_VERBOSE 1
 
+WORKDIR /go-ipfs
+
 CMD /go-ipfs/run_sharness.sh

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -1,11 +1,11 @@
 FROM golang:1.14.4-buster 
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
-# Add test user (sharness tests cannot run as root)
+# add test user (sharness tests cannot run as root)
 RUN groupadd -r tester && useradd -r -g tester -d /tester tester && \
         mkdir -p /tester && chown -R tester:tester /tester
 
-# Install deps
+# install deps
 RUN apt-get update && apt-get install -y \
   socat \
   libssl-dev \
@@ -14,17 +14,20 @@ RUN apt-get update && apt-get install -y \
 
 ENV SRC_DIR /go-ipfs
 
-# Proceed as tester
+# with write accesss to /tmp
+# RUN chown -R tester:tester /tmp
+
+# proceed as tester
 USER tester
 
-# Download packages first so they can be cached.
+# download packages first so they can be cached.
 COPY --chown=tester:tester go.mod go.sum $SRC_DIR/
 RUN cd $SRC_DIR && \
         go mod download
 
 COPY --chown=tester:tester . $SRC_DIR
 
-# Make output directories.
-RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/{unit,sharness}
+# make output directories.
+RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/unit /tmp/circleci-test-results/sharness
 
 CMD ["/go-ipfs/run_sharness.sh"]

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -1,0 +1,23 @@
+FROM golang:1.14.4-buster 
+LABEL maintainer="Steven Allen <steven@stebalien.com>"
+
+# Install deps
+RUN apt-get update && apt-get install -y \
+  socat \
+  libssl-dev \
+  ca-certificates \
+  fuse
+
+ENV SRC_DIR /go-ipfs
+
+# Download packages first so they can be cached.
+COPY go.mod go.sum $SRC_DIR/
+RUN cd $SRC_DIR && \
+        go mod download
+
+COPY . $SRC_DIR
+
+# Make output directories.
+RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/{unit,sharness}
+
+CMD ["/go-ipfs/run_sharness.sh"]

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -1,6 +1,10 @@
 FROM golang:1.14.4-buster 
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
+# Add test user (sharness tests cannot run as root)
+RUN groupadd -r tester && useradd -r -g tester -d /tester tester && \
+        mkdir -p /tester && chown -R tester:tester /tester
+
 # Install deps
 RUN apt-get update && apt-get install -y \
   socat \
@@ -10,12 +14,15 @@ RUN apt-get update && apt-get install -y \
 
 ENV SRC_DIR /go-ipfs
 
+# Proceed as tester
+USER tester
+
 # Download packages first so they can be cached.
-COPY go.mod go.sum $SRC_DIR/
+COPY --chown=tester:tester go.mod go.sum $SRC_DIR/
 RUN cd $SRC_DIR && \
         go mod download
 
-COPY . $SRC_DIR
+COPY --chown=tester:tester . $SRC_DIR
 
 # Make output directories.
 RUN mkdir -p /tmp/circleci-artifacts /tmp/circleci-workspace /tmp/circleci-test-results/{unit,sharness}

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y \
   socat \
   libssl-dev \
   ca-certificates \
-  fuse
+  fuse \
+  less \
+  sudo
 
 # Add suid bit on fusermount so it will run properly
 RUN chmod 4755 /bin/fusermount

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y \
   fuse \
   less \
   sudo  \
-  net-tools
+  net-tools \
+  pstree
 
 # Add suid bit on fusermount so it will run properly
 RUN chmod 4755 /bin/fusermount

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -13,8 +13,7 @@ RUN apt-get update && apt-get install -y \
   fuse \
   less \
   sudo  \
-  net-tools \
-  pstree
+  net-tools
 
 # Add suid bit on fusermount so it will run properly
 RUN chmod 4755 /bin/fusermount

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y \
   ca-certificates \
   fuse \
   less \
-  sudo
+  sudo  \
+  net-tools
 
 # Add suid bit on fusermount so it will run properly
 RUN chmod 4755 /bin/fusermount

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y \
   fuse \
   less \
   sudo  \
-  net-tools
+  net-tools \
+  htop
 
 # Add suid bit on fusermount so it will run properly
 RUN chmod 4755 /bin/fusermount

--- a/Dockerfile.sharness
+++ b/Dockerfile.sharness
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
   libssl-dev \
   ca-certificates \
   fuse \
+  xz-utils \
   less \
   sudo  \
   net-tools \

--- a/build_sharness.sh
+++ b/build_sharness.sh
@@ -1,0 +1,1 @@
+docker build --network=host -t ipfs/go-ipfs-sharness -f ./Dockerfile.sharness .

--- a/run_sharness.sh
+++ b/run_sharness.sh
@@ -7,8 +7,11 @@ cd $SRC_DIR
 
 make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
 
-bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile
-
+# export results
 mv test/sharness/test-results/sharness.xml /tmp/circleci-test-results/sharness
 
+# make sure we fail if there are test failures
 find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'
+
+# upload coverage
+bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile

--- a/run_sharness.sh
+++ b/run_sharness.sh
@@ -9,6 +9,6 @@ make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sh
 
 bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile
 
-mv "test/sharness/test-results/sharness.xml" /tmp/circleci-test-results/sharness
+mv test/sharness/test-results/sharness.xml /tmp/circleci-test-results/sharness
 
 find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'

--- a/run_sharness.sh
+++ b/run_sharness.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -xe
+
+SRC_DIR=/go-ipfs
+cd $SRC_DIR
+
+make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
+
+bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile
+
+mv "test/sharness/test-results/sharness.xml" /tmp/circleci-test-results/sharness
+
+find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'

--- a/run_sharness.sh
+++ b/run_sharness.sh
@@ -1,17 +1,7 @@
 #!/bin/sh
-
 set -xe
 
 SRC_DIR=/go-ipfs
 cd $SRC_DIR
 
 make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
-
-# export results
-mv test/sharness/test-results/sharness.xml /tmp/circleci-test-results/sharness
-
-# make sure we fail if there are test failures
-find test/sharness/test-results -name 't*-*.sh.*.counts' | test/sharness/lib/sharness/aggregate-results.sh | grep 'failed\s*0'
-
-# upload coverage
-bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile

--- a/run_sharness.sh
+++ b/run_sharness.sh
@@ -4,4 +4,4 @@ set -xe
 SRC_DIR=/go-ipfs
 cd $SRC_DIR
 
-make -O -j 5 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
+make -O -j 2 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1

--- a/run_sharness.sh
+++ b/run_sharness.sh
@@ -4,4 +4,4 @@ set -xe
 SRC_DIR=/go-ipfs
 cd $SRC_DIR
 
-make -O -j 10 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1
+make -O -j 5 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1

--- a/shell_into_sharness.sh
+++ b/shell_into_sharness.sh
@@ -1,0 +1,1 @@
+docker run -ti ipfs/go-ipfs-sharness /bin/bash

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 
+set -x
+
 test_description="Test car file import/export functionality"
 
 . lib/test-lib.sh


### PR DESCRIPTION
Needed in order to establish a network link between sharness and the mock Remote Pinning API service (which also runs in a container in CI).