### PR TITLE
feat: add blake3 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/ipfs/go-pinning-service-http-client v0.1.1
 	github.com/ipfs/go-unixfs v0.4.0
 	github.com/ipfs/go-unixfsnode v1.4.0
-	github.com/ipfs/go-verifcid v0.0.1
+	github.com/ipfs/go-verifcid v0.0.2
 	github.com/ipfs/interface-go-ipfs-core v0.7.0
 	github.com/ipfs/tar-utils v0.0.2
 	github.com/ipld/go-car v0.4.0
@@ -88,7 +88,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multibase v0.1.0
 	github.com/multiformats/go-multicodec v0.5.0
-	github.com/multiformats/go-multihash v0.2.0
+	github.com/multiformats/go-multihash v0.2.1
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -652,8 +652,9 @@ github.com/ipfs/go-unixfs v0.4.0/go.mod h1:I7Nqtm06HgOOd+setAoCU6rf/HgVFHE+peeNu
 github.com/ipfs/go-unixfsnode v1.1.2/go.mod h1:5dcE2x03pyjHk4JjamXmunTMzz+VUtqvPwZjIEkfV6s=
 github.com/ipfs/go-unixfsnode v1.4.0 h1:9BUxHBXrbNi8mWHc6j+5C580WJqtVw9uoeEKn4tMhwA=
 github.com/ipfs/go-unixfsnode v1.4.0/go.mod h1:qc7YFFZ8tABc58p62HnIYbUMwj9chhUuFWmxSokfePo=
-github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
+github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
+github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
 github.com/ipfs/interface-go-ipfs-core v0.4.0/go.mod h1:UJBcU6iNennuI05amq3FQ7g0JHUkibHFAfhfUIy927o=
 github.com/ipfs/interface-go-ipfs-core v0.7.0 h1:7tb+2upz8oCcjIyjo1atdMk+P+u7wPmI+GksBlLE8js=
 github.com/ipfs/interface-go-ipfs-core v0.7.0/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
@@ -1274,8 +1275,8 @@ github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUj
 github.com/multiformats/go-multihash v0.0.15/go.mod h1:D6aZrWNLFTV/ynMpKsNtB40mJzmCl4jb1alC0OvHiHg=
 github.com/multiformats/go-multihash v0.0.16/go.mod h1:zhfEIgVnB/rPMfxgFw15ZmGoNaKyNUIE4IWHG/kC+Ag=
 github.com/multiformats/go-multihash v0.1.0/go.mod h1:RJlXsxt6vHGaia+S8We0ErjhojtKzPP2AH4+kYM7k84=
-github.com/multiformats/go-multihash v0.2.0 h1:oytJb9ZA1OUW0r0f9ea18GiaPOo4SXyc7p2movyUuo4=
-github.com/multiformats/go-multihash v0.2.0/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
+github.com/multiformats/go-multihash v0.2.1 h1:aem8ZT0VA2nCHHk7bPJ1BjUbHNciqZC/d16Vve9l108=
+github.com/multiformats/go-multihash v0.2.1/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
 github.com/multiformats/go-multistream v0.0.1/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.0.4/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=
 github.com/multiformats/go-multistream v0.1.0/go.mod h1:fJTiDfXJVmItycydCnNx4+wSzZ5NwG2FEVAI30fiovg=

--- a/test/sharness/t0275-cid-security.sh
+++ b/test/sharness/t0275-cid-security.sh
@@ -23,7 +23,7 @@ test_expect_success "adding using too short of a hash function gives out an erro
 '
 
 test_expect_success "error reason is pointed out" '
-  grep "hashes must be at 20 least bytes long" block_out
+  grep "hashes must be at least 20 bytes long" block_out
 '
 
 
@@ -45,7 +45,7 @@ test_cat_get() {
     '
 
   test_expect_success "error reason is pointed out" '
-     grep "hashes must be at 20 least bytes long" ipfs_get
+     grep "hashes must be at least 20 bytes long" ipfs_get
   '
 }
 

--- a/test/sharness/t0290-cid.sh
+++ b/test/sharness/t0290-cid.sh
@@ -173,6 +173,7 @@ cat <<EOF > hashes_expect
    27  keccak-256
    28  keccak-384
    29  keccak-512
+   30  blake3
    86  dbl-sha2-256
 45588  blake2b-160
 45589  blake2b-168

--- a/test/sharness/t0800-blake3.sh
+++ b/test/sharness/t0800-blake3.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Claudia Richoux
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test blake3 mhash support"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+# the blake3 hash of "foo\n" in UTF8 (which is what comes out of echo when you pipe into `ipfs`) starts with "49dc870df1de7fd60794cebce449f5ccdae575affaa67a24b62acb03e039db92"
+# without the newline it's "04e0bb39f30b1a3feb89f536c93be15055482df748674b00d26e5a75777702e9". so if you start seeing these values that's your problem
+BLAKE3RAWCID32BYTE="bafkr4icj3sdq34o6p7lapfgoxtset5om3lsxll72uz5cjnrkzmb6aoo3si"
+BLAKE3RAWCID64BYTE="bafkr4qcj3sdq34o6p7lapfgoxtset5om3lsxll72uz5cjnrkzmb6aoo3sknmbprpe27pbfrb67tonydgfot5ixuq4skiva76ppbgpjlzc4ua4"
+BLAKE3RAWCID128BYTE="bafkr5aabjhoiodpr3z75mb4uz26oispvztnok5np7kthujfwflfqhybz3ojjvqf6f4tl54eweh36nzxamyv2pvc6sdsjjcud7z54ez5fpelsqdtax2k3rvuq3wdl5a4blxv3gvsroa3nakfzzknamhu2apf3vvytyiobabrn2bfnfajq66ikjy5lewsp5jyddsg5l7u3emr2ancimryay"
+
+### block tests, including for various sizes of hash ###
+
+test_expect_success "putting a block with an mhash blake3 succeeds (default 32 bytes)" '
+  HASH=$(echo "foo" | ipfs block put --mhtype=blake3 --cid-codec=raw | tee actual_out) &&
+  test $BLAKE3RAWCID32BYTE = "$HASH"
+'
+
+test_expect_success "block get output looks right" '
+  ipfs block get $BLAKE3RAWCID32BYTE > blk_get_out &&
+  echo "foo" > blk_get_exp &&
+  test_cmp blk_get_exp blk_get_out
+'
+
+test_expect_success "putting a block with an mhash blake3 succeeds: 64 bytes" '
+  HASH=$(echo "foo" | ipfs block put --mhtype=blake3 --mhlen=64 --cid-codec=raw | tee actual_out) &&
+  test $BLAKE3RAWCID64BYTE = "$HASH"
+'
+
+test_expect_success "64B block get output looks right" '
+  ipfs block get $BLAKE3RAWCID64BYTE > blk_get_out &&
+  echo "foo" > blk_get_exp &&
+  test_cmp blk_get_exp blk_get_out
+'
+
+test_expect_success "putting a block with an mhash blake3 succeeds: 128 bytes" '
+  HASH=$(echo "foo" | ipfs block put --mhtype=blake3 --mhlen=128 --cid-codec=raw | tee actual_out) &&
+  test $BLAKE3RAWCID128BYTE = "$HASH"
+'
+
+test_expect_success "32B block get output looks right" '
+  ipfs block get $BLAKE3RAWCID128BYTE > blk_get_out &&
+  echo "foo" > blk_get_exp &&
+  test_cmp blk_get_exp blk_get_out
+'
+
+### dag tests ###
+
+test_expect_success "dag put works with blake3" '
+  HASH=$(echo "foo" | ipfs dag put --input-codec=raw --store-codec=raw --hash=blake3 | tee actual_out) &&
+  test $BLAKE3RAWCID32BYTE = "$HASH"
+'
+
+test_expect_success "dag get output looks right" '
+  ipfs dag get --output-codec=raw $BLAKE3RAWCID32BYTE > dag_get_out &&
+  echo "foo" > dag_get_exp &&
+  test_cmp dag_get_exp dag_get_out
+'
+
+### add and cat tests ###
+
+test_expect_success "adding a file with just foo in it to ipfs" '
+  echo "foo" > afile &&
+  HASH=$(ipfs add -q --hash=blake3 --raw-leaves afile | tee actual_out) &&
+  test $BLAKE3RAWCID32BYTE = "$HASH"
+'
+
+test_expect_success "catting it" '
+  ipfs cat $BLAKE3RAWCID32BYTE > cat_out &&
+  echo "foo" > cat_exp &&
+  test_cmp cat_exp cat_out
+'
+
+test_done


### PR DESCRIPTION
Support hashes from 20 <= x <= 128 bytes, but does not yet have any option to generate anything else than 32 bytes hashes.

This will be forward compatible when we add such option.

This is #9073 with squashes.