### PR TITLE
chore: switch to dist.ipfs.tech

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,7 +22,7 @@ body:
           required: true
         - label: I have searched on the [issue tracker](https://github.com/ipfs/kubo/issues?q=is%3Aissue) for my bug.
           required: true
-        - label: I am running the latest [kubo version](https://dist.ipfs.io/#kubo) or have an issue updating.
+        - label: I am running the latest [kubo version](https://dist.ipfs.tech/#kubo) or have an issue updating.
           required: true
   - type: dropdown
     id: install
@@ -33,7 +33,7 @@ body:
       description: Please select your installation method
       options:
         - ipfs-desktop
-        - ipfs-update or dist.ipfs.io
+        - ipfs-update or dist.ipfs.tech
         - third-party binary
         - built from source
   - type: textarea

--- a/.github/workflows/sync-release-assets.yml
+++ b/.github/workflows/sync-release-assets.yml
@@ -1,4 +1,4 @@
-name: Sync github release assets with dist.ipfs.io
+name: Sync github release assets with dist.ipfs.tech
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sync-github-and-dist-ipfs-io:
+  sync-github-and-dist.ipfs.tech:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: "ubuntu-latest"
     steps:
@@ -50,8 +50,8 @@ jobs:
                 github_assets.add(asset.name)
               }
 
-              // fetch asset info from dist.ipfs.io
-              p = '/ipns/dist.ipfs.io/kubo/' + release.tag_name
+              // fetch asset info from dist.ipfs.tech
+              p = '/ipns/dist.ipfs.tech/kubo/' + release.tag_name
               let stdout = ''
               const options = {}
               options.listeners = {
@@ -74,7 +74,7 @@ jobs:
                 }
               }
 
-              // if dist.ipfs.io has files not found in github, copy them over
+              // if dist.ipfs.tech has files not found in github, copy them over
               for (const file of missing_files) {
                 file_sha = file + ".sha512"
                 file_cid = file + ".cid"
@@ -82,12 +82,12 @@ jobs:
                 // skip files that don't have .cid and .sha512 checksum files
                 if (!dist_assets.has(file_sha) || !dist_assets.has(file_cid)) {
                   if (!file.endsWith('.cid') && !file.endsWith('.sha512')) { // silent skip of .sha512.sha512 :)
-                    console.log(`skipping "${file}" as dist.ipfs.io does not provide .cid and .sha512 checksum files for it`)
+                    console.log(`skipping "${file}" as dist.ipfs.tech does not provide .cid and .sha512 checksum files for it`)
                   }
                   continue
                 }
 
-                console.log("fetching", file, "from dist.ipfs.io")
+                console.log("fetching", file, "from dist.ipfs.tech")
                 await exec.exec('ipfs', ['get', p + '/' + file])
                 await exec.exec('ipfs', ['get', p + '/' + file_sha])
                 await exec.exec('ipfs', ['get', p + '/' + file_cid])

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Before opening an issue, consider using one of the following locations to ensure
   - Documentation issues in [ipfs/docs issues](https://github.com/ipfs/ipfs-docs/issues).
   - IPFS _design_ in [ipfs/specs issues](https://github.com/ipfs/specs/issues).
   - Exploration of new ideas in [ipfs/notes issues](https://github.com/ipfs/notes/issues).
-  - Ask questions and meet the rest of the community at the [IPFS Forum](https://discuss.ipfs.io).
+  - Ask questions and meet the rest of the community at the [IPFS Forum](https://discuss.ipfs.tech).
   - Or [chat with us](https://docs.ipfs.tech/community/chat/).
  
 [![YouTube Channel Subscribers](https://img.shields.io/youtube/channel/subscribers/UCdjsUXJ3QawK4O5L1kqqsew?label=Subscribe%20IPFS&style=social&cacheSeconds=3600)](https://www.youtube.com/channel/UCdjsUXJ3QawK4O5L1kqqsew) [![Follow @IPFS on Twitter](https://img.shields.io/twitter/follow/IPFS?style=social&cacheSeconds=3600)](https://twitter.com/IPFS)
@@ -244,16 +244,16 @@ PS> scoop install go-ipfs
 
 ### Install prebuilt binaries
 
-[![dist.ipfs.io Downloads](https://img.shields.io/github/v/release/ipfs/kubo?label=dist.ipfs.io&logo=ipfs&style=flat-square&cacheSeconds=3600)](https://dweb.link/ipns/dist.ipfs.io#kubo)
+[![dist.ipfs.tech Downloads](https://img.shields.io/github/v/release/ipfs/kubo?label=dist.ipfs.tech&logo=ipfs&style=flat-square&cacheSeconds=3600)](https://dweb.link/ipns/dist.ipfs.tech#kubo)
 
 From there:
 - Click the blue "Download kubo" on the right side of the page.
 - Open/extract the archive.
 - Move kubo (`ipfs`) to your path (`install.sh` can do it for you).
 
-If you are unable to access [dist.ipfs.io](https://dist.ipfs.io#kubo), you can also download kubo (go-ipfs) from:
+If you are unable to access [dist.ipfs.tech](https://dist.ipfs.tech#kubo), you can also download kubo (go-ipfs) from:
 - this project's GitHub [releases](https://github.com/ipfs/kubo/releases/latest) page
-- `/ipns/dist.ipfs.io` at [dweb.link](https://dweb.link/ipns/dist.ipfs.io#kubo) gateway
+- `/ipns/dist.ipfs.tech` at [dweb.link](https://dweb.link/ipns/dist.ipfs.tech#kubo) gateway
 
 ### Build from Source
 
@@ -329,34 +329,34 @@ dependencies as well.
 
 IPFS has an updating tool that can be accessed through `ipfs update`. The tool is
 not installed alongside IPFS in order to keep that logic independent of the main
-codebase. To install `ipfs update`, [download it here](https://ipfs.io/ipns/dist.ipfs.io/#ipfs-update).
+codebase. To install `ipfs update`, [download it here](https://dist.ipfs.tech/#ipfs-update).
 
 #### Downloading builds using IPFS
 
-<!-- TODO: rename this section after we figure out if dist.ipfs.io sgould produce both /go-ipfs/ and /kubo/ -->
+<!-- TODO: rename this section after we figure out if dist.ipfs.tech sgould produce both /go-ipfs/ and /kubo/ -->
 
 List the available versions of kubo (go-ipfs) implementation:
 
 ```
-$ ipfs cat /ipns/dist.ipfs.io/go-ipfs/versions
+$ ipfs cat /ipns/dist.ipfs.tech/go-ipfs/versions
 ```
 
 Then, to view available builds for a version from the previous command ($VERSION):
 
 ```
-$ ipfs ls /ipns/dist.ipfs.io/go-ipfs/$VERSION
+$ ipfs ls /ipns/dist.ipfs.tech/go-ipfs/$VERSION
 ```
 
 To download a given build of a version:
 
 ```
-$ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_darwin-386.tar.gz # darwin 32-bit build
-$ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_darwin-amd64.tar.gz # darwin 64-bit build
-$ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_freebsd-amd64.tar.gz # freebsd 64-bit build
-$ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_linux-386.tar.gz # linux 32-bit build
-$ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_linux-amd64.tar.gz # linux 64-bit build
-$ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_linux-arm.tar.gz # linux arm build
-$ ipfs get /ipns/dist.ipfs.io/go-ipfs/$VERSION/go-ipfs_$VERSION_windows-amd64.zip # windows 64-bit build
+$ ipfs get /ipns/dist.ipfs.tech/go-ipfs/$VERSION/go-ipfs_$VERSION_darwin-386.tar.gz # darwin 32-bit build
+$ ipfs get /ipns/dist.ipfs.tech/go-ipfs/$VERSION/go-ipfs_$VERSION_darwin-amd64.tar.gz # darwin 64-bit build
+$ ipfs get /ipns/dist.ipfs.tech/go-ipfs/$VERSION/go-ipfs_$VERSION_freebsd-amd64.tar.gz # freebsd 64-bit build
+$ ipfs get /ipns/dist.ipfs.tech/go-ipfs/$VERSION/go-ipfs_$VERSION_linux-386.tar.gz # linux 32-bit build
+$ ipfs get /ipns/dist.ipfs.tech/go-ipfs/$VERSION/go-ipfs_$VERSION_linux-amd64.tar.gz # linux 64-bit build
+$ ipfs get /ipns/dist.ipfs.tech/go-ipfs/$VERSION/go-ipfs_$VERSION_linux-arm.tar.gz # linux arm build
+$ ipfs get /ipns/dist.ipfs.tech/go-ipfs/$VERSION/go-ipfs_$VERSION_windows-amd64.zip # windows 64-bit build
 ```
 
 ## Getting Started
@@ -385,7 +385,7 @@ Basic proof of 'ipfs working' locally:
 
 If you have previously installed IPFS before and you are running into problems getting a newer version to work, try deleting (or backing up somewhere else) your IPFS config directory (~/.ipfs by default) and rerunning `ipfs init`. This will reinitialize the config file to its defaults and clear out the local datastore of any bad entries.
 
-Please direct general questions and help requests to our [forum](https://discuss.ipfs.io) or our IRC channel (freenode #ipfs).
+Please direct general questions and help requests to our [forums](https://discuss.ipfs.tech).
 
 If you believe you've found a bug, check the [issues list](https://github.com/ipfs/kubo/issues) and, if you don't see your problem there, either come talk to us on [Matrix chat](https://docs.ipfs.tech/community/chat/), or file an issue of your own!
 

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -292,7 +292,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 		if !domigrate {
 			fmt.Println("Not running migrations of fs-repo now.")
-			fmt.Println("Please get fs-repo-migrations from https://dist.ipfs.io")
+			fmt.Println("Please get fs-repo-migrations from https://dist.ipfs.tech")
 			return fmt.Errorf("fs-repo requires migration")
 		}
 

--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -324,7 +324,7 @@ func isKnownHostname(hostname string, knownGateways gatewayHosts) (gw *config.Ga
 func knownSubdomainDetails(hostname string, knownGateways gatewayHosts) (gw *config.GatewaySpec, gwHostname, ns, rootID string, ok bool) {
 	labels := strings.Split(hostname, ".")
 	// Look for FQDN of a known gateway hostname.
-	// Example: given "dist.ipfs.io.ipns.dweb.link":
+	// Example: given "dist.ipfs.tech.ipns.dweb.link":
 	// 1. Lookup "link" TLD in knownGateways: negative
 	// 2. Lookup "dweb.link" in knownGateways: positive
 	//

--- a/core/corehttp/hostname_test.go
+++ b/core/corehttp/hostname_test.go
@@ -261,7 +261,7 @@ func TestKnownSubdomainDetails(t *testing.T) {
 		// dnslink in subdomain
 		{"en.wikipedia-on-ipfs.org.ipns.localhost:8080", gwLocalhost, "localhost:8080", "ipns", "en.wikipedia-on-ipfs.org", true},
 		{"en.wikipedia-on-ipfs.org.ipns.localhost", gwLocalhost, "localhost", "ipns", "en.wikipedia-on-ipfs.org", true},
-		{"dist.ipfs.io.ipns.localhost:8080", gwLocalhost, "localhost:8080", "ipns", "dist.ipfs.io", true},
+		{"dist.ipfs.tech.ipns.localhost:8080", gwLocalhost, "localhost:8080", "ipns", "dist.ipfs.tech", true},
 		{"en.wikipedia-on-ipfs.org.ipns.dweb.link", gwDweb, "dweb.link", "ipns", "en.wikipedia-on-ipfs.org", true},
 		// edge case check: public gateway under long TLD (see: https://publicsuffix.org)
 		{"foo.dweb.ipfs.pvt.k12.ma.us", nil, "", "", "", false},

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -139,7 +139,7 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 	if cfg.Swarm.EnableRelayHop {
 		logger.Fatal("The `Swarm.EnableRelayHop` config field was removed.\n" +
 			"Use `Swarm.RelayService` to configure the circuit v2 relay.\n" +
-			"If you want to continue running a circuit v1 relay, please use the standalone relay daemon: https://dist.ipfs.io/#libp2p-relay-daemon (with RelayV1.Enabled: true)")
+			"If you want to continue running a circuit v1 relay, please use the standalone relay daemon: https://dist.ipfs.tech/#libp2p-relay-daemon (with RelayV1.Enabled: true)")
 	}
 
 	peerChan := make(libp2p.AddrInfoChan)

--- a/docs/PATCH_RELEASE_TEMPLATE.md
+++ b/docs/PATCH_RELEASE_TEMPLATE.md
@@ -10,17 +10,17 @@ This process handles patch releases from version `vX.Y.Z` to `vX.Y.Z+1` assuming
 - [ ] Make a PR merging `release-vX.Y.Z+1` into the release branch
   - This may be unnecessary, e.g. for backports
 - [ ] Tag the merge commit in the `release` branch with `vX.Y.Z+1` (ensure the tag is signed)
-- [ ] Upload to dist.ipfs.io
+- [ ] Upload to dist.ipfs.tech
   1. Build: https://github.com/ipfs/distributions#usage.
   2. Pin the resulting release.
   3. Make a PR against ipfs/distributions with the updated versions, including the new hash in the PR comment.
-  4. Ask the infra team to update the DNSLink record for dist.ipfs.io to point to the new distribution.
+  4. Ask the infra team to update the DNSLink record for dist.ipfs.tech to point to the new distribution.
 - [ ] cut a release on [github](https://github.com/ipfs/kubo/releases) and upload the result of the ipfs/distributions build in the previous step.
 - Announce the Release:
   - [ ] On IRC/Matrix (both #ipfs and #ipfs-dev)
   - [ ] On discuss.ipfs.io
 - [ ] Release published
-  - [ ] to [dist.ipfs.io](https://dist.ipfs.io)
+  - [ ] to [dist.ipfs.tech](https://dist.ipfs.tech)
   - [ ] to [npm-go-ipfs](https://github.com/ipfs/npm-go-ipfs)
   - [ ] to [chocolatey](https://chocolatey.org/packages/ipfs)
   - [ ] to [snap](https://snapcraft.io/ipfs)

--- a/docs/RELEASE_ISSUE_TEMPLATE.md
+++ b/docs/RELEASE_ISSUE_TEMPLATE.md
@@ -24,11 +24,11 @@ For each RC published in each stage:
 
 - version string in `version.go` has been updated (in the `release-vX.Y.Z` branch).
 - tag commit with `vX.Y.Z-rcN`
-- upload to dist.ipfs.io
+- upload to dist.ipfs.tech
   1. Build: https://github.com/ipfs/distributions#usage.
   2. Pin the resulting release.
   3. Make a PR against ipfs/distributions with the updated versions, including the new hash in the PR comment.
-  4. Ask the infra team to update the DNSLink record for dist.ipfs.io to point to the new distribution.
+  4. Ask the infra team to update the DNSLink record for dist.ipfs.tech to point to the new distribution.
 - cut a pre-release on [github](https://github.com/ipfs/kubo/releases) and upload the result of the ipfs/distributions build in the previous step.
 - Announce the RC:
   - [ ] On Matrix (both #ipfs and #ipfs-dev)
@@ -79,13 +79,13 @@ Checklist:
     - [ ] Merge `release-vX.Y.Z` into the `release` branch.
     - [ ] Tag this merge commit (on the `release` branch) with `vX.Y.Z`.
     - [ ] Release published
-      - [ ] to [dist.ipfs.io](https://dist.ipfs.io)
+      - [ ] to [dist.ipfs.tech](https://dist.ipfs.tech)
       - [ ] to [npm-go-ipfs](https://github.com/ipfs/npm-go-ipfs)
       - [ ] to [chocolatey](https://chocolatey.org/packages/go-ipfs)
          - [ ] Manually run [the release workflow](https://github.com/ipfs/choco-go-ipfs/actions/workflows/main.yml)
       - [ ] to [snap](https://snapcraft.io/ipfs)
       - [ ] to [github](https://github.com/ipfs/go-ipfs/releases)
-        - [ ] use the artifacts built in CI for dist.ipfs.io: `wget "https://ipfs.io/api/v0/get?arg=/ipns/dist.ipfs.io/kubo/$(curl -s https://dist.ipfs.io/kubo/versions | tail -n 1)"`
+        - [ ] reuse signed artifacts from https://dist.ipfs.tech/kubo (run [sync-release-assets.yml workflow](https://github.com/ipfs/kubo/actions/workflows/sync-release-assets.yml))
       - [ ] to [arch](https://www.archlinux.org/packages/community/x86_64/go-ipfs/) (flag it out of date)
     - [ ] Cut a new ipfs-desktop release
   - [ ] Submit [this form](https://airtable.com/shrNH8YWole1xc70I) to publish a blog post, linking to the GitHub release notes

--- a/docs/changelogs/v0.11.md
+++ b/docs/changelogs/v0.11.md
@@ -73,7 +73,7 @@ Switching to v2 of the relay spec means removal or deprecation of configuration 
   - `Swarm.DisableRelay` is deprecated, relay transport can be now disabled globally (both client and service) by setting `Swarm.Transports.Network.Relay` to `false`
 - Relay v1 service provider was replaced by v2:
   - `Swarm.EnableRelayHop` no longer starts an unlimited v1 relay. If you have it set to `true` the node will refuse to start and display an error message.
-  - Existing users who choose to continue running a v1 relay should migrate their setups to relay v1 based on js-ipfs running in node, or the standalone [libp2p-relay-daemon](https://dist.ipfs.io/#libp2p-relay-daemon) [configured](https://github.com/libp2p/go-libp2p-relay-daemon/#configuration) with `RelayV1.Enabled` set to `true`. Be mindful that v1 relays are unlimited, and one may want to set up some ACL based either on PeerIDs or Subnets.
+  - Existing users who choose to continue running a v1 relay should migrate their setups to relay v1 based on js-ipfs running in node, or the standalone [libp2p-relay-daemon](https://dist.ipfs.tech/#libp2p-relay-daemon) [configured](https://github.com/libp2p/go-libp2p-relay-daemon/#configuration) with `RelayV1.Enabled` set to `true`. Be mindful that v1 relays are unlimited, and one may want to set up some ACL based either on PeerIDs or Subnets.
 
 #### 🕳 Decentralized Hole Punching (DCUtR protocol client)
 

--- a/docs/changelogs/v0.12.md
+++ b/docs/changelogs/v0.12.md
@@ -58,7 +58,7 @@ As usual, this release includes important fixes, some of which may be critical f
 
 - `ipfs refs local` will now list all blocks as if they were [raw]() CIDv1 instead of with whatever CID version and IPLD codecs they were stored with. All other functionality should remain the same.
 
-Note: This change also effects [ipfs-update](https://github.com/ipfs/ipfs-update) so if you use that tool to mange your go-ipfs installation then grab ipfs-update v1.8.0 from [dist](https://dist.ipfs.io/#ipfs-update).
+Note: This change also effects [ipfs-update](https://github.com/ipfs/ipfs-update) so if you use that tool to mange your go-ipfs installation then grab ipfs-update v1.8.0 from [dist](https://dist.ipfs.tech/#ipfs-update).
 
 Keep reading to learn more details.
 
@@ -127,7 +127,7 @@ It is also possible to revert the migration after it has succeeded, for example 
 
 The revert process does not delete any blocks--it only makes sure that blocks that were accessible with CIDv1s before the migration are again keyed with CIDv1s. This may result in a datastore becoming twice as large (i.e. if all the blocks were CIDv1-addressed before the migration). This is however done this way to cover corner cases: user can add CIDv1s after migration, which may reference blocks that existed as CIDv0 before migration. The revert aims to ensure that no data becomes unavailable on downgrade.
 
-While go-ipfs will auto-run the migration for you, it will not run the reversion. To do so you can download the [latest migration binary](https://dist.ipfs.io/fs-repo-11-to-12) or use [ipfs-update](https://dist.ipfs.io/#ipfs-update).
+While go-ipfs will auto-run the migration for you, it will not run the reversion. To do so you can download the [latest migration binary](https://dist.ipfs.tech/fs-repo-11-to-12) or use [ipfs-update](https://dist.ipfs.tech/#ipfs-update).
 
 ###### Custom datastores
 
@@ -140,7 +140,7 @@ For this migration, if your datastore has fast renames you may want to consider 
 - github.com/ipfs/go-ipfs:
   - Release v0.12.0
   - docs: v0.12.0 release notes
-  - chore: bump migrations dist.ipfs.io CID to contain fs-repo-11-to-12 v1.0.2
+  - chore: bump migrations dist.ipfs.tech CID to contain fs-repo-11-to-12 v1.0.2
   - feat: refactor Fetcher interface used for downloading migrations (#8728) ([ipfs/go-ipfs#8728](https://github.com/ipfs/go-ipfs/pull/8728))
   - feat: log multifetcher errors
   - Release v0.12.0-rc1

--- a/docs/changelogs/v0.14.md
+++ b/docs/changelogs/v0.14.md
@@ -51,13 +51,13 @@ We've renamed Go-IPFS to Kubo ([details](https://github.com/ipfs/go-ipfs/issues/
 
 Published artifacts use `kubo` now, and are available at:
 
-- https://dist.ipfs.io/kubo/
+- https://dist.ipfs.tech/kubo/
 - https://hub.docker.com/r/ipfs/kubo/
 
 To minimize the impact on infrastructure that autoupdates on a new release,
 the same binaries are still published under the old name at:
 
-- https://dist.ipfs.io/go-ipfs/
+- https://dist.ipfs.tech/go-ipfs/
 - https://hub.docker.com/r/ipfs/go-ipfs/
 
 The libp2p identify useragent of Kubo has also been changed from `go-ipfs` to `kubo`.

--- a/docs/changelogs/v0.4.md
+++ b/docs/changelogs/v0.4.md
@@ -1237,7 +1237,7 @@ To initialize a go-ipfs instance with a randomly chosen port, run:
 #### 👂 Gateway Directory Listing
 
 IPNS (and/or DNSLink) directory listings on the gateway, e.g.
-https://ipfs.io/ipns/dist.ipfs.io/go-ipfs/, will now display the _ipfs_ hash of
+https://ipfs.io/ipns/dist.ipfs.tech/go-ipfs/, will now display the _ipfs_ hash of
 the current directory. This way users can more easily create permanent links to
 otherwise mutable data.
 
@@ -3705,7 +3705,7 @@ This is the first Release Candidate. Unless there are vulnerabilities or regress
 - Security Vulnerability
 
   - The `master` branch if go-ipfs suffered from a vulnerability for about 3 weeks. It allowed an attacker to use an iframe to request malicious HTML and JS from the API of a local go-ipfs node. The attacker could then gain unrestricted access to the node's API, and e.g. extract the private key. We fixed this issue by reintroducing restrictions on which particular objects can be loaded through the API (@lgierth, [ipfs/go-ipfs#2949](https://github.com/ipfs/go-ipfs/pull/2949)), and by completely excluding the private key from the API (@Kubuxu, [ipfs/go-ipfs#2957](https://github.com/ipfs/go-ipfs/pull/2957)). We will also work on more hardening of the API in the next release.
-  - **The previous release 0.4.2 is not vulnerable. That means if you're using official binaries from [dist.ipfs.io](https://dist.ipfs.io) you're not affected.** If you're running go-ipfs built from the `master` branch between June 17th ([ipfs/go-ipfs@1afebc21](https://github.com/ipfs/go-ipfs/commit/1afebc21f324982141ca8a29710da0d6f83ca804)) and July 7th ([ipfs/go-ipfs@39bef0d5](https://github.com/ipfs/go-ipfs/commit/39bef0d5b01f70abf679fca2c4d078a2d55620e2)), please update to v0.4.3-rc1 immediately.
+  - **The previous release 0.4.2 is not vulnerable. That means if you're using official binaries from [dist.ipfs.tech](https://dist.ipfs.tech) you're not affected.** If you're running go-ipfs built from the `master` branch between June 17th ([ipfs/go-ipfs@1afebc21](https://github.com/ipfs/go-ipfs/commit/1afebc21f324982141ca8a29710da0d6f83ca804)) and July 7th ([ipfs/go-ipfs@39bef0d5](https://github.com/ipfs/go-ipfs/commit/39bef0d5b01f70abf679fca2c4d078a2d55620e2)), please update to v0.4.3-rc1 immediately.
   - We are grateful to the group of independent researchers who made us aware of this vulnerability. We wanna use this opportunity to reiterate that we're very happy about any additional review of pull requests and releases. You can contact us any time at security@ipfs.io (GPG [4B9665FB 92636D17 7C7A86D3 50AAE8A9 59B13AF3](https://pgp.mit.edu/pks/lookup?op=get&search=0x50AAE8A959B13AF3)).
 
 - Notable changes
@@ -3860,12 +3860,12 @@ There are also a few other nice improvements.
   * Update gx and gx-go. (@chriscool)
   * Make blocks.Block an interface. (@kevina)
   * Silence check for Docker existance. (@chriscool)
-  * Add dist_get script for fetching tools from dist.ipfs.io. (@whyrusleeping)
+  * Add dist_get script for fetching tools from dist.ipfs.tech. (@whyrusleeping)
   * Add proper defaults to all `ipfs` commands. (@richardlitt)
   * Remove dead `count` option from `ipfs pin ls`. (@richardlitt)
   * Initialize pin mode strings only once. (@chriscool)
   * Add changelog for v0.4.2. (@lgierth)
-  * Specify a dist.ipfs.io hash for tool downloads instead of trusting DNS. (@lgierth)
+  * Specify a dist.ipfs.tech hash for tool downloads instead of trusting DNS. (@lgierth)
 
 * CI
   * Fix t0170-dht sharness test. (@chriscool)

--- a/docs/changelogs/v0.5.md
+++ b/docs/changelogs/v0.5.md
@@ -514,7 +514,7 @@ In general, migrations should not require significant manual intervention. Howev
 * If you update go-ipfs with `ipfs update`, `ipfs update` will run the migration for you. Note: `ipfs update` will refuse to run the migrations while ipfs itself is running.
 * If you start the ipfs daemon with `ipfs daemon --migrate`, ipfs will migrate your repo for you on start.
 
-Otherwise, if you want more control over the repo migration process, you can manually install and run the [repo migration tool](http://dist.ipfs.io/#fs-repo-migrations).
+Otherwise, if you want more control over the repo migration process, you can manually install and run the [repo migration tool](http://dist.ipfs.tech/#fs-repo-migrations).
 
 ##### Bootstrap Peer Changes
 

--- a/docs/changelogs/v0.7.md
+++ b/docs/changelogs/v0.7.md
@@ -51,9 +51,9 @@ Size: 30362191, NumBlocks: 346
 
 #### Plugin build changes
 
-We have changed the build flags used by the official binary distributions on dist.ipfs.io (or `/ipns/dist.ipfs.io`) to use the simpler and more reliable `-trimpath` flag instead of the more complicated and brittle `-asmflags=all=-trimpath="$(GOPATH)" -gcflags=all=-trimpath="$(GOPATH)"` flags, however the build flags used by default in go-ipfs remain the same.
+We have changed the build flags used by the official binary distributions on dist.ipfs.tech (or `/ipns/dist.ipfs.tech`) to use the simpler and more reliable `-trimpath` flag instead of the more complicated and brittle `-asmflags=all=-trimpath="$(GOPATH)" -gcflags=all=-trimpath="$(GOPATH)"` flags, however the build flags used by default in go-ipfs remain the same.
 
-The scripts in https://github.com/ipfs/go-ipfs-example-plugin have been updated to reflect this change. This is a breaking change to how people have been building plugins against the dist.ipfs.io binary of go-ipfs and plugins should update their build processes accordingly see https://github.com/ipfs/go-ipfs-example-plugin/pull/9 for details.
+The scripts in https://github.com/ipfs/go-ipfs-example-plugin have been updated to reflect this change. This is a breaking change to how people have been building plugins against the dist.ipfs.tech binary of go-ipfs and plugins should update their build processes accordingly see https://github.com/ipfs/go-ipfs-example-plugin/pull/9 for details.
 
 ### Changelog
 

--- a/docs/changelogs/v0.9.md
+++ b/docs/changelogs/v0.9.md
@@ -136,7 +136,7 @@ This means faster download times for upgrades, a much easier time building migra
 
 ##### Configurable migration downloads enable downloading over IPFS
 
-Previously the migration downloader built into go-ipfs downloaded the migrations from [dist.ipfs.io](https://dist.ipfs.io). While users could use tools like [ipfs-update](https://github.com/ipfs/ipfs-update) to download the migrations over IPFS or manually download the migrations (over IPFS or otherwise) themselves, this is now automated and configurable. Users can choose to download the migrations over IPFS or from any specified IPFS Gateway.
+Previously the migration downloader built into go-ipfs downloaded the migrations from [dist.ipfs.tech](https://dist.ipfs.tech). While users could use tools like [ipfs-update](https://github.com/ipfs/ipfs-update) to download the migrations over IPFS or manually download the migrations (over IPFS or otherwise) themselves, this is now automated and configurable. Users can choose to download the migrations over IPFS or from any specified IPFS Gateway.
 
 The configurable migration options are described in the config file [documentation](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#migration), although most users should not need to change the default settings.
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,7 +1,7 @@
 # Building on Windows
 ![](https://ipfs.io/ipfs/QmccXW7JSZMVXidSc7tHsU6aktuaiV923q4yBGHUsdymYo/build.gif)
 
-If you just want to install kubo, please download it from https://dist.ipfs.io/#kubo. This document explains how to build it from source.
+If you just want to install kubo, please download it from https://dist.ipfs.tech/#kubo. This document explains how to build it from source.
 
 ## Install Go
 `kubo` is built on Golang and thus depends on it for all building methods.  

--- a/repo/fsrepo/migrations/fetch.go
+++ b/repo/fsrepo/migrations/fetch.go
@@ -173,7 +173,7 @@ func osWithVariant() (string, error) {
 
 // makeArchivePath composes the path, relative to the distribution site, from which to
 // download a binary.  The path returned does not contain the distribution site path,
-// e.g. "/ipns/dist.ipfs.io/", since that is know to the fetcher.
+// e.g. "/ipns/dist.ipfs.tech/", since that is know to the fetcher.
 //
 // Returns the archive path and the base name.
 //

--- a/repo/fsrepo/migrations/fetcher.go
+++ b/repo/fsrepo/migrations/fetcher.go
@@ -13,7 +13,7 @@ const (
 	// Current distribution to fetch migrations from
 	CurrentIpfsDist = "/ipfs/QmdaCHYBDHEhXCMoynH5UcohEay6m1XayZCcxWZzKAHNVN" // fs-repo-11-to-12 v1.0.2
 	// Latest distribution path.  Default for fetchers.
-	LatestIpfsDist = "/ipns/dist.ipfs.io"
+	LatestIpfsDist = "/ipns/dist.ipfs.tech"
 
 	// Distribution environ variable
 	envIpfsDistPath = "IPFS_DIST_PATH"

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -58,7 +58,7 @@ test_expect_success "ipfs daemon --migrate=false fails" '
 '
 
 test_expect_success "output looks good" '
-  grep "Please get fs-repo-migrations from https://dist.ipfs.io" false_out
+  grep "Please get fs-repo-migrations from https://dist.ipfs.tech" false_out
 '
 
 # The migrations will succeed, but the daemon will still exit with 1 because
@@ -81,7 +81,7 @@ test_expect_success "'ipfs daemon' prompts to auto migrate" '
 test_expect_success "output looks good" '
   grep "Found outdated fs-repo" daemon_out > /dev/null &&
   grep "Run migrations now?" daemon_out > /dev/null &&
-  grep "Please get fs-repo-migrations from https://dist.ipfs.io" daemon_out > /dev/null
+  grep "Please get fs-repo-migrations from https://dist.ipfs.tech" daemon_out > /dev/null
 '
 
 test_expect_success "ipfs repo migrate succeed" '


### PR DESCRIPTION
> Part of https://github.com/protocol/bifrost-infra/issues/2018

This PR replaces all mentions of `dist.ipfs.io` with `dist.ipfs.tech`

![HAhaa](https://user-images.githubusercontent.com/157609/184446957-574d5fd6-68a8-4abd-8557-d2dc39338180.png)


