### PR TITLE
fix: preserve content path for unixfs directories for cache headers

### DIFF
--- a/core/corehttp/gateway_handler_unixfs_dir.go
+++ b/core/corehttp/gateway_handler_unixfs_dir.go
@@ -42,7 +42,8 @@ func (i *gatewayHandler) serveDirectory(ctx context.Context, w http.ResponseWrit
 	originalUrlPath := requestURI.Path
 
 	// Check if directory has index.html, if so, serveFile
-	idxPath := ipath.Join(resolvedPath, "index.html")
+	// use contentPath instead of resolved path to preserve mutability for caching headers
+	idxPath := ipath.Join(contentPath, "index.html")
 	idx, err := i.api.Unixfs().Get(ctx, idxPath)
 	switch err.(type) {
 	case nil:


### PR DESCRIPTION
`addCacheControlHeaders` uses the mutability of the given content path to determine which cache control headers to set. This path is currently overwritten with an immutable path when serving a UnixFS directory which leads to immutable cache-control headers being sent even when the the original content path is mutable. 

This has implications for caching across various kubo deployments but I believe the current behavior to be incorrect since it disallows appropriate cache invalidation when a DNSLink record is changed.

https://github.com/ipfs/kubo/blob/master/core/corehttp/gateway_handler.go#L672