### PR TITLE
feat(gw): Cache-Control: only-if-cached

### DIFF
--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -92,12 +92,16 @@ func GatewayOption(writable bool, paths ...string) ServeOption {
 				"X-Ipfs-Roots",
 			}, headers[ACEHeadersName]...))
 
-		var gateway http.Handler = newGatewayHandler(GatewayConfig{
+		var gateway http.Handler
+		gateway, err = newGatewayHandler(GatewayConfig{
 			Headers:               headers,
 			Writable:              writable,
 			PathPrefixes:          cfg.Gateway.PathPrefixes,
 			FastDirIndexThreshold: int(cfg.Gateway.FastDirIndexThreshold.WithDefault(100)),
 		}, api)
+		if err != nil {
+			return nil, err
+		}
 
 		gateway = otelhttp.NewHandler(gateway, "Gateway.Request")
 

--- a/test/sharness/t0116-gateway-cache.sh
+++ b/test/sharness/t0116-gateway-cache.sh
@@ -67,6 +67,28 @@ test_expect_success "Prepare IPNS unixfs content path for testing" '
     cat curl_ipns_file_output
     '
 
+# Cache-Control: only-if-cached
+    test_expect_success "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore" '
+    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" > curl_onlyifcached_postitive_head 2>&1 &&
+    cat curl_onlyifcached_postitive_head &&
+    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_head
+    '
+    test_expect_success "HEAD for /ipfs/ with only-if-cached fails when not in local datastore" '
+    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" > curl_onlyifcached_negative_head 2>&1 &&
+    cat curl_onlyifcached_negative_head &&
+    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_head
+    '
+    test_expect_success "GET for /ipfs/ with only-if-cached succeeds when in local datastore" '
+    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_onlyifcached_postitive_out &&
+    cat curl_onlyifcached_postitive_out &&
+    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_out
+    '
+    test_expect_success "GET for /ipfs/ with only-if-cached fails when not in local datastore" '
+    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" >/dev/null 2>curl_onlyifcached_negative_out &&
+    cat curl_onlyifcached_negative_out &&
+    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_out
+    '
+
 # X-Ipfs-Path
 
     ## dir generated listing


### PR DESCRIPTION
This PR implements support for requests sent with `only-if-cached` prerequisite, as documented in Gateway specs:

[PATH_GATEWAY.md#cache-control-request-header](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md#cache-control-request-header):
> Client can send Cache-Control: only-if-cached to request data only if the gateway already has the data (e.g. in local datastore) and can return it immediately.
> 
>  If data is not cached locally, and the response requires an expensive remote fetch, a [412 Precondition Failed](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md#412-precondition-failed) HTTP status code should be returned by the gateway without any payload or specific HTTP headers.

[PATH_GATEWAY.md#only-if-cached-head-behavior](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md#only-if-cached-head-behavior):
> HTTP client can send HEAD request with [Cache-Control: only-if-cached](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md#cache-control-request-header) to disable IPFS data transfer and inexpensively probe if the gateway has the data cached.
> 
> Implementation MUST ensure that handling only-if-cached HEAD response is fast and does not generate any additional I/O such as IPFS data transfer. This allows light clients to probe and prioritize gateways which already have the data.

## Why we need this?

- We want kubo to implement  [gateway specs](https://github.com/ipfs/specs/tree/main/http-gateways#readme)  (I missed the fact that  `only-if-cached`  was not implemented yet)
- Closes  #8783

## How  does this PR  work?

Implementation from this PR is minimal: when `only-if-cached` is present in a request, 
the Gateway will try to read block size for requested CID using API in offline mode (only local blockstore). 

- Error means the block is not in the local datastore, and `412 Precondition Failed` is returned.
- Success with `HEAD` method returns early with `200 OK` without doing any additional IO

