### PR TITLE
correct data type for Reprovider.Interval

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1281,7 +1281,7 @@ not being able to discover that you have the objects that you have. If you want
 to have this disabled and keep the network aware of what you have, you must
 manually announce your content periodically.
 
-Type: `string` (value which gets parsed into time.Duration) 
+Type: `duration`
 
 ### `Reprovider.Strategy`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1281,7 +1281,7 @@ not being able to discover that you have the objects that you have. If you want
 to have this disabled and keep the network aware of what you have, you must
 manually announce your content periodically.
 
-Type: `array[peering]`
+Type: `string` (value which gets parsed into time.Duration) 
 
 ### `Reprovider.Strategy`
 


### PR DESCRIPTION
`config.md` states that `Reprovider.Interval` is of type `array[peering]`, however is used as a string which is parsed into a `time.Duration` type. 
This PR corrects documentation so the Reprovider.Interval type is listed as a `string` in `config.md`.

Signed-off-by: Oleg Silkin <16809287+osilkin98@users.noreply.github.com>