### PR TITLE
Update `ipfs daemon --help` text for DHTClient

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -150,7 +150,7 @@ running the daemon as:
 
 Or you can set routing to dhtclient in the config:
 
-ipfs config Routing.Type dhtclient
+  ipfs config Routing.Type dhtclient
 
 DEPRECATION NOTICE
 

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -142,14 +142,15 @@ environment variable:
 
 Routing
 
-IPFS by default will use a DHT for content routing. There is a highly
-experimental alternative that operates the DHT in a 'client only' mode that
-can be enabled by running the daemon as:
+IPFS by default will use a DHT for content routing. There is an alternative
+that operates the DHT in a 'client only' mode which can be enabled by
+running the daemon as:
 
   ipfs daemon --routing=dhtclient
 
-This will later be transitioned into a config option once it gets out of the
-'experimental' stage.
+Or you can set routing to dhtclient in the config:
+
+ipfs config Routing.Type dhtclient
 
 DEPRECATION NOTICE
 


### PR DESCRIPTION
This rewords the help description for DHTClient so it isn't described as experimental, and it has the relevant `ipfs config` command which was previously marked as not existing.