### PR TITLE
feat: increase default republish interval

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -76,8 +76,8 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			APICommands: []string{},
 		},
 		Reprovider: Reprovider{
-			Interval: "22h",
-			Strategy: "all",
+			Interval: nil,
+			Strategy: nil,
 		},
 		Pinning: Pinning{
 			RemoteServices: map[string]RemotePinningService{},

--- a/config/init.go
+++ b/config/init.go
@@ -76,7 +76,7 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			APICommands: []string{},
 		},
 		Reprovider: Reprovider{
-			Interval: "12h",
+			Interval: "22h",
 			Strategy: "all",
 		},
 		Pinning: Pinning{

--- a/config/profile.go
+++ b/config/profile.go
@@ -176,7 +176,7 @@ fetching may be degraded.
 		Transform: func(c *Config) error {
 			c.Routing.Type = "dhtclient"
 			c.AutoNAT.ServiceMode = AutoNATServiceDisabled
-			c.Reprovider.Interval = "0"
+			c.Reprovider.Interval = NewOptionalDuration(0)
 
 			lowWater := int64(20)
 			highWater := int64(40)

--- a/config/reprovider.go
+++ b/config/reprovider.go
@@ -1,6 +1,6 @@
 package config
 
 type Reprovider struct {
-	Interval string // Time period to reprovide locally stored objects to the network
-	Strategy string // Which keys to announce
+	Interval *OptionalDuration `json:",omitempty"` // Time period to reprovide locally stored objects to the network
+	Strategy *OptionalString   `json:",omitempty"` // Which keys to announce
 }

--- a/config/types.go
+++ b/config/types.go
@@ -218,6 +218,11 @@ type OptionalDuration struct {
 	value *time.Duration
 }
 
+// NewOptionalDuration returns an OptionalDuration from a string
+func NewOptionalDuration(d time.Duration) *OptionalDuration {
+	return &OptionalDuration{value: &d}
+}
+
 func (d *OptionalDuration) UnmarshalJSON(input []byte) error {
 	switch string(input) {
 	case "null", "undefined", "\"null\"", "", "default", "\"\"", "\"default\"":

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -291,7 +291,12 @@ func Online(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 		fx.Provide(p2p.New),
 
 		LibP2P(bcfg, cfg),
-		OnlineProviders(cfg.Experimental.StrategicProviding, cfg.Experimental.AcceleratedDHTClient, cfg.Reprovider.Strategy, cfg.Reprovider.Interval),
+		OnlineProviders(
+			cfg.Experimental.StrategicProviding,
+			cfg.Experimental.AcceleratedDHTClient,
+			cfg.Reprovider.Strategy.WithDefault(DefaultReproviderStrategy),
+			cfg.Reprovider.Interval.WithDefault(DefaultReproviderInterval),
+		),
 	)
 }
 
@@ -304,7 +309,12 @@ func Offline(cfg *config.Config) fx.Option {
 		fx.Provide(libp2p.Routing),
 		fx.Provide(libp2p.ContentRouting),
 		fx.Provide(libp2p.OfflineRouting),
-		OfflineProviders(cfg.Experimental.StrategicProviding, cfg.Experimental.AcceleratedDHTClient, cfg.Reprovider.Strategy, cfg.Reprovider.Interval),
+		OfflineProviders(
+			cfg.Experimental.StrategicProviding,
+			cfg.Experimental.AcceleratedDHTClient,
+			cfg.Reprovider.Strategy.WithDefault(DefaultReproviderStrategy),
+			cfg.Reprovider.Interval.WithDefault(DefaultReproviderInterval),
+		),
 	)
 }
 

--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -18,7 +18,8 @@ import (
 	irouting "github.com/ipfs/kubo/routing"
 )
 
-const kReprovideFrequency = time.Hour * 12
+const DefaultReproviderInterval = time.Hour * 22 // https://github.com/ipfs/kubo/pull/9326
+const DefaultReproviderStrategy = "all"
 
 // SIMPLE
 
@@ -61,20 +62,10 @@ func SimpleProviderSys(isOnline bool) interface{} {
 }
 
 // BatchedProviderSys creates new provider system
-func BatchedProviderSys(isOnline bool, reprovideInterval string) interface{} {
+func BatchedProviderSys(isOnline bool, reprovideInterval time.Duration) interface{} {
 	return func(lc fx.Lifecycle, cr irouting.ProvideManyRouter, q *q.Queue, keyProvider simple.KeyChanFunc, repo repo.Repo) (provider.System, error) {
-		reprovideIntervalDuration := kReprovideFrequency
-		if reprovideInterval != "" {
-			dur, err := time.ParseDuration(reprovideInterval)
-			if err != nil {
-				return nil, err
-			}
-
-			reprovideIntervalDuration = dur
-		}
-
 		sys, err := batched.New(cr, q,
-			batched.ReproviderInterval(reprovideIntervalDuration),
+			batched.ReproviderInterval(reprovideInterval),
 			batched.Datastore(repo.Datastore()),
 			batched.KeyProvider(keyProvider))
 		if err != nil {
@@ -100,7 +91,7 @@ func BatchedProviderSys(isOnline bool, reprovideInterval string) interface{} {
 // ONLINE/OFFLINE
 
 // OnlineProviders groups units managing provider routing records online
-func OnlineProviders(useStrategicProviding bool, useBatchedProviding bool, reprovideStrategy string, reprovideInterval string) fx.Option {
+func OnlineProviders(useStrategicProviding bool, useBatchedProviding bool, reprovideStrategy string, reprovideInterval time.Duration) fx.Option {
 	if useStrategicProviding {
 		return fx.Provide(provider.NewOfflineProvider)
 	}
@@ -113,7 +104,7 @@ func OnlineProviders(useStrategicProviding bool, useBatchedProviding bool, repro
 }
 
 // OfflineProviders groups units managing provider routing records offline
-func OfflineProviders(useStrategicProviding bool, useBatchedProviding bool, reprovideStrategy string, reprovideInterval string) fx.Option {
+func OfflineProviders(useStrategicProviding bool, useBatchedProviding bool, reprovideStrategy string, reprovideInterval time.Duration) fx.Option {
 	if useStrategicProviding {
 		return fx.Provide(provider.NewOfflineProvider)
 	}
@@ -126,17 +117,7 @@ func OfflineProviders(useStrategicProviding bool, useBatchedProviding bool, repr
 }
 
 // SimpleProviders creates the simple provider/reprovider dependencies
-func SimpleProviders(reprovideStrategy string, reprovideInterval string) fx.Option {
-	reproviderInterval := kReprovideFrequency
-	if reprovideInterval != "" {
-		dur, err := time.ParseDuration(reprovideInterval)
-		if err != nil {
-			return fx.Error(err)
-		}
-
-		reproviderInterval = dur
-	}
-
+func SimpleProviders(reprovideStrategy string, reproviderInterval time.Duration) fx.Option {
 	var keyProvider fx.Option
 	switch reprovideStrategy {
 	case "all":

--- a/docs/changelogs/v0.18.md
+++ b/docs/changelogs/v0.18.md
@@ -11,6 +11,7 @@ Below is an outline of all that is in this release, so you get a sense of all th
     - [Overview](#overview)
     - [🔦 Highlights](#-highlights)
       - [(DAG-)JSON and (DAG-)CBOR Response Formats on Gateways](#dag-json-and-dag-cbor-response-formats-on-gateways)
+      - [Increased `Reprovider.Interval`](#increased-reproviderinterval)
     - [Changelog](#changelog)
     - [Contributors](#contributors)
 
@@ -67,6 +68,16 @@ $ curl "http://127.0.0.1:8080/ipfs/$DIR_CID?format=dag-json" | jq
   ]
 }
 ```
+
+#### Increased `Reprovider.Interval`
+
+Default changed from 12h to 22h.
+We also stopped `ipfs init` from hardcoding the default value in user config, allowing Kubo to adjust implicit default in future releases.
+
+Rationale for increasing this can be found in [RFM 17: Provider Record Livenes Report](https://github.com/protocol/network-measurements/blob/master/results/rfm17-provider-record-liveness.md)
+and [kubo#9326](https://github.com/ipfs/kubo/pull/9326).
+
+Learn more: [`Reprovider` config](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#reprovider)
 
 ### Changelog
 


### PR DESCRIPTION
## Description
This PR aims to increase `kubo`'s default republish interval from `12h` to `22h` based on [RFM17](https://github.com/protocol/network-measurements/blob/master/results/rfm17-provider-record-liveness.md) as discussed in [libp2p/specs#451](https://github.com/libp2p/specs/pull/451#issue-1372605284).

## Motivation
The measurements from RFM17 were surprising and promising for the steady provider record's liveness gathered in the IPFS live network. Based on the average of 70% of online PR holders and 70% of PR holders being among the 20 closest peers for over +48 hours, we suggest increasing the republish interval for the CIDs and extending the expiration time to help reduce part of the overhead that providing large sets of CIDs implies.

**Why 22 hours?**
Since the current `expiration time` for the PR is set to `24h`, setting it to `22h` will give enough margin to providers to publish the PR again before they expire.

_Note: this PR will be twined with one at `go-libp2p-kad-dht` to extend the `expiration time`_


## Modifications
- Increase `Reprovider.Interval` from `12h` -> `22h`  