### PR TITLE
feat: download migrations using car files

### DIFF
--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/ipfs/go-unixfsnode v1.4.0 // indirect
 	github.com/ipfs/go-verifcid v0.0.2 // indirect
 	github.com/ipld/edelweiss v0.1.4 // indirect
+	github.com/ipld/go-car/v2 v2.4.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.4.1 // indirect
 	github.com/ipld/go-ipld-prime v0.17.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
@@ -211,6 +212,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	go4.org v0.0.0-20200411211856-f5505b9728dd // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220630215102-69896b714898 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -671,6 +671,7 @@ github.com/ipld/go-ipld-prime v0.14.1/go.mod h1:QcE4Y9n/ZZr8Ijg5bGPT0GqYWgZ1704n
 github.com/ipld/go-ipld-prime v0.16.0/go.mod h1:axSCuOCBPqrH+gvXr2w9uAOulJqBPhHPT2PjoiiU1qA=
 github.com/ipld/go-ipld-prime v0.17.0 h1:+U2peiA3aQsE7mrXjD2nYZaZrCcakoz2Wge8K42Ld8g=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
+github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73 h1:TsyATB2ZRRQGTwafJdgEUQkmjOExRV0DNokcihZxbnQ=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=

--- a/repo/fsrepo/migrations/httpfetcher.go
+++ b/repo/fsrepo/migrations/httpfetcher.go
@@ -134,14 +134,14 @@ func carStreamToFileBytes(ctx context.Context, r io.Reader) ([]byte, error) {
 	for {
 		block, err := car.Next()
 		if err != nil && err != io.EOF {
-			return nil, err
+			return nil, fmt.Errorf("error reading block from car: %s", err)
 		} else if block == nil {
 			break
 		}
 
 		err = bs.Put(ctx, block)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error putting block in blockstore: %s", err)
 		}
 	}
 
@@ -152,13 +152,13 @@ func carStreamToFileBytes(ctx context.Context, r io.Reader) ([]byte, error) {
 	// Get node from DAG service with the file.
 	node, err := ds.Get(ctx, car.Roots[0])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting cid from dag service: %s", err)
 	}
 
 	// Make UnixFS file out of the node.
 	uf, err := unixfile.NewUnixfsFile(ctx, ds, node)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error building unixfs file: %s", err)
 	}
 
 	// Check if it's a file and return.


### PR DESCRIPTION
Close #8851.

This is an initial draft on replacing the migrations logic to use CAR files instead of retrieving the file directly from the gateway.

cc @lidel 