### PR TITLE
fix(ci): ipfs-webui requires node 16.12.0

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -52,7 +52,7 @@ executors:
       <<: *default_environment
   node-browsers:
     docker:
-      - image: circleci/node:14-browsers
+      - image: circleci/node:16.12.0-browsers
     working_directory: ~/ipfs/kubo
     environment:
       <<: *default_environment
@@ -347,7 +347,7 @@ jobs:
       - run:
           name: Installing dependencies
           command: |
-            npm install
+            npm ci --prefer-offline --no-audit --progress=false --cache ~/ipfs/kubo/.cache/npm
             npx playwright install
           working_directory: ~/ipfs/kubo/ipfs-webui
       - run:
@@ -365,7 +365,7 @@ jobs:
           key: v1-ipfs-webui-{{ checksum "~/ipfs/kubo/ipfs-webui/package-lock.json" }}
           paths:
             - ~/.cache/ms-playwright
-            - ~/ipfs/kubo/ipfs-webui/node_modules
+            - ~/ipfs/kubo/.cache/npm
   # We only run build as a test here. DockerHub images are built and published
   # by GitHub Action now: https://github.com/ipfs/kubo/pull/8467
   docker-build:


### PR DESCRIPTION
This PR aims to fix ipfs-webui tests run on CI. Testing Kubo against ipfs-webui main branch fails right now:
https://app.circleci.com/pipelines/github/ipfs/kubo/7228/workflows/528ee100-ccc9-4e9c-8bb4-46cdbbe4e306/jobs/78516

```
npm ERR! notsup Unsupported engine for ipfs-webui@2.16.0: wanted: {"node":"=16.12.0","npm":"=8.1.0"} (current: {"node":"14.18.2","npm":"6.14.15"})
npm ERR! notsup Not compatible with your version of node/npm: ipfs-webui@2.16.0
npm ERR! notsup Not compatible with your version of node/npm: ipfs-webui@2.16.0
npm ERR! notsup Required: {"node":"=16.12.0","npm":"=8.1.0"}
npm ERR! notsup Actual:   {"npm":"6.14.15","node":"14.18.2"}
```

cc @SgtPooki:

Let's see if  CI is green (then it will auto-merge, fixing master).
If it fails, we need to  fix it after Iceland (added to the board so we dont forget)