### PR TITLE
docs: fix broken ENS DoH example

### DIFF
--- a/config/dns.go
+++ b/config/dns.go
@@ -9,7 +9,7 @@ type DNS struct {
 	// https://en.wikipedia.org/wiki/DNS_over_HTTPS
 	//
 	// Example:
-	// - Custom resolver for ENS:          `eth.` → `https://eth.link/dns-query`
+	// - Custom resolver for ENS:          `eth.` → `https://dns.eth.limo/dns-query`
 	// - Override the default OS resolver: `.`    → `https://doh.applied-privacy.net/query`
 	Resolvers map[string]string
 	// MaxCacheTTL is the maximum duration DNS entries are valid in the cache.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1947,6 +1947,15 @@ Be mindful that:
     "crypto.": "https://resolver.cloudflare-eth.com/dns-query"
   }
   ```
+
+  Optionally, [eth.limo](https://eth.limo) can be used as an alternative to Cloudflare for `eth.` resolution:
+
+  ```json
+  {
+    "eth.": "https://dns.eth.limo/dns-query"
+  }
+  ```
+
   To get all the benefits of a decentralized naming system we strongly suggest setting DoH endpoint to an empty string and running own decentralized resolver as catch-all one on localhost.
 
 Default: `{}`

--- a/docs/config.md
+++ b/docs/config.md
@@ -1928,7 +1928,7 @@ Example:
 {
   "DNS": {
     "Resolvers": {
-      "eth.": "https://eth.link/dns-query",
+      "eth.": "https://dns.eth.limo/dns-query",
       "crypto.": "https://resolver.unstoppable.io/dns-query",
       "libre.": "https://ns1.iriseden.fr/dns-query",
       ".": "https://cloudflare-dns.com/dns-query"
@@ -1947,15 +1947,6 @@ Be mindful that:
     "crypto.": "https://resolver.cloudflare-eth.com/dns-query"
   }
   ```
-
-  Optionally, [eth.limo](https://eth.limo) can be used as an alternative to Cloudflare for `eth.` resolution:
-
-  ```json
-  {
-    "eth.": "https://dns.eth.limo/dns-query"
-  }
-  ```
-
   To get all the benefits of a decentralized naming system we strongly suggest setting DoH endpoint to an empty string and running own decentralized resolver as catch-all one on localhost.
 
 Default: `{}`


### PR DESCRIPTION
This PR adds documentation for using [eth.limo](https://eth.limo) as an alternative DoH resolver for `eth.` domains.