### PR TITLE
fix(gw): no backlink when listing root dir

### DIFF
--- a/assets/dir-index-html/dir-index.html
+++ b/assets/dir-index-html/dir-index.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<meta name="description" content="A directory of files hosted on the distributed, decentralized web using IPFS">
+<meta name="description" content="A directory of content-addressed files hosted on IPFS">
 <meta property="og:title" content="Files on IPFS">
 <meta property="og:description" content="{{ .Path }}">
 <meta property="og:type" content="website">
@@ -62,6 +62,7 @@
     </div>
     <div class="table-responsive">
     <table>
+      {{ if .BackLink }}
       <tr>
         <td class="type-icon">
           <div class="ipfs-_blank">&nbsp;</div>
@@ -72,6 +73,7 @@
         <td></td>
         <td></td>
       </tr>
+      {{ end }}
       {{ range .Listing }}
       <tr>
         <td class="type-icon">

--- a/assets/dir-index-html/src/dir-index.html
+++ b/assets/dir-index-html/src/dir-index.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<meta name="description" content="A directory of files hosted on the distributed, decentralized web using IPFS">
+<meta name="description" content="A directory of content-addressed files hosted on IPFS">
 <meta property="og:title" content="Files on IPFS">
 <meta property="og:description" content="{{ .Path }}">
 <meta property="og:type" content="website">
@@ -61,6 +61,7 @@
     </div>
     <div class="table-responsive">
     <table>
+      {{ if .BackLink }}
       <tr>
         <td class="type-icon">
           <div class="ipfs-_blank">&nbsp;</div>
@@ -71,6 +72,7 @@
         <td></td>
         <td></td>
       </tr>
+      {{ end }}
       {{ range .Listing }}
       <tr>
         <td class="type-icon">

--- a/core/corehttp/gateway_handler_unixfs_dir.go
+++ b/core/corehttp/gateway_handler_unixfs_dir.go
@@ -152,11 +152,13 @@ func (i *gatewayHandler) serveDirectory(ctx context.Context, w http.ResponseWrit
 	// don't go further up than /ipfs/$hash/
 	pathSplit := path.SplitList(contentPath.String())
 	switch {
-	// keep backlink
+	// skip backlink when listing a content root
 	case len(pathSplit) == 3: // url: /ipfs/$hash
+		backLink = ""
 
-	// keep backlink
+	// skip backlink when listing a content root
 	case len(pathSplit) == 4 && pathSplit[3] == "": // url: /ipfs/$hash/
+		backLink = ""
 
 	// add the correct link depending on whether the path ends with a slash
 	default:

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -529,8 +529,8 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 	if !matchPathOrBreadcrumbs(s, "/") {
 		t.Fatalf("expected a path in directory listing")
 	}
-	if !strings.Contains(s, "<a href=\"/\">") {
-		t.Fatalf("expected backlink in directory listing")
+	if strings.Contains(s, "<a href=\"/\">") {
+		t.Fatalf("expected no backlink in directory listing of the root CID")
 	}
 	if !strings.Contains(s, "<a href=\"/file.txt\">") {
 		t.Fatalf("expected file in directory listing")

--- a/test/sharness/t0115-gateway-dir-listing.sh
+++ b/test/sharness/t0115-gateway-dir-listing.sh
@@ -37,10 +37,10 @@ test_expect_success "Add the test directory" '
 ## Test dir listing on path gateway (eg. 127.0.0.1:8080/ipfs/)
 ## ============================================================================
 
-test_expect_success "path gw: backlink on root CID should point at self" '
+test_expect_success "path gw: backlink on root CID should be hidden" '
   curl -sD - http://127.0.0.1:$GWAY_PORT/ipfs/${DIR_CID}/ > list_response &&
   test_should_contain "Index of" list_response &&
-  test_should_contain "<a href=\"/ipfs/$DIR_CID/\">..</a>" list_response
+  test_should_not_contain "<a href=\"/ipfs/$DIR_CID/\">..</a>" list_response
 '
 
 test_expect_success "path gw: Etag should be present" '
@@ -53,7 +53,7 @@ test_expect_success "path gw: breadcrumbs should point at /ipfs namespace mounte
   test_should_contain "/ipfs/<a href=\"/ipfs/$DIR_CID\">$DIR_CID</a>/<a href=\"/ipfs/$DIR_CID/%C4%85\">ą</a>/<a href=\"/ipfs/$DIR_CID/%C4%85/%C4%99\">ę</a>" list_response
 '
 
-test_expect_success "path gw: backlink should point at parent directory" '
+test_expect_success "path gw: backlink on subdirectory should point at parent directory" '
   test_should_contain "<a href=\"/ipfs/$DIR_CID/%C4%85/%C4%99/..\">..</a>" list_response
 '
 
@@ -72,16 +72,20 @@ test_expect_success "path gw: hash column should be a CID link with filename par
 DIR_HOSTNAME="${DIR_CID}.ipfs.localhost"
 # note: we skip DNS lookup by running curl with --resolve $DIR_HOSTNAME:127.0.0.1
 
-test_expect_success "path gw: backlink on root CID should point origin root" '
+test_expect_success "path gw: backlink on root CID should be hidden" '
   curl -sD - --resolve $DIR_HOSTNAME:$GWAY_PORT:127.0.0.1 http://$DIR_HOSTNAME:$GWAY_PORT/ > list_response &&
   test_should_contain "Index of" list_response &&
-  test_should_contain "<a href=\"/\">..</a>" list_response
+  test_should_not_contain "<a href=\"/\">..</a>" list_response
 '
 
 test_expect_success "path gw: Etag should be present" '
   curl -sD - --resolve $DIR_HOSTNAME:$GWAY_PORT:127.0.0.1 http://$DIR_HOSTNAME:$GWAY_PORT/ą/ę > list_response &&
   test_should_contain "Index of" list_response &&
   test_should_contain "Etag: \"DirIndex-" list_response
+'
+
+test_expect_success "path gw: backlink on subdirectory should point at parent directory" '
+  test_should_contain "<a href=\"/%C4%85/%C4%99/..\">..</a>" list_response
 '
 
 test_expect_success "subdomain gw: breadcrumbs should leverage path-based router mounted on the parent domain" '
@@ -111,16 +115,20 @@ test_launch_ipfs_daemon
 #   (go tests and sharness tests should be kept in sync)
 # - we skip DNS lookup by running curl with --resolve $DNSLINK_HOSTNAME:127.0.0.1
 
-test_expect_success "dnslink gw: backlink on root CID should point origin root" '
+test_expect_success "dnslink gw: backlink on root CID should be hidden" '
   curl -v -sD - --resolve $DNSLINK_HOSTNAME:$GWAY_PORT:127.0.0.1 http://$DNSLINK_HOSTNAME:$GWAY_PORT/ > list_response &&
   test_should_contain "Index of" list_response &&
-  test_should_contain "<a href=\"/\">..</a>" list_response
+  test_should_not_contain "<a href=\"/\">..</a>" list_response
 '
 
 test_expect_success "dnslink gw: Etag should be present" '
   curl -sD - --resolve $DNSLINK_HOSTNAME:$GWAY_PORT:127.0.0.1 http://$DNSLINK_HOSTNAME:$GWAY_PORT/ą/ę > list_response &&
   test_should_contain "Index of" list_response &&
   test_should_contain "Etag: \"DirIndex-" list_response
+'
+
+test_expect_success "dnslink gw: backlink on subdirectory should point at parent directory" '
+  test_should_contain "<a href=\"/%C4%85/%C4%99/..\">..</a>" list_response
 '
 
 test_expect_success "dnslink gw: breadcrumbs should point at content root mounted at dnslink origin" '


### PR DESCRIPTION
This PR removes "one level up" backlink when listing a content root (the root CID being an UnixFS directory).

Closes #9071

## Root  dir

> ![Screenshot 2022-07-18 at 23-43-37 Files on IPFS](https://user-images.githubusercontent.com/157609/179622812-73d73b3f-3b9e-4ba6-bdf8-bf22443006c9.png)

## Subdirectory

> ![Screenshot 2022-07-18 at 23-43-58 Files on IPFS](https://user-images.githubusercontent.com/157609/179622848-263c2dc8-87b9-4357-98f2-6139ed2e0c6e.png)
