### PR TITLE
Fixed md link syntax typo for AutoNAT.ServiceMode

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1618,7 +1618,7 @@ Set `Swarm.Transports.Network.Relay` to `false` instead.
 
 **REMOVED**
 
-Please use [`AutoNAT.ServiceMode`][#autonatservicemode].
+Please use [`AutoNAT.ServiceMode`](#autonatservicemode).
 
 ### `Swarm.ConnMgr`
 


### PR DESCRIPTION
A small typo fix in config.md from docs