### PR TITLE
Add reference to Experimental config doc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -602,7 +602,7 @@ in the [new mDNS implementation](https://github.com/libp2p/zeroconf#readme).
 
 ## `Experimental`
 
-Toggle and configure experimental features of Kubo. Experimental features are listed [here](https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md).
+Toggle and configure experimental features of Kubo. Experimental features are listed [here](./experimental-features.md).
 
 ## `Gateway`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,6 +46,7 @@ config file at runtime.
     - [`Discovery.MDNS`](#discoverymdns)
       - [`Discovery.MDNS.Enabled`](#discoverymdnsenabled)
       - [`Discovery.MDNS.Interval`](#discoverymdnsinterval)
+  - [`Experimental`](#experimental)
   - [`Gateway`](#gateway)
     - [`Gateway.NoFetch`](#gatewaynofetch)
     - [`Gateway.NoDNSLink`](#gatewaynodnslink)
@@ -598,6 +599,10 @@ Type: `bool`
 
 **REMOVED:**  this is not configurable any more
 in the [new mDNS implementation](https://github.com/libp2p/zeroconf#readme).
+
+## `Experimental`
+
+Toggle and configure experimental features of Kubo. Experimental features are listed [here](https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md).
 
 ## `Gateway`
 


### PR DESCRIPTION
this clarifies that `Experimental` is in fact a top level configuration key, and links to the most current documentation