### PR TITLE
docs: replace `docs.ipfs.io` with `docs.ipfs.tech`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,7 +10,7 @@ contact_links:
    url: https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md#readme
    about: Documentation on Private Networks, Filestore and other experimental features.
  - name: RPC API Reference
-   url: https://docs.ipfs.io/reference/http/api/
+   url: https://docs.ipfs.tech/reference/http/api/
    about: Documentation of all Kubo RPC API endpoints.
  - name: IPFS Official Forum
    url: https://discuss.ipfs.io

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,7 +10,7 @@ contact_links:
    url: https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md#readme
    about: Documentation on Private Networks, Filestore and other experimental features.
  - name: RPC API Reference
-   url: https://docs.ipfs.tech/reference/http/api/
+   url: https://docs.ipfs.tech/reference/kubo/rpc/
    about: Documentation of all Kubo RPC API endpoints.
  - name: IPFS Official Forum
    url: https://discuss.ipfs.io

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -7,13 +7,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        Problems with documentation on https://docs.ipfs.io should be reported to https://github.com/ipfs/ipfs-docs
+        Problems with documentation on https://docs.ipfs.tech should be reported to https://github.com/ipfs/ipfs-docs
   - type: checkboxes
     attributes:
       label: Checklist
       description: Please verify the following.
       options:
-        - label: I am reporting a documentation issue in this repo, not https://docs.ipfs.io.
+        - label: I am reporting a documentation issue in this repo, not https://docs.ipfs.tech.
           required: true
         - label: I have searched on the [issue tracker](https://github.com/ipfs/kubo/issues?q=is%3Aissue) for my issue.
           required: true

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Kubo (go-ipfs) the earliest and most widely used implementation of IPFS.
 
 It includes:
 - an IPFS daemon server
-- extensive [command line tooling](https://docs.ipfs.io/reference/cli/)
+- extensive [command line tooling](https://docs.ipfs.tech/reference/kubo/cli/)
 - an [HTTP Gateway](https://github.com/ipfs/specs/tree/main/http-gateways#readme) (`/ipfs/`, `/ipns/`) for serving content to HTTP browsers
 - an HTTP RPC API (`/api/v0`) for controlling the daemon node
 
-Note: [other implementations exist](https://docs.ipfs.io/basics/ipfs-implementations/).
+Note: [other implementations exist](https://docs.ipfs.tech/basics/ipfs-implementations/).
 
 ## What is IPFS?
 
@@ -32,7 +32,7 @@ Before opening an issue, consider using one of the following locations to ensure
   - IPFS _design_ in [ipfs/specs issues](https://github.com/ipfs/specs/issues).
   - Exploration of new ideas in [ipfs/notes issues](https://github.com/ipfs/notes/issues).
   - Ask questions and meet the rest of the community at the [IPFS Forum](https://discuss.ipfs.io).
-  - Or [chat with us](https://docs.ipfs.io/community/chat/).
+  - Or [chat with us](https://docs.ipfs.tech/community/chat/).
  
 [![YouTube Channel Subscribers](https://img.shields.io/youtube/channel/subscribers/UCdjsUXJ3QawK4O5L1kqqsew?label=Subscribe%20IPFS&style=social&cacheSeconds=3600)](https://www.youtube.com/channel/UCdjsUXJ3QawK4O5L1kqqsew) [![Follow @IPFS on Twitter](https://img.shields.io/twitter/follow/IPFS?style=social&cacheSeconds=3600)](https://twitter.com/IPFS)
 
@@ -115,7 +115,7 @@ If your system is resource-constrained, we recommend:
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/ipfs/kubo?color=blue&label=kubo%20docker%20image&logo=docker&sort=semver&style=flat-square&cacheSeconds=3600)](https://hub.docker.com/r/ipfs/kubo/)
 -->
 
-More info on how to run kubo (go-ipfs) inside Docker can be found [here](https://docs.ipfs.io/how-to/run-ipfs-inside-docker/).
+More info on how to run kubo (go-ipfs) inside Docker can be found [here](https://docs.ipfs.tech/how-to/run-ipfs-inside-docker/).
 
 ### Native Linux package managers
 
@@ -363,8 +363,8 @@ $ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_windows-amd64.zi
 
 ### Usage
 
-[![docs: Command-line quick start](https://img.shields.io/static/v1?label=docs&message=Command-line%20quick%20start&color=blue&style=flat-square&cacheSeconds=3600)](https://docs.ipfs.io/how-to/command-line-quick-start/)
-[![docs: Command-line reference](https://img.shields.io/static/v1?label=docs&message=Command-line%20reference&color=blue&style=flat-square&cacheSeconds=3600)](https://docs.ipfs.io/reference/cli/)
+[![docs: Command-line quick start](https://img.shields.io/static/v1?label=docs&message=Command-line%20quick%20start&color=blue&style=flat-square&cacheSeconds=3600)](https://docs.ipfs.tech/how-to/command-line-quick-start/)
+[![docs: Command-line reference](https://img.shields.io/static/v1?label=docs&message=Command-line%20reference&color=blue&style=flat-square&cacheSeconds=3600)](https://docs.ipfs.tech/reference/kubo/cli/)
 
 To start using IPFS, you must first initialize IPFS's config files on your
 system, this is done with `ipfs init`. See `ipfs init --help` for information on
@@ -387,11 +387,11 @@ If you have previously installed IPFS before and you are running into problems g
 
 Please direct general questions and help requests to our [forum](https://discuss.ipfs.io) or our IRC channel (freenode #ipfs).
 
-If you believe you've found a bug, check the [issues list](https://github.com/ipfs/kubo/issues) and, if you don't see your problem there, either come talk to us on [Matrix chat](https://docs.ipfs.io/community/chat/), or file an issue of your own!
+If you believe you've found a bug, check the [issues list](https://github.com/ipfs/kubo/issues) and, if you don't see your problem there, either come talk to us on [Matrix chat](https://docs.ipfs.tech/community/chat/), or file an issue of your own!
 
 ## Packages
 
-See [IPFS in GO](https://docs.ipfs.io/reference/go/api/) documentation.
+See [IPFS in GO](https://docs.ipfs.tech/reference/go/api/) documentation.
 
 ## Development
 
@@ -446,7 +446,7 @@ We ❤️ all [our contributors](docs/AUTHORS); this project wouldn’t be what 
 
 This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
-Please reach out to us in one [chat](https://docs.ipfs.io/community/chat/) rooms.
+Please reach out to us in one [chat](https://docs.ipfs.tech/community/chat/) rooms.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Note: [other implementations exist](https://docs.ipfs.io/basics/ipfs-implementat
 
 IPFS is a global, versioned, peer-to-peer filesystem. It combines good ideas from previous systems such as Git, BitTorrent, Kademlia, SFS, and the Web. It is like a single BitTorrent swarm, exchanging git objects. IPFS provides an interface as simple as the HTTP web, but with permanence built-in. You can also mount the world at /ipfs.
 
-For more info see: https://docs.ipfs.io/introduction/overview/
+For more info see: https://docs.ipfs.tech/concepts/what-is-ipfs/
 
 Before opening an issue, consider using one of the following locations to ensure you are opening your thread in the right place:
   - kubo (previously named go-ipfs) _implementation_ bugs in [this repo](https://github.com/ipfs/kubo/issues).
@@ -97,7 +97,7 @@ Please follow [`SECURITY.md`](SECURITY.md).
 
 ## Install
 
-The canonical download instructions for IPFS are over at: https://docs.ipfs.io/guides/guides/install/. It is **highly recommended** you follow those instructions if you are not interested in working on IPFS development.
+The canonical download instructions for IPFS are over at: https://docs.ipfs.tech/install/. It is **highly recommended** you follow those instructions if you are not interested in working on IPFS development.
 
 ### System Requirements
 

--- a/core/corehttp/hostname_test.go
+++ b/core/corehttp/hostname_test.go
@@ -91,7 +91,7 @@ func TestToDNSLinkFQDN(t *testing.T) {
 		out string
 	}{
 		{"singlelabel", "singlelabel"},
-		{"docs-ipfs-io", "docs.ipfs.io"},
+		{"docs-ipfs-tech", "docs.ipfs.tech"},
 		{"dnslink-long--name-example-com", "dnslink.long-name.example.com"},
 	} {
 		out := toDNSLinkFQDN(test.in)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Developer Documentation and Guides
 
-If you are looking for User Documentation & Guides, please visit [docs.ipfs.io](https://docs.ipfs.io/).
+If you are looking for User Documentation & Guides, please visit [docs.ipfs.tech](https://docs.ipfs.tech/).
 
 If you’re experiencing an issue with IPFS, **please follow [our issue guide](github-issue-guide.md) when filing an issue!**
 

--- a/docs/changelogs/v0.10.md
+++ b/docs/changelogs/v0.10.md
@@ -31,7 +31,7 @@ This is significant refactor of a core component that touches many parts of IPFS
 * **IPLD plugins**:
   * The `PluginIPLD` interface has been changed to utilize go-ipld-prime. There is a demonstration of the change in the [bundled git plugin](./plugin/plugins/git/).
 * **The semantics of `dag put` and `dag get` change**:
-  * `dag get` now takes the `output-codec` option which accepts a [multicodec](https://docs.ipfs.io/concepts/glossary/#multicodec) name used to encode the output. By default this is `dag-json`, which is  a strict and deterministic subset of JSON created by the IPLD team. Users may notice differences from the previously plain Go JSON output, particularly where bytes are concerned which are now encoded using a form similar to CIDs: `{"/":{"bytes":"unpadded-base64-bytes"}}` rather than the previously Go-specific plain padded base64 string. See the [dag-json specification](https://ipld.io/specs/codecs/dag-json/spec/) for an explanation of these forms.
+  * `dag get` now takes the `output-codec` option which accepts a [multicodec](https://docs.ipfs.tech/concepts/glossary/#multicodec) name used to encode the output. By default this is `dag-json`, which is  a strict and deterministic subset of JSON created by the IPLD team. Users may notice differences from the previously plain Go JSON output, particularly where bytes are concerned which are now encoded using a form similar to CIDs: `{"/":{"bytes":"unpadded-base64-bytes"}}` rather than the previously Go-specific plain padded base64 string. See the [dag-json specification](https://ipld.io/specs/codecs/dag-json/spec/) for an explanation of these forms.
   * `dag get` no longer prints an additional new-line character at the end of the encoded block output. This means that the output as presented by `dag get` are the exact bytes of the requested node. A round-trip of such bytes back in through `dag put` using the same codec should result in the same CID.
   * `dag put` uses the `input-codec` option to specify the multicodec name of the format data is being provided in, and the `store-codec` option to specify the multicodec name of the format the data should be stored in at rest. These formerly defaulted to `json` and `cbor` respectively. They now default to `dag-json` and `dag-cbor` respectively but may be changed to any supported codec (bundled or loaded via plugin) by its [multicodec name](https://github.com/multiformats/multicodec/blob/master/table.csv).
   * The `json` and `cbor` multicodec names (as used by `input-enc` and `format` options) are now no longer aliases for `dag-json` and `dag-cbor` respectively. Instead, they now refer to their proper [multicodec](https://github.com/multiformats/multicodec/blob/master/table.csv) types. `cbor` refers to a plain CBOR format, which will not encode CIDs and does not have strict deterministic encoding rules. `json` is a plain JSON format, which also won't encode CIDs and will encode bytes in the Go-specific padded base64 string format rather than the dag-json method of byte encoding. See https://ipld.io/specs/codecs/ for more information on IPLD codecs.
@@ -47,7 +47,7 @@ This is significant refactor of a core component that touches many parts of IPFS
 
 #### Ⓜ Multibase Command
 
-go-ipfs now provides utility commands for working with [multibase](https://docs.ipfs.io/concepts/glossary/#multibase):
+go-ipfs now provides utility commands for working with [multibase](https://docs.ipfs.tech/concepts/glossary/#multibase):
 
 ```console
 $ echo -n hello | ipfs multibase encode -b base16 > file-mbase16

--- a/docs/changelogs/v0.11.md
+++ b/docs/changelogs/v0.11.md
@@ -31,9 +31,9 @@ As usual, this release includes important fixes, some of which may be critical f
 ### 🛠 BREAKING CHANGES
 
 -  UnixFS sharding is now automatic and enabled by default
-   - HAMT-based sharding is applied to large directories (i.e. those that would serialize into [block](https://docs.ipfs.io/concepts/glossary/#block) larger than ~256KiB)s. This means importing data via commands like `ipfs add -r <directory>` may result in different [CID](https://docs.ipfs.io/concepts/glossary/#cid)s due to the different [DAG](https://docs.ipfs.io/concepts/glossary/#dag) representations.
+   - HAMT-based sharding is applied to large directories (i.e. those that would serialize into [block](https://docs.ipfs.tech/concepts/glossary/#block) larger than ~256KiB)s. This means importing data via commands like `ipfs add -r <directory>` may result in different [CID](https://docs.ipfs.tech/concepts/glossary/#cid)s due to the different [DAG](https://docs.ipfs.tech/concepts/glossary/#dag) representations.
    - Support for `Experimental.ShardingEnabled` is removed.
-- go-ipfs can no longer act as a [Circuit Relay](https://docs.ipfs.io/concepts/glossary/#circuit-relay) v1
+- go-ipfs can no longer act as a [Circuit Relay](https://docs.ipfs.tech/concepts/glossary/#circuit-relay) v1
   - Node will refuse to start if `Swarm.EnableRelayHop` is set to `true`
   -  If you depend on v1 relay service provider, see "Removal of v1 relay service" section for available migration options.
 - HTTP RPC wire format for experimental commands at  `/api/v0/pubsub` changed.
@@ -46,7 +46,7 @@ Keep reading to learn more details.
 
 #### 🗃 Automatic UnixFS sharding
 
-Truly big directories can have so many items, that the root block with all of their names is too big to be exchanged with other peers. This was partially solved by [HAMT-sharding](https://docs.ipfs.io/concepts/glossary/#hamt-sharding), which was introduced a while ago as opt-in. The main downside of the implementation was that it was a global flag that sharded all imported directories (big and small).
+Truly big directories can have so many items, that the root block with all of their names is too big to be exchanged with other peers. This was partially solved by [HAMT-sharding](https://docs.ipfs.tech/concepts/glossary/#hamt-sharding), which was introduced a while ago as opt-in. The main downside of the implementation was that it was a global flag that sharded all imported directories (big and small).
 
 This release solves that inconvenience by making UnixFS sharding smarter and applies it only to larger directories (i.e. directories that would be at least ~256KiB). This is now the default behavior in `ipfs add` and `ipfs files` commands, where UnixFS sharding works out-of-the-box.
 
@@ -54,7 +54,7 @@ This release solves that inconvenience by making UnixFS sharding smarter and app
 
 This release adds support for the [circuit relay v2](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md) protocol based on the reference implementation from [go-libp2p 0.16](https://github.com/libp2p/go-libp2p/releases/tag/v0.16.0).
 
-This is the cornerstone for maximizing p2p connections between IPFS peers. Every publicly dialable peer can now act as a limited relay v2, which can be used for [hole punching](https://docs.ipfs.io/concepts/glossary/#hole-punching) and other decentralized signaling protocols.
+This is the cornerstone for maximizing p2p connections between IPFS peers. Every publicly dialable peer can now act as a limited relay v2, which can be used for [hole punching](https://docs.ipfs.tech/concepts/glossary/#hole-punching) and other decentralized signaling protocols.
 
 ##### Limited relay v2 configuration options
 
@@ -93,7 +93,7 @@ This release fixed some edge cases that were reported by users of the PubSub exp
 
 If you use the HTTP RPC API with the [go-ipfs-http-client](https://github.com/ipfs/go-ipfs-http-client) library, make sure to update to the latest version. The next version of [js-ipfs-http-client](https://www.npmjs.com/package/ipfs-http-client) will use the new wire format as well, so you don't need to do anything.
 
-If you use `/api/v0/pubsub/*` directly or maintain your own client library, you must adjust your HTTP client code. Byte fields and URL args are now encoded in `base64url` [Multibase](https://docs.ipfs.io/concepts/glossary/#multibase). Encode/decode bytes using the `ipfs multibase --help` commands, or use the multiformats libraries ([js-multiformats](https://github.com/multiformats/js-multiformats#readme), [go-multibase](https://github.com/multiformats/go-multibase)).
+If you use `/api/v0/pubsub/*` directly or maintain your own client library, you must adjust your HTTP client code. Byte fields and URL args are now encoded in `base64url` [Multibase](https://docs.ipfs.tech/concepts/glossary/#multibase). Encode/decode bytes using the `ipfs multibase --help` commands, or use the multiformats libraries ([js-multiformats](https://github.com/multiformats/js-multiformats#readme), [go-multibase](https://github.com/multiformats/go-multibase)).
 
 Low level changes:
 - `topic` passed as URL `arg` in requests to `/api/v0/pubsub/*` must be encoded in URL-safe multibase (`base64url`)

--- a/docs/changelogs/v0.12.md
+++ b/docs/changelogs/v0.12.md
@@ -68,7 +68,7 @@ There is only one change since 0.11:
 
 ##### Blockstore migration from full CID to Multihash keys
 
-We are switching the default low level [datastore](https://docs.ipfs.io/concepts/glossary/#datastore) to be keyed only by the [Multihash](https://docs.ipfs.io/concepts/glossary/#multihash) part of the [CID](https://docs.ipfs.io/concepts/glossary/#cid), and deduplicate some [blocks](https://docs.ipfs.io/concepts/glossary/#block) in the process. The blockstore will become [codec](https://docs.ipfs.io/concepts/glossary/#codec)-agnostic.
+We are switching the default low level [datastore](https://docs.ipfs.tech/concepts/glossary/#datastore) to be keyed only by the [Multihash](https://docs.ipfs.tech/concepts/glossary/#multihash) part of the [CID](https://docs.ipfs.tech/concepts/glossary/#cid), and deduplicate some [blocks](https://docs.ipfs.tech/concepts/glossary/#block) in the process. The blockstore will become [codec](https://docs.ipfs.tech/concepts/glossary/#codec)-agnostic.
 
 ###### Rationale
 

--- a/docs/changelogs/v0.13.md
+++ b/docs/changelogs/v0.13.md
@@ -373,7 +373,7 @@ For more information, see:
 
 #### RPC API docs for experimental and deprecated commands
 
-https://docs.ipfs.tech/reference/http/api/ now includes separate sections for _experimental_ and _deprecated_ commands.
+https://docs.ipfs.tech/reference/kubo/rpc/ now includes separate sections for _experimental_ and _deprecated_ commands.
 
 We also display a warning in the command line:
 

--- a/docs/changelogs/v0.13.md
+++ b/docs/changelogs/v0.13.md
@@ -6,7 +6,7 @@
 <summary>Full Changelog</summary>
 
 This release includes security fixes for various DOS vectors when importing untrusted user input with `ipfs dag import`
-and the [`v0/dag/import`](https://docs.ipfs.io/reference/http/api/#api-v0-dag-import) endpoint.
+and the [`v0/dag/import`](https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-dag-import) endpoint.
 
 View the linked [security advisory](https://github.com/ipfs/go-ipfs/security/advisories/GHSA-f2gr-7299-487h) for more information.
 
@@ -215,7 +215,7 @@ For now, `{format}` is limited to two options:
 
 When not set, the default UnixFS response is returned.
 
-*Why these two formats?* Requesting Block or CAR for `/ipfs/{cid}` allows a client to **use gateways in a trustless fashion**. These types of gateway responses can be verified locally and rejected if digest inside of requested CID does not match received bytes. This enables creation of "light IPFS clients" which use HTTP Gateways as inexpensive transport for [content-addressed](https://docs.ipfs.io/concepts/content-addressing/) data, unlocking use in Mobile and IoT contexts.
+*Why these two formats?* Requesting Block or CAR for `/ipfs/{cid}` allows a client to **use gateways in a trustless fashion**. These types of gateway responses can be verified locally and rejected if digest inside of requested CID does not match received bytes. This enables creation of "light IPFS clients" which use HTTP Gateways as inexpensive transport for [content-addressed](https://docs.ipfs.tech/concepts/content-addressing/) data, unlocking use in Mobile and IoT contexts.
 
 
 Future releases will [add support for dag-json and dag-cbor responses](https://github.com/ipfs/go-ipfs/issues/8823).
@@ -280,7 +280,7 @@ Gateway evaluates Etags sent by a client in [`If-None-Match`](https://developer.
 
 `X-Ipfs-Roots` is now returned with every Gateway response. It is a way to indicate all CIDs required for resolving path segments from `X-Ipfs-Path`. Together, these two headers are meant to improve interop with existing HTTP software (load-balancers, caches, CDNs).
 
-This additional information allows HTTP caches and CDNs to make better decisions around cache invalidation: not just invalidate everything under specific IPNS website when the root changes, but do more fine-grained cache invalidation by detecting when only a specific subdirectory (branch of a [DAG](https://docs.ipfs.io/concepts/glossary/#dag)) changes.
+This additional information allows HTTP caches and CDNs to make better decisions around cache invalidation: not just invalidate everything under specific IPNS website when the root changes, but do more fine-grained cache invalidation by detecting when only a specific subdirectory (branch of a [DAG](https://docs.ipfs.tech/concepts/glossary/#dag)) changes.
 
 ##### 🌡️ Added metrics per response type
 
@@ -368,12 +368,12 @@ Docker images published at https://hub.docker.com/r/ipfs/go-ipfs/  now support c
 Scripts are executed sequentially and in lexicographic order, before the IPFS daemon is started and after `ipfs init` is run and the swarm keys are copied (if the IPFS repo needs initialization).
 
 For more information, see:
-- Documentation: [ Run IPFS inside Docker](https://docs.ipfs.io/how-to/run-ipfs-inside-docker/) <!-- TODO: needs https://github.com/ipfs/ipfs-docs/pull/1115/files -->
+- Documentation: [ Run IPFS inside Docker](https://docs.ipfs.tech/how-to/run-ipfs-inside-docker/) <!-- TODO: needs https://github.com/ipfs/ipfs-docs/pull/1115/files -->
 - Examples in [ipfs-shipyard/go-ipfs-docker-examples](https://github.com/ipfs-shipyard/go-ipfs-docker-examples).
 
 #### RPC API docs for experimental and deprecated commands
 
-https://docs.ipfs.io/reference/http/api/ now includes separate sections for _experimental_ and _deprecated_ commands.
+https://docs.ipfs.tech/reference/http/api/ now includes separate sections for _experimental_ and _deprecated_ commands.
 
 We also display a warning in the command line:
 

--- a/docs/changelogs/v0.14.md
+++ b/docs/changelogs/v0.14.md
@@ -70,7 +70,7 @@ See `ipfs repo migrate --help` for more info.
 
 #### 🚀 Emoji support in Multibase
 
-Kubo now supports [`base256emoji`](https://github.com/multiformats/multibase/blob/master/rfcs/Base256Emoji.md) encoding in all [Multibase](https://docs.ipfs.io/concepts/glossary/#multibase) contexts. Use it for testing Unicode support, as visual aid while explaining Multiformats, or just for fun:
+Kubo now supports [`base256emoji`](https://github.com/multiformats/multibase/blob/master/rfcs/Base256Emoji.md) encoding in all [Multibase](https://docs.ipfs.tech/concepts/glossary/#multibase) contexts. Use it for testing Unicode support, as visual aid while explaining Multiformats, or just for fun:
 
 ```console
 $ echo -n "test" | ipfs multibase encode -b base256emoji -

--- a/docs/changelogs/v0.9.md
+++ b/docs/changelogs/v0.9.md
@@ -159,7 +159,7 @@ While the Object API and commands are still usable they are now marked as deprec
 
 ##### `X-Ipfs-Gateway-Prefix` is now deprecated
 
-IPFS community moved towards dedicated Origins (DNSLink and [subdomain gateways](https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway)) which are much easier to isolate and reason about.
+IPFS community moved towards dedicated Origins (DNSLink and [subdomain gateways](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway)) which are much easier to isolate and reason about.
 
 Setting up `Gateway.PathPrefixes` and `X-Ipfs-Gateway-Prefix` is no longer necessary and support [will be removed in near future](https://github.com/ipfs/go-ipfs/issues/7702).
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -748,7 +748,7 @@ Type: `array[string]`
 A boolean to configure whether the gateway at the hostname provides [Origin isolation](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)
 between content roots.
 
-- `true` - enables [subdomain gateway](#https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://*.{hostname}/`
+- `true` - enables [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://*.{hostname}/`
     - **Requires whitelist:** make sure respective `Paths` are set.
       For example, `Paths: ["/ipfs", "/ipns"]` are required for `http://{cid}.ipfs.{hostname}` and `http://{foo}.ipns.{hostname}` to work:
         ```json
@@ -764,7 +764,7 @@ between content roots.
     - **Backward-compatible:** requests for content paths such as `http://{hostname}/ipfs/{cid}` produce redirect to `http://{cid}.ipfs.{hostname}`
     - **API:** if `/api` is on the `Paths` whitelist, `http://{hostname}/api/{cmd}` produces redirect to `http://api.{hostname}/api/{cmd}`
 
-- `false` - enables [path gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#path-gateway) at `http://{hostname}/*`
+- `false` - enables [path gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway) at `http://{hostname}/*`
   - Example:
     ```json
     "Gateway": {
@@ -821,7 +821,7 @@ $ ipfs config --json Gateway.PublicGateways '{"localhost": null }'
 
 Below is a list of the most common public gateway setups.
 
-* Public [subdomain gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://{cid}.ipfs.dweb.link` (each content root gets its own Origin)
+* Public [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://{cid}.ipfs.dweb.link` (each content root gets its own Origin)
    ```console
    $ ipfs config --json Gateway.PublicGateways '{
        "dweb.link": {
@@ -845,7 +845,7 @@ Below is a list of the most common public gateway setups.
      `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.example.com`
 
 
-* Public [path gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#path-gateway) at `http://ipfs.io/ipfs/{cid}` (no Origin separation)
+* Public [path gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway) at `http://ipfs.io/ipfs/{cid}` (no Origin separation)
    ```console
    $ ipfs config --json Gateway.PublicGateways '{
        "ipfs.io": {
@@ -861,7 +861,7 @@ Below is a list of the most common public gateway setups.
   ```
   * Note that `NoDNSLink: false` is the default (it works out of the box unless set to `true` manually)
 
-* Hardened, site-specific [DNSLink gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#dnslink-gateway).
+* Hardened, site-specific [DNSLink gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#dnslink-gateway).
 
   Disable fetching of remote data (`NoFetch: true`) and resolving DNSLink at unknown hostnames (`NoDNSLink: true`).
   Then, enable DNSLink gateway only for the specific hostname (for which data
@@ -1931,7 +1931,7 @@ Type: `priority`
 
 ## `DNS`
 
-Options for configuring DNS resolution for [DNSLink](https://docs.ipfs.io/concepts/dnslink/) and `/dns*` [Multiaddrs](https://github.com/multiformats/multiaddr/).
+Options for configuring DNS resolution for [DNSLink](https://docs.ipfs.tech/concepts/dnslink/) and `/dns*` [Multiaddrs](https://github.com/multiformats/multiaddr/).
 
 ### `DNS.Resolvers`
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -54,7 +54,7 @@ for details</sub>
 
 You can use an IPFS gateway to serve static websites at a custom domain using
 [DNSLink](https://docs.ipfs.tech/concepts/glossary/#dnslink). See [Example: IPFS
-Gateway](https://dnslink.io/#example-ipfs-gateway) for instructions.
+Gateway](https://dnslink.dev/#example-ipfs-gateway) for instructions.
 
 ## Filenames
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -4,15 +4,15 @@ An IPFS Gateway acts as a bridge between traditional web browsers and IPFS.
 Through the gateway, users can browse files and websites stored in IPFS as if
 they were stored in a traditional web server. 
 
-[More about Gateways](https://docs.ipfs.io/concepts/ipfs-gateway/) and [addressing IPFS on the web](https://docs.ipfs.io/how-to/address-ipfs-on-web/).
+[More about Gateways](https://docs.ipfs.tech/concepts/ipfs-gateway/) and [addressing IPFS on the web](https://docs.ipfs.tech/how-to/address-ipfs-on-web/).
 
 Kubo's Gateway implementation follows [ipfs/specs: Specification for HTTP Gateways](https://github.com/ipfs/specs/tree/main/http-gateways#readme).
 
 ### Local gateway
 
 By default, Kubo nodes run
-a [path gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#path-gateway) at `http://127.0.0.1:8080/`
-and a [subdomain gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://localhost:8080/`
+a [path gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway) at `http://127.0.0.1:8080/`
+and a [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://localhost:8080/`
 
 Additional listening addresses and gateway behaviors can be set in the [config](#configuration) file.
 
@@ -53,7 +53,7 @@ for details</sub>
 ## Static Websites
 
 You can use an IPFS gateway to serve static websites at a custom domain using
-[DNSLink](https://docs.ipfs.io/concepts/glossary#dnslink). See [Example: IPFS
+[DNSLink](https://docs.ipfs.tech/concepts/glossary/#dnslink). See [Example: IPFS
 Gateway](https://dnslink.io/#example-ipfs-gateway) for instructions.
 
 ## Filenames

--- a/misc/systemd/ipfs-hardened.service
+++ b/misc/systemd/ipfs-hardened.service
@@ -18,7 +18,7 @@
 
 [Unit]
 Description=InterPlanetary File System (IPFS) daemon
-Documentation=https://docs.ipfs.io/
+Documentation=https://docs.ipfs.tech/
 After=network.target
 
 [Service]

--- a/misc/systemd/ipfs.service
+++ b/misc/systemd/ipfs.service
@@ -14,7 +14,7 @@
 
 [Unit]
 Description=InterPlanetary File System (IPFS) daemon
-Documentation=https://docs.ipfs.io/
+Documentation=https://docs.ipfs.tech/
 After=network.target
 
 [Service]


### PR DESCRIPTION
The PR to fix the redirecting URL in README.md