### PR TITLE
feat: add $IPFS_PATH/gateway file

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -806,6 +806,10 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 		return nil, fmt.Errorf("serveHTTPGateway: ConstructNode() failed: %s", err)
 	}
 
+	if err := node.Repo.SetGatewayAddr(listeners[0].Addr()); err != nil {
+		return nil, fmt.Errorf("serveHTTPGateway: SetGatewayAddr() failed: %s", err)
+	}
+
 	errc := make(chan error)
 	var wg sync.WaitGroup
 	for _, lis := range listeners {

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -806,8 +806,10 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 		return nil, fmt.Errorf("serveHTTPGateway: ConstructNode() failed: %s", err)
 	}
 
-	if err := node.Repo.SetGatewayAddr(listeners[0].Addr()); err != nil {
-		return nil, fmt.Errorf("serveHTTPGateway: SetGatewayAddr() failed: %w", err)
+	if len(listeners) > 0 {
+		if err := node.Repo.SetGatewayAddr(listeners[0].Addr()); err != nil {
+			return nil, fmt.Errorf("serveHTTPGateway: SetGatewayAddr() failed: %w", err)
+		}
 	}
 
 	errc := make(chan error)

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -807,7 +807,7 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 	}
 
 	if err := node.Repo.SetGatewayAddr(listeners[0].Addr()); err != nil {
-		return nil, fmt.Errorf("serveHTTPGateway: SetGatewayAddr() failed: %s", err)
+		return nil, fmt.Errorf("serveHTTPGateway: SetGatewayAddr() failed: %w", err)
 	}
 
 	errc := make(chan error)

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -401,7 +401,9 @@ func (r *FSRepo) SetGatewayAddr(addr net.Addr) error {
 	var good bool
 	// Silently remove as worst last case with defers.
 	defer func() {
-	  if !good { os.Remove(tmpPath) }
+		if !good {
+			os.Remove(tmpPath)
+		}
 	}()
 	defer f.Close()
 

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -420,7 +420,7 @@ func (r *FSRepo) SetGatewayAddr(addr net.Addr) error {
 	}
 	// Remove the temp file when rename return error
 	if err1 := os.Remove(tmpPath); err1 != nil {
-		return fmt.Errorf("File Rename error: %w, File remove error: %s", err.Error(), err1.Error())
+		return fmt.Errorf("File Rename error: %w, File remove error: %s", err, err1.Error())
 	}
 	return err
 }

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-	"net"
 
 	filestore "github.com/ipfs/go-filestore"
 	keystore "github.com/ipfs/go-ipfs-keystore"
@@ -398,7 +398,7 @@ func (r *FSRepo) SetGatewayAddr(addr net.Addr) error {
 		return err
 	}
 
-	if _, err = fmt.Fprintf(f, "http://%s", addr.String()); err != nil {
+	if _, err := fmt.Fprintf(f, "http://%s", addr.String()); err != nil {
 		return err
 	}
 	if err = f.Close(); err != nil {

--- a/repo/mock.go
+++ b/repo/mock.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"errors"
+	"net"
 
 	filestore "github.com/ipfs/go-filestore"
 	keystore "github.com/ipfs/go-ipfs-keystore"
@@ -49,6 +50,8 @@ func (m *Mock) GetStorageUsage(_ context.Context) (uint64, error) { return 0, ni
 func (m *Mock) Close() error { return m.D.Close() }
 
 func (m *Mock) SetAPIAddr(addr ma.Multiaddr) error { return errTODO }
+
+func (m *Mock) SetGatewayAddr(addr net.Addr) error { return errTODO }
 
 func (m *Mock) Keystore() keystore.Keystore { return m.K }
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 
 	filestore "github.com/ipfs/go-filestore"
 	keystore "github.com/ipfs/go-ipfs-keystore"
@@ -50,6 +51,9 @@ type Repo interface {
 
 	// SetAPIAddr sets the API address in the repo.
 	SetAPIAddr(addr ma.Multiaddr) error
+
+	// SetGatewayAddr sets the Gateway address in the repo.
+	SetGatewayAddr(addr net.Addr) error
 
 	// SwarmKey returns the configured shared symmetric key for the private networks feature.
 	SwarmKey() ([]byte, error)

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -287,6 +287,12 @@ test_expect_success "GET compact blocks succeeds" '
   test_cmp expected actual
 '
 
+test_expect_success "Verify gateway file" '
+  cat "$IPFS_PATH/gateway" >> gateway_file_actual &&
+  echo -n "http://$GWAY_ADDR" >> gateway_daemon_actual &&
+  test_cmp gateway_daemon_actual gateway_file_actual
+'
+
 test_kill_ipfs_daemon
 
 


### PR DESCRIPTION
The file contains the gateway your node is hosting in the http://<host>:<port> format.
Structurally it works exactly the same as the API file.


IPIP: https://github.com/ipfs/specs/pull/280