### PR TITLE
perf: use performance-enhancing FUSE mount options

### DIFF
--- a/fuse/mount/fuse.go
+++ b/fuse/mount/fuse.go
@@ -33,11 +33,15 @@ func NewMount(p goprocess.Process, fsys fs.FS, mountpoint string, allow_other bo
 	var conn *fuse.Conn
 	var err error
 
-	if allow_other {
-		conn, err = fuse.Mount(mountpoint, fuse.AllowOther())
-	} else {
-		conn, err = fuse.Mount(mountpoint)
+	var mountOpts = []fuse.MountOption{
+		fuse.MaxReadahead(64 * 1024 * 1024),
+		fuse.AsyncRead(),
 	}
+
+	if allow_other {
+		mountOpts = append(mountOpts, fuse.AllowOther())
+	}
+	conn, err = fuse.Mount(mountpoint, mountOpts...)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`bazil/fuse` [offers a variety of performance-enhancing mount options](https://github.com/bazil/fuse/blob/fb710f7dfd05053a3bc9516dd5a7a8f84ead8aab/options.go#L157). These apparently need to be explicitly set, as is done [here](https://github.com/bazil/bazil/blob/810cf82680de28f1a758a1fd19492b113203d464/server/server.go#L317) in Bazil itself. Without them, FUSE defaults to reading files in 4K chunks. Recent versions of the Linux kernel seem to cap out at 128K when given a larger readahead value. This leads to a very significant gain in read performance.

This should fix https://github.com/ipfs/go-ipfs/issues/4228 https://github.com/ipfs/go-ipfs/issues/2166