### PR TITLE
fix: use the "state" directory in systemd unit files

### DIFF
--- a/misc/systemd/ipfs-hardened.service
+++ b/misc/systemd/ipfs-hardened.service
@@ -69,7 +69,7 @@ Type=notify
 User=ipfs
 Group=ipfs
 StateDirectory=ipfs
-Environment=IPFS_PATH="${HOME}"
+Environment=IPFS_PATH="%S"
 ExecStart=/usr/bin/ipfs daemon --init --migrate
 Restart=on-failure
 KillSignal=SIGINT

--- a/misc/systemd/ipfs.service
+++ b/misc/systemd/ipfs.service
@@ -40,7 +40,7 @@ Type=notify
 User=ipfs
 Group=ipfs
 StateDirectory=ipfs
-Environment=IPFS_PATH="${HOME}"
+Environment=IPFS_PATH="%S"
 ExecStart=/usr/bin/ipfs daemon --init --migrate
 Restart=on-failure
 KillSignal=SIGINT


### PR DESCRIPTION
As pointed out by @MrCowKing in, "${HOME}" isn't expanded. We use the state directory as that's guaranteed to exist (and, in the default configuration, will match the "HOME" directory of the ipfs user).

See: https://github.com/ipfs/kubo/commit/b47ecd0cba85905f18b85de9dd771008adf60fd0#commitcomment-83565661