### PR TITLE
docs(license): fix broken link to apache-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,4 +5,4 @@ licensed under MIT-only. All new contributions (and past contributions since 201
 are licensed under a dual MIT/Apache-2.0 license.
 
 MIT: https://www.opensource.org/licenses/mit
-Apache-2.0: https://www.apache.org/licenses/license-2.0
+Apache-2.0: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
https://github.com/ipfs/kubo/issues/9130

chose to used repaired apache link instead of using opensource.org host.