### PR TITLE
Fix: `swarm stats all` command

### DIFF
--- a/core/node/libp2p/rcmgr_logging.go
+++ b/core/node/libp2p/rcmgr_logging.go
@@ -32,6 +32,7 @@ type loggingScope struct {
 }
 
 var _ network.ResourceManager = (*loggingResourceManager)(nil)
+var _ rcmgr.ResourceManagerState = (*loggingResourceManager)(nil)
 
 func (n *loggingResourceManager) start(ctx context.Context) {
 	logInterval := n.logInterval
@@ -101,6 +102,40 @@ func (n *loggingResourceManager) OpenStream(p peer.ID, dir network.Direction) (n
 }
 func (n *loggingResourceManager) Close() error {
 	return n.delegate.Close()
+}
+
+func (n *loggingResourceManager) ListServices() []string {
+	rapi, ok := n.delegate.(rcmgr.ResourceManagerState)
+	if !ok {
+		return nil
+	}
+
+	return rapi.ListServices()
+}
+func (n *loggingResourceManager) ListProtocols() []protocol.ID {
+	rapi, ok := n.delegate.(rcmgr.ResourceManagerState)
+	if !ok {
+		return nil
+	}
+
+	return rapi.ListProtocols()
+}
+func (n *loggingResourceManager) ListPeers() []peer.ID {
+	rapi, ok := n.delegate.(rcmgr.ResourceManagerState)
+	if !ok {
+		return nil
+	}
+
+	return rapi.ListPeers()
+}
+
+func (n *loggingResourceManager) Stat() rcmgr.ResourceManagerStat {
+	rapi, ok := n.delegate.(rcmgr.ResourceManagerState)
+	if !ok {
+		return rcmgr.ResourceManagerStat{}
+	}
+
+	return rapi.Stat()
 }
 
 func (s *loggingScope) ReserveMemory(size int, prio uint8) error {

--- a/test/sharness/t0139-swarm-rcmgr.sh
+++ b/test/sharness/t0139-swarm-rcmgr.sh
@@ -55,6 +55,10 @@ test_expect_success 'ResourceMgr enabled: swarm limit' '
   jq -e .StreamsOutbound < json
 '
 
+test_expect_success 'connected: swarm stats all working properly' '
+  test_expect_code 0 ipfs swarm stats all
+'
+
 # every scope has the same fields, so we only inspect System
 test_expect_success 'ResourceMgr enabled: swarm stats' '
   ipfs swarm stats all --enc=json | tee json &&


### PR DESCRIPTION
`swarm stats all` requires that the ResourceManager instance implements `rcmgr.ResourceManagerState`, and `loggingResourceManager` was not implementing it, so the command was failing.

Also added a sharness test to check that the command is executing correctly because `jq -e` doesn't return an error if the JSON is nil.

Closes #9284 

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>