### PR TITLE
docs(config): mention routing.delegate.ipfs.io

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1347,7 +1347,7 @@ Reframe:
   - `Endpoint` (mandatory): URL that will be used to connect to a specified router.
   - `Priority` (optional): Priority is used when making a routing request. Small numbers represent more important routers. The default priority is 100000.
 
-**Example:**
+**Examples:**
 
 To add router provided by _Store the Index_ team at [cid.contact](https://cid.contact):
 
@@ -1360,7 +1360,7 @@ $ ipfs config Routing.Routers.CidContact --json '{
 }'
 ```
 
-Anyone can create and run their own Reframe endpoint, and experiment with custom routing logic. See [`someguy`](https://github.com/aschmahmann/someguy) example, which proxies requests to BOTH the IPFS Public DHT AND an Indexer node.
+Anyone can create and run their own Reframe endpoint, and experiment with custom routing logic. See [`someguy`](https://github.com/aschmahmann/someguy) example, which proxies requests to BOTH the IPFS Public DHT AND an Indexer node. Protocol Labs provides a public instance at `https://routing.delegate.ipfs.io/reframe`.
 
 Default: `{}` (use the safe implicit defaults)
 


### PR DESCRIPTION
@aschmahmann thoughts on mentioning this in config docs? IMO has way more utility than the indexer on its own.