### PR TITLE
fix: kubo in daemon and cli stdout

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -923,7 +923,7 @@ func printVersion() {
 	if version.CurrentCommit != "" {
 		v += "-" + version.CurrentCommit
 	}
-	fmt.Printf("go-ipfs version: %s\n", v)
+	fmt.Printf("Kubo version: %s\n", v)
 	fmt.Printf("Repo version: %d\n", fsrepo.RepoVersion)
 	fmt.Printf("System version: %s\n", runtime.GOARCH+"/"+runtime.GOOS)
 	fmt.Printf("Golang version: %s\n", runtime.Version())

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -46,7 +46,7 @@ var VersionCmd = &cmds.Command{
 				if version.Commit != "" {
 					ver += "-" + version.Commit
 				}
-				out := fmt.Sprintf("go-ipfs version: %s\n"+
+				out := fmt.Sprintf("Kubo version: %s\n"+
 					"Repo version: %s\nSystem version: %s\nGolang version: %s\n",
 					ver, version.Repo, version.System, version.Golang)
 				fmt.Fprint(w, out)

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -35,7 +35,7 @@ test_expect_success "ipfs versions matches ipfs --version" '
 
 test_expect_success "ipfs version --all has all required fields" '
   ipfs version --all > version_all.txt &&
-  grep "go-ipfs version" version_all.txt &&
+  grep "Kubo version" version_all.txt &&
   grep "Repo version" version_all.txt &&
   grep "System version" version_all.txt &&
   grep "Golang version" version_all.txt


### PR DESCRIPTION
(let's see if this breaks any tests)

### Before

```
ipfs version 0.14.0-rc1
Found IPFS fs-repo at /data/ipfs
Initializing daemon...
go-ipfs version: 0.14.0-rc1-10c3cc1
Repo version: 12
System version: amd64/linux
Golang version: go1.18.3
Swarm listening on /ip4/127.0.0.1/tcp/4001
```

### After 

```
ipfs version 0.14.0-rc1
Found IPFS fs-repo at /data/ipfs
Initializing daemon...
Kubo version: 0.14.0-rc1-10c3cc1
Repo version: 12
System version: amd64/linux
Golang version: go1.18.3
Swarm listening on /ip4/127.0.0.1/tcp/4001
```