### PR TITLE
chore: bump xxhash to v2

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipfs/boxo/files"
 	"github.com/ipfs/boxo/path"
+	"github.com/cespare/xxhash/v2"
 	cid "github.com/ipfs/go-cid"
 	options "github.com/ipfs/kubo/core/coreiface/options"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/ceramicnetwork/go-dag-jose v0.1.0
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dustin/go-humanize v1.0.1
@@ -98,7 +99,6 @@ require (
 	github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/crackcomm/go-gitignore v0.0.0-20231225121904-e25f5bc08668 // indirect
 	github.com/cskr/pubsub v1.0.2 // indirect


### PR DESCRIPTION
The goal is eventually to remove the dupped code (v1 vs v2).

Prometheus already uses v2, might as well switch too (It's also very 
slightly faster).

This commit doesn't actually remove v1 because badger still use v1.