### PR TITLE
add refs local alias repo ls

### DIFF
--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -227,6 +227,7 @@ func TestCommands(t *testing.T) {
 		"/repo/stat",
 		"/repo/verify",
 		"/repo/version",
+		"/repo/ls",
 		"/resolve",
 		"/shutdown",
 		"/stats",

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -43,6 +43,7 @@ var RepoCmd = &cmds.Command{
 		"version": repoVersionCmd,
 		"verify":  repoVerifyCmd,
 		"migrate": repoMigrateCmd,
+		"ls":      RefsLocalCmd,
 	},
 }
 


### PR DESCRIPTION
Added sub command "ls" under "repo" command and gave RefsLocalCmd. 

This helps to maintain both the commands for backward compatibility and easy modification which reflects in "repo ls".