### PR TITLE
TTL option for PubsubRouter

### DIFF
--- a/core/node/libp2p/routing.go
+++ b/core/node/libp2p/routing.go
@@ -161,6 +161,7 @@ func PubsubRouter(mctx helpers.MetricsCtx, lc fx.Lifecycle, in p2pPSRoutingIn) (
 		in.PubSub,
 		in.Validator,
 		namesys.WithRebroadcastInterval(time.Minute),
+		namesys.WithUnusedSubscriptionTTL(36*time.Hour, "ipns"),
 	)
 
 	if err != nil {

--- a/docs/config.md
+++ b/docs/config.md
@@ -70,6 +70,7 @@ config file at runtime.
     - [`Ipns.RecordLifetime`](#ipnsrecordlifetime)
     - [`Ipns.ResolveCacheSize`](#ipnsresolvecachesize)
     - [`Ipns.UsePubsub`](#ipnsusepubsub)
+    - [`Ipns.ReproviderDuration`](#ipnsreproviderduration)
   - [`Migration`](#migration)
     - [`Migration.DownloadSources`](#migrationdownloadsources)
     - [`Migration.Keep`](#migrationkeep)
@@ -958,6 +959,14 @@ Enables IPFS over pubsub experiment for publishing IPNS records in real time.
 Default: `disabled`
 
 Type: `flag`
+
+### `Ipns.ReproviderDuration`
+
+Time duration specifying how long a node stays subscribed to an IPNS PubSub topic after a lookup.
+
+Default: `36h`.
+
+Type: `duration`
 
 ## `Migration`
 


### PR DESCRIPTION
`go-ipfs` part of https://github.com/libp2p/go-libp2p-pubsub-router/pull/92, which fixes https://github.com/ipfs/go-ipfs/issues/8586.