### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -4,14 +4,13 @@
 package node
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"bazil.org/fuse"
-
-	"context"
 
 	core "github.com/ipfs/kubo/core"
 	ipns "github.com/ipfs/kubo/fuse/ipns"
@@ -52,11 +51,8 @@ func TestExternalUnmount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// get the test dir paths (/tmp/fusetestXXXX)
-	dir, err := os.MkdirTemp("", "fusetest")
-	if err != nil {
-		t.Fatal(err)
-	}
+	// get the test dir paths (/tmp/TestExternalUnmount)
+	dir := t.TempDir()
 
 	ipfsDir := dir + "/ipfs"
 	ipnsDir := dir + "/ipns"

--- a/repo/fsrepo/config_test.go
+++ b/repo/fsrepo/config_test.go
@@ -2,7 +2,6 @@ package fsrepo_test
 
 import (
 	"encoding/json"
-	"os"
 	"reflect"
 	"testing"
 
@@ -88,11 +87,7 @@ func TestDefaultDatastoreConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	config := new(config.Datastore)
 	err = json.Unmarshal(defaultConfig, config)
@@ -126,11 +121,7 @@ func TestLevelDbConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	spec := make(map[string]interface{})
 	err = json.Unmarshal(leveldbConfig, &spec)
@@ -164,11 +155,7 @@ func TestFlatfsConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	spec := make(map[string]interface{})
 	err = json.Unmarshal(flatfsConfig, &spec)
@@ -202,11 +189,7 @@ func TestMeasureConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 
 	spec := make(map[string]interface{})
 	err = json.Unmarshal(measureConfig, &spec)

--- a/repo/fsrepo/fsrepo_test.go
+++ b/repo/fsrepo/fsrepo_test.go
@@ -13,18 +13,9 @@ import (
 	config "github.com/ipfs/kubo/config"
 )
 
-// swap arg order
-func testRepoPath(p string, t *testing.T) string {
-	name, err := os.MkdirTemp("", p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return name
-}
-
 func TestInitIdempotence(t *testing.T) {
 	t.Parallel()
-	path := testRepoPath("", t)
+	path := t.TempDir()
 	for i := 0; i < 10; i++ {
 		assert.Nil(Init(path, &config.Config{Datastore: config.DefaultDatastoreConfig()}), t, "multiple calls to init should succeed")
 	}
@@ -37,8 +28,8 @@ func Remove(repoPath string) error {
 
 func TestCanManageReposIndependently(t *testing.T) {
 	t.Parallel()
-	pathA := testRepoPath("a", t)
-	pathB := testRepoPath("b", t)
+	pathA := t.TempDir()
+	pathB := t.TempDir()
 
 	t.Log("initialize two repos")
 	assert.Nil(Init(pathA, &config.Config{Datastore: config.DefaultDatastoreConfig()}), t, "a", "should initialize successfully")
@@ -65,7 +56,7 @@ func TestCanManageReposIndependently(t *testing.T) {
 
 func TestDatastoreGetNotAllowedAfterClose(t *testing.T) {
 	t.Parallel()
-	path := testRepoPath("test", t)
+	path := t.TempDir()
 
 	assert.True(!IsInitialized(path), t, "should NOT be initialized")
 	assert.Nil(Init(path, &config.Config{Datastore: config.DefaultDatastoreConfig()}), t, "should initialize successfully")
@@ -83,7 +74,7 @@ func TestDatastoreGetNotAllowedAfterClose(t *testing.T) {
 
 func TestDatastorePersistsFromRepoToRepo(t *testing.T) {
 	t.Parallel()
-	path := testRepoPath("test", t)
+	path := t.TempDir()
 
 	assert.Nil(Init(path, &config.Config{Datastore: config.DefaultDatastoreConfig()}), t)
 	r1, err := Open(path)
@@ -104,7 +95,7 @@ func TestDatastorePersistsFromRepoToRepo(t *testing.T) {
 
 func TestOpenMoreThanOnceInSameProcess(t *testing.T) {
 	t.Parallel()
-	path := testRepoPath("", t)
+	path := t.TempDir()
 	assert.Nil(Init(path, &config.Config{Datastore: config.DefaultDatastoreConfig()}), t)
 
 	r1, err := Open(path)

--- a/test/bench/bench_cli_ipfs_add/main.go
+++ b/test/bench/bench_cli_ipfs_add/main.go
@@ -45,12 +45,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 		b.SetBytes(amount)
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				benchmarkError = err
-				b.Fatal(err)
-			}
-			defer os.RemoveAll(tmpDir)
+			tmpDir := b.TempDir()
 
 			env := append(
 				[]string{fmt.Sprintf("%s=%s", config.EnvDir, path.Join(tmpDir, config.DefaultPathName))}, // first in order to override

--- a/test/bench/offline_add/main.go
+++ b/test/bench/offline_add/main.go
@@ -37,11 +37,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 		b.SetBytes(amount)
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
-			tmpDir, err := os.MkdirTemp("", "")
-			if err != nil {
-				b.Fatal(err)
-			}
-			defer os.RemoveAll(tmpDir)
+			tmpDir := b.TempDir()
 
 			env := append(os.Environ(), fmt.Sprintf("%s=%s", config.EnvDir, path.Join(tmpDir, config.DefaultPathName)))
 			setupCmd := func(cmd *exec.Cmd) {


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```