### PR TITLE
chore: remove Gateway.PathPrefixes

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -798,7 +798,7 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 	}
 
 	if len(cfg.Gateway.PathPrefixes) > 0 {
-		log.Error("Support for X-Ipfs-Gateway-Prefix and Gateway.PathPrefixes is deprecated and will be removed in the next release. Please comment on the issue if you're using this feature: https://github.com/ipfs/kubo/issues/7702")
+		log.Fatal("Support for custom Gateway.PathPrefixes was removed: https://github.com/ipfs/go-ipfs/issues/7702")
 	}
 
 	node, err := cctx.ConstructNode()

--- a/config/gateway.go
+++ b/config/gateway.go
@@ -8,7 +8,7 @@ type GatewaySpec struct {
 	// UseSubdomains indicates whether or not this gateway uses subdomains
 	// for IPFS resources instead of paths. That is: http://CID.ipfs.GATEWAY/...
 	//
-	// If this flag is set, any /ipns/$id and/or /ipfs/$id paths in PathPrefixes
+	// If this flag is set, any /ipns/$id and/or /ipfs/$id paths in Paths
 	// will be permanently redirected to http://$id.[ipns|ipfs].$gateway/.
 	//
 	// We do not support using both paths and subdomains for a single domain
@@ -35,22 +35,7 @@ type Gateway struct {
 	// writing is done through the API, not the gateway.
 	Writable bool
 
-	// PathPrefixes  is an array of acceptable url paths that a client can
-	// specify in X-Ipfs-Path-Prefix header.
-	//
-	// The X-Ipfs-Path-Prefix header is used to specify a base path to prepend
-	// to links in directory listings and for trailing-slash redirects. It is
-	// intended to be set by a frontend http proxy like nginx.
-	//
-	// Example: To mount blog.ipfs.io (a DNSLink site) at ipfs.io/blog
-	// set PathPrefixes to ["/blog"] and nginx config to translate paths
-	// and pass Host header (for DNSLink):
-	//  location /blog/ {
-	//    rewrite "^/blog(/.*)$" $1 break;
-	//    proxy_set_header Host blog.ipfs.io;
-	//    proxy_set_header X-Ipfs-Gateway-Prefix /blog;
-	//    proxy_pass http://127.0.0.1:8080;
-	//  }
+	// PathPrefixes was removed: https://github.com/ipfs/go-ipfs/issues/7702
 	PathPrefixes []string
 
 	// FastDirIndexThreshold is the maximum number of items in a directory

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -18,7 +18,6 @@ import (
 type GatewayConfig struct {
 	Headers               map[string][]string
 	Writable              bool
-	PathPrefixes          []string
 	FastDirIndexThreshold int
 }
 
@@ -96,7 +95,6 @@ func GatewayOption(writable bool, paths ...string) ServeOption {
 		gateway, err = newGatewayHandler(GatewayConfig{
 			Headers:               headers,
 			Writable:              writable,
-			PathPrefixes:          cfg.Gateway.PathPrefixes,
 			FastDirIndexThreshold: int(cfg.Gateway.FastDirIndexThreshold.WithDefault(100)),
 		}, api)
 		if err != nil {

--- a/docs/config.md
+++ b/docs/config.md
@@ -675,40 +675,7 @@ Type: `bool`
 
 ### `Gateway.PathPrefixes`
 
-**DEPRECATED:** see [kubo#7702](https://github.com/ipfs/kubo/issues/7702)
-
-<!--
-An array of acceptable url paths that a client can specify in X-Ipfs-Path-Prefix
-header.
-
-The X-Ipfs-Path-Prefix header is used to specify a base path to prepend to links
-in directory listings and for trailing-slash redirects. It is intended to be set
-by a frontend http proxy like nginx.
-
-Example: We mount `blog.ipfs.io` (a dnslink page) at `ipfs.io/blog`.
-
-**.ipfs/config**
-```json
-"Gateway": {
-  "PathPrefixes": ["/blog"],
-}
-```
-
-**nginx_ipfs.conf**
-```nginx
-location /blog/ {
-  rewrite "^/blog(/.*)$" $1 break;
-  proxy_set_header Host blog.ipfs.io;
-  proxy_set_header X-Ipfs-Gateway-Prefix /blog;
-  proxy_pass http://127.0.0.1:8080;
-}
-```
-
--->
-
-Default: `[]`
-
-Type: `array[string]`
+**REMOVED:** see [go-ipfs#7702](https://github.com/ipfs/go-ipfs/issues/7702)
 
 ### `Gateway.PublicGateways`
 


### PR DESCRIPTION
Closes #7702 – should be part of 0.14, keeping as draft so we don't forget.