### PR TITLE
chore: update go-pinning-service-http-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/ipfs/go-mfs v0.2.1
 	github.com/ipfs/go-namesys v0.5.0
 	github.com/ipfs/go-path v0.3.0
-	github.com/ipfs/go-pinning-service-http-client v0.1.1
+	github.com/ipfs/go-pinning-service-http-client v0.1.2-0.20220721232344-29ee6ce74148
 	github.com/ipfs/go-unixfs v0.4.0
 	github.com/ipfs/go-unixfsnode v1.4.0
 	github.com/ipfs/go-verifcid v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ github.com/ipfs/go-peertaskqueue v0.2.0/go.mod h1:5/eNrBEbtSKWCG+kQK8K8fGNixoYUn
 github.com/ipfs/go-peertaskqueue v0.7.0/go.mod h1:M/akTIE/z1jGNXMU7kFB4TeSEFvj68ow0Rrb04donIU=
 github.com/ipfs/go-peertaskqueue v0.7.1 h1:7PLjon3RZwRQMgOTvYccZ+mjzkmds/7YzSWKFlBAypE=
 github.com/ipfs/go-peertaskqueue v0.7.1/go.mod h1:M/akTIE/z1jGNXMU7kFB4TeSEFvj68ow0Rrb04donIU=
-github.com/ipfs/go-pinning-service-http-client v0.1.1 h1:Bar+Vi60A0zI8GSSrumVqnbFg6qkUgZSQTX9sV5jWrA=
-github.com/ipfs/go-pinning-service-http-client v0.1.1/go.mod h1:i6tC2nWOnJbZZUQPgxOlrg4CX8bhQZMh4II09FxvD58=
+github.com/ipfs/go-pinning-service-http-client v0.1.2-0.20220721232344-29ee6ce74148 h1:/ncNarwKnep0ZZiqZwMIcy79/laONGiWkAumLAZArls=
+github.com/ipfs/go-pinning-service-http-client v0.1.2-0.20220721232344-29ee6ce74148/go.mod h1:i6tC2nWOnJbZZUQPgxOlrg4CX8bhQZMh4II09FxvD58=
 github.com/ipfs/go-unixfs v0.2.4/go.mod h1:SUdisfUjNoSDzzhGVxvCL9QO/nKdwXdr+gbMUdqcbYw=
 github.com/ipfs/go-unixfs v0.3.1/go.mod h1:h4qfQYzghiIc8ZNFKiLMFWOTzrWIAtzYQ59W/pCFf1o=
 github.com/ipfs/go-unixfs v0.4.0 h1:qSyyxfB/OiDdWHYiSbyaqKC7zfSE/TFL0QdwkRjBm20=


### PR DESCRIPTION
This PR is WIP, do not merge.

### Context

We are planning changes to relax some requirements of pinning service API, and will have to re-generate client based on updated OpenAPI spec. We did it only once around v0.8.0, using `go-experimental` generator which got replaced by `go` one, so doing it again requires additional refactoring and testing.

Details in https://github.com/ipfs/go-pinning-service-http-client/pull/19

### TODO

- [ ] test updated `go-pinning-service-http-client` (generated using "stable" go generator) against `ipfs pin remote` tests we have in sharness
- [ ] make sure CI is green
- [ ] make sure any changes we make to pagination logic described in https://github.com/ipfs/go-pinning-service-http-client/pull/19 have test coverage here