### PR TITLE
fix(gw): correct cache-control of index.html websites

### DIFF
--- a/core/corehttp/gateway_handler_unixfs_dir.go
+++ b/core/corehttp/gateway_handler_unixfs_dir.go
@@ -42,7 +42,7 @@ func (i *gatewayHandler) serveDirectory(ctx context.Context, w http.ResponseWrit
 	originalUrlPath := requestURI.Path
 
 	// Check if directory has index.html, if so, serveFile
-	idxPath := ipath.Join(resolvedPath, "index.html")
+	idxPath := ipath.Join(contentPath, "index.html")
 	idx, err := i.api.Unixfs().Get(ctx, idxPath)
 	switch err.(type) {
 	case nil:

--- a/test/sharness/t0116-gateway-cache.sh
+++ b/test/sharness/t0116-gateway-cache.sh
@@ -67,6 +67,35 @@ test_expect_success "Prepare IPNS unixfs content path for testing" '
     cat curl_ipns_file_output
     '
 
+# Cache-Control
+
+# Cache-Control: immutable /ipfs/ file
+    test_expect_success "GET /ipfs/ unixfs file has expected Cache-Control" '
+    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_file_output
+    '
+# Cache-Control: generated /ipfs/dir/ (listing)
+    # TODO: test_should_contain "< Cache-Control: public, max-age=TBD" curl_ipfs_dir_listing_output
+    test_expect_success "GET /ipfs/ unixfs dir listing has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
+    '
+# Cache-Control: immutable /ipfs/dir/ (index.html)
+    test_expect_success "GET /ipfs/ unixfs dir with index.html has expected Cache-Control" '
+    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_index.html_output
+    '
+
+# Cache-Control: mutable /ipns/ file
+    test_expect_success "GET /ipns/ unixfs file has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_file_output
+    '
+# Cache-Control: generated /ipns/dir/ (listing)
+    test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
+    '
+# Cache-Control: immutable /ipns/dir/ (index.html)
+    test_expect_success "GET /ipns/ unixfs dir with index.html has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_dir_index.html_output
+    '
+
 # Cache-Control: only-if-cached
     test_expect_success "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore" '
     curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" > curl_onlyifcached_postitive_head 2>&1 &&

--- a/test/sharness/t0117-gateway-block.sh
+++ b/test/sharness/t0117-gateway-block.sh
@@ -68,7 +68,7 @@ test_expect_success "Create text fixtures" '
     '
 
     test_expect_success "GET response for application/vnd.ipld.raw includes Cache-Control" '
-    grep "< Cache-Control" curl_output
+    grep "< Cache-Control: public, max-age=29030400, immutable" curl_output
     '
 
 test_kill_ipfs_daemon


### PR DESCRIPTION
This PR fixes a regression introduced in 0.13.0:

- websites hosted via  `index.html` placed in UnixFS directory were always returned with `Cache-Control: public, max-age=29030400, immutable`  even when loaded from **mutable** `/ipns/*`  content path
  - this contributed to weird stale cache behaviors like the one at https://github.com/ipfs/ipfs-website/issues/141
- adds missing tests of `Cache-Control` on `/ipfs/` and `/ipns/` namespaces  :skull: 

Thank you, @thattommyhall,  for help with debugging and finding this.


