### PR TITLE
feat: check for context err on listing handler

### DIFF
--- a/core/corehttp/gateway_handler_unixfs_dir.go
+++ b/core/corehttp/gateway_handler_unixfs_dir.go
@@ -117,6 +117,11 @@ func (i *gatewayHandler) serveDirectory(ctx context.Context, w http.ResponseWrit
 	dirListing := make([]directoryItem, 0, len(results))
 
 	for link := range results {
+		if ctx.Err() != nil {
+			internalWebError(w, ctx.Err())
+			return
+		}
+
 		if link.Err != nil {
 			internalWebError(w, err)
 			return


### PR DESCRIPTION
Closes #9066.