### PR TITLE
fix(test): flaky t0182-circuit-relay.sh

### DIFF
--- a/test/dependencies/iptb/iptb.go
+++ b/test/dependencies/iptb/iptb.go
@@ -27,6 +27,7 @@ func init() {
 
 func main() {
 	cli := cli.NewCli()
+	os.Setenv("GOLOG_LOG_LEVEL", "autorelay=debug")
 	if err := cli.Run(os.Args); err != nil {
 		fmt.Fprintf(cli.ErrWriter, "%s\n", err)
 		os.Exit(1)

--- a/test/sharness/t0182-circuit-relay.sh
+++ b/test/sharness/t0182-circuit-relay.sh
@@ -56,14 +56,7 @@ test_expect_success 'connect B <-> Relay' '
 '
 
 test_expect_success 'wait until relay is ready to do work' '
-  while ! ipfsi 2 swarm connect /p2p/$PEERID_1/p2p-circuit/p2p/$PEERID_0; do
-    iptb stop &&
-    iptb_wait_stop &&
-    iptb start -wait -- --routing=none &&
-    iptb connect 0 1 &&
-    iptb connect 2 1 &&
-    sleep 5
-  done
+  sleep 1
 '
 
 test_expect_success 'connect A <-Relay-> B' '


### PR DESCRIPTION
This PR removes fixup introduced in https://github.com/ipfs/go-ipfs/pull/8868#discussion_r860219918 so we can dig into the underlying cause.

## About the flaky test

It started failing every 3-10 run after we switched to go-libp2p 0.19.0 in https://github.com/ipfs/go-ipfs/pull/8868 – tests in  `go-ipfs/test/sharness/t0182-circuit-relay.sh`   became  flaky.

`ipfsi 2 swarm connect /p2p/$PEERID_1/p2p-circuit/p2p/$PEERID_0`   sometimes fails with:
```
NO_RESERVATION (204)
Error: connect 12D3KooWLuY1Q13o6Q91NoJn4Qv7RSq5rYS6uC4YCzKCJ3S8GnwQ failure: failed to dial 12D3KooWLuY1Q13o6Q91NoJn4Qv7RSq5rYS6uC4YCzKCJ3S8GnwQ:
  * [/p2p/12D3KooWNfs8uFpQf6NnseZKLyS3c8EFppGtUGejHpViBeg8f7Vt/p2p-circuit] error opening relay circuit: NO_RESERVATION (204)`
```

- it happens randomly, bumping it to 10 seconds does not help much, it still fails sometimes.
- shutting down nodes and starting them again fixes the problem (what is what removed code did)
  - ...but it feels like covering up some underlying racy bug:   once `NO_RESERVATION` error is returned, the relay will never work, no matter how long we wait and retry again  (only way to fix it is to reboot of the relay node /  testbed). 


Repro (keep running  ` t0182-circuit-relay.sh`  until the error):

```console
$ killall ipfs ; i=0; while ./t0182-circuit-relay.sh -v; do echo -n " -----> $i <----\n\n\n"; sleep 1; ((i=i+1)) ; done
```

cc @aschmahmann @marten-seemann @schomatis  – any ideas how to debug this?