### PR TITLE
refactor(config): remove Swarm.ConnMgr defaults

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -79,14 +79,6 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			Interval: "12h",
 			Strategy: "all",
 		},
-		Swarm: SwarmConfig{
-			ConnMgr: ConnMgr{
-				LowWater:    DefaultConnMgrLowWater,
-				HighWater:   DefaultConnMgrHighWater,
-				GracePeriod: DefaultConnMgrGracePeriod.String(),
-				Type:        "basic",
-			},
-		},
 		Pinning: Pinning{
 			RemoteServices: map[string]RemotePinningService{},
 		},
@@ -113,6 +105,10 @@ const DefaultConnMgrLowWater = 600
 // DefaultConnMgrGracePeriod is the default value for the connection managers
 // grace period
 const DefaultConnMgrGracePeriod = time.Second * 20
+
+// DefaultConnMgrType is the default value for the connection managers
+// type.
+const DefaultConnMgrType = "basic"
 
 func addressesConfig() Addresses {
 	return Addresses{

--- a/config/profile.go
+++ b/config/profile.go
@@ -178,9 +178,13 @@ fetching may be degraded.
 			c.AutoNAT.ServiceMode = AutoNATServiceDisabled
 			c.Reprovider.Interval = "0"
 
-			c.Swarm.ConnMgr.LowWater = 20
-			c.Swarm.ConnMgr.HighWater = 40
-			c.Swarm.ConnMgr.GracePeriod = time.Minute.String()
+			lowWater := int64(20)
+			highWater := int64(40)
+			gracePeriod := time.Minute
+			c.Swarm.ConnMgr.Type = NewOptionalString("basic")
+			c.Swarm.ConnMgr.LowWater = &OptionalInteger{value: &lowWater}
+			c.Swarm.ConnMgr.HighWater = &OptionalInteger{value: &highWater}
+			c.Swarm.ConnMgr.GracePeriod = &OptionalDuration{&gracePeriod}
 			return nil
 		},
 	},

--- a/config/swarm.go
+++ b/config/swarm.go
@@ -131,10 +131,10 @@ type Transports struct {
 
 // ConnMgr defines configuration options for the libp2p connection manager
 type ConnMgr struct {
-	Type        string
-	LowWater    int
-	HighWater   int
-	GracePeriod string
+	Type        *OptionalString   `json:",omitempty"`
+	LowWater    *OptionalInteger  `json:",omitempty"`
+	HighWater   *OptionalInteger  `json:",omitempty"`
+	GracePeriod *OptionalDuration `json:",omitempty"`
 }
 
 // ResourceMgr defines configuration options for the libp2p Network Resource Manager

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -38,33 +38,20 @@ var BaseLibP2P = fx.Options(
 )
 
 func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
-	// parse ConnMgr config
+	var connmgr fx.Option
 
-	grace := config.DefaultConnMgrGracePeriod
-	low := config.DefaultConnMgrLowWater
-	high := config.DefaultConnMgrHighWater
-
-	connmgr := fx.Options()
-
-	if cfg.Swarm.ConnMgr.Type != "none" {
-		switch cfg.Swarm.ConnMgr.Type {
-		case "":
-			// 'default' value is the basic connection manager
-			break
-		case "basic":
-			var err error
-			grace, err = time.ParseDuration(cfg.Swarm.ConnMgr.GracePeriod)
-			if err != nil {
-				return fx.Error(fmt.Errorf("parsing Swarm.ConnMgr.GracePeriod: %s", err))
-			}
-
-			low = cfg.Swarm.ConnMgr.LowWater
-			high = cfg.Swarm.ConnMgr.HighWater
-		default:
-			return fx.Error(fmt.Errorf("unrecognized ConnMgr.Type: %q", cfg.Swarm.ConnMgr.Type))
-		}
-
+	// set connmgr based on Swarm.ConnMgr.Type
+	connMgrType := cfg.Swarm.ConnMgr.Type.WithDefault(config.DefaultConnMgrType)
+	switch connMgrType {
+	case "none":
+		connmgr = fx.Options() // noop
+	case "", "basic":
+		grace := cfg.Swarm.ConnMgr.GracePeriod.WithDefault(config.DefaultConnMgrGracePeriod)
+		low := int(cfg.Swarm.ConnMgr.LowWater.WithDefault(config.DefaultConnMgrLowWater))
+		high := int(cfg.Swarm.ConnMgr.HighWater.WithDefault(config.DefaultConnMgrHighWater))
 		connmgr = fx.Provide(libp2p.ConnectionManager(low, high, grace))
+	default:
+		return fx.Error(fmt.Errorf("unrecognized Swarm.ConnMgr.Type: %q", connMgrType))
 	}
 
 	// parse PubSub config

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -197,12 +197,5 @@ func createDefaultLimitConfig(cfg config.SwarmConfig) (rcmgr.LimitConfig, error)
 
 	defaultLimitConfig := scalingLimitConfig.Scale(int64(maxMemory), int(numFD))
 
-	// If a high water mark is set:
-	if cfg.ConnMgr.Type == "basic" {
-		// set the connection limit higher than high water mark so that the ConnMgr has "space and time" to close "least useful" connections.
-		defaultLimitConfig.System.Conns = 2 * cfg.ConnMgr.HighWater
-		log.Info("adjusted default resource manager System.Conns limits to match ConnMgr.HighWater value of %s", cfg.ConnMgr.HighWater)
-	}
-
 	return defaultLimitConfig, nil
 }

--- a/docs/changelogs/v0.17.md
+++ b/docs/changelogs/v0.17.md
@@ -9,8 +9,8 @@ Below is an outline of all that is in this release, so you get a sense of all th
 - [Kubo changelog v0.17](#kubo-changelog-v017)
   - [v0.17.0](#v0170)
     - [Overview](#overview)
-    - [TOC](#toc)
     - [🔦 Highlights](#-highlights)
+      - [Implicit connection manager limits](#implicit-connection-manager-limits)
       - [TAR Response Format on Gateways](#tar-response-format-on-gateways)
     - [Changelog](#changelog)
     - [Contributors](#contributors)
@@ -18,6 +18,23 @@ Below is an outline of all that is in this release, so you get a sense of all th
 ### 🔦 Highlights
 
 <!-- TODO -->
+
+#### Implicit connection manager limits
+
+Starting with this release, `ipfs init` will no longer store the default
+[Connection Manager](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmconnmgr)
+limits in the user config under `Swarm.ConnMgr`.
+
+Users are still free to use this setting to set custom values, but for most use
+cases, the defaults provided with the latest Kubo release should be sufficient.
+
+To remove any custom limits and switch to the implicit defaults managed by Kubo:
+
+```console
+$ ipfs config --json Swarm.ConnMgr '{}'
+```
+
+We will be adjusting defaults in the future releases.
 
 #### TAR Response Format on Gateways
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -243,9 +243,15 @@ documented in `ipfs config profile --help`.
 
 - `lowpower`
 
-  Reduces daemon overhead on the system. May affect node
+  Reduces daemon overhead on the system. Affects node
   functionality - performance of content discovery and data
-  fetching may be degraded.
+  fetching may be degraded. Local data won't be announced on routing systems like DHT.
+
+  - `Swarm.ConnMgr` set to maintain minimum number of p2p connections at a time.
+  - Disables [`Reprovider`](#reprovider) service → no CID will be announced on DHT and other routing systems(!)
+  - Disables AutoNAT.
+
+  Use this profile with caution.
 
 ## Types
 
@@ -1730,7 +1736,8 @@ be configured to keep. Kubo currently supports two connection managers:
 * none: never close idle connections.
 * basic: the default connection manager.
 
-Default: basic
+By default, this section is empty and the implicit defaults defined below
+are used.
 
 #### `Swarm.ConnMgr.Type`
 
@@ -1739,8 +1746,7 @@ management) and `"basic"`.
 
 Default: "basic".
 
-Type: `string` (when unset or `""`, the default connection manager is applied
-and all `ConnMgr` fields are ignored).
+Type: `optionalString` (default when unset or empty)
 
 #### Basic Connection Manager
 
@@ -1779,7 +1785,7 @@ trim down to.
 
 Default: `600`
 
-Type: `integer`
+Type: `optionalInteger`
 
 ##### `Swarm.ConnMgr.HighWater`
 
@@ -1789,7 +1795,7 @@ towards this limit.
 
 Default: `900`
 
-Type: `integer`
+Type: `optionalInteger`
 
 ##### `Swarm.ConnMgr.GracePeriod`
 
@@ -1798,7 +1804,7 @@ by the connection manager.
 
 Default: `"20s"`
 
-Type: `duration`
+Type: `optionalDuration`
 
 ### `Swarm.ResourceMgr`
 


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-ipfs/issues/8845.

Sorry for the delay. I was digging around config's `Optional` structs implementation to look for a cleaner approach but that shouldn't be blocking this (it can be addressed later in a separate issue).