### PR TITLE
fix(gateway): handle streaming errors, IPIP 332

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -1124,6 +1124,6 @@ func abortConn(w http.ResponseWriter) {
 
 	err = conn.Close()
 	if err != nil {
-	  panic(http.ErrAbortHandler)
+		panic(http.ErrAbortHandler)
 	}
 }

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -1104,3 +1104,30 @@ func (i *gatewayHandler) setCommonHeaders(w http.ResponseWriter, r *http.Request
 
 	return nil
 }
+
+// closeConnWithError forcefully closes an HTTP/1.x connection, leading to a network
+// error on the user side. If it is not possible to forcefully close the connection,
+// we call webError which prints the error to the client, leading to a corrupt file.
+// This is a way of showing the client that there was an error while streaming the contents.
+// Currently, there are no great ways of telling the client that an error occurred while
+// streaming in HTTP.
+func closeConnWithError(w http.ResponseWriter, err error) {
+	// There are no good ways of showing an error during a stream. Therefore, we try
+	// to hijack the connection to forcefully close it, causing a network error.
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		// If we could not Hijack the connection, we write the original error. This will hopefully
+		// corrupt the generated TAR file, such that the client will receive an error unpacking.
+		webError(w, "could not build tar archive", err, http.StatusInternalServerError)
+		return
+	}
+
+	conn, _, hijackErr := hj.Hijack()
+	if hijackErr != nil {
+		// Deliberately pass the original tar error here instead of the hijacking error.
+		webError(w, "could not build tar archive", err, http.StatusInternalServerError)
+		return
+	}
+
+	conn.Close()
+}

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -1122,5 +1122,8 @@ func abortConn(w http.ResponseWriter) {
 		panic(http.ErrAbortHandler)
 	}
 
-	conn.Close()
+	err = conn.Close()
+	if err != nil {
+	  panic(http.ErrAbortHandler)
+	}
 }

--- a/core/corehttp/gateway_handler_block.go
+++ b/core/corehttp/gateway_handler_block.go
@@ -49,7 +49,8 @@ func (i *gatewayHandler) serveRawBlock(ctx context.Context, w http.ResponseWrite
 	_, dataSent, err := ServeContent(w, r, name, modtime, content)
 
 	if err != nil {
-		closeConnWithError(w, err)
+		abortConn(w)
+		return
 	}
 
 	if dataSent {

--- a/core/corehttp/gateway_handler_block.go
+++ b/core/corehttp/gateway_handler_block.go
@@ -46,7 +46,11 @@ func (i *gatewayHandler) serveRawBlock(ctx context.Context, w http.ResponseWrite
 
 	// ServeContent will take care of
 	// If-None-Match+Etag, Content-Length and range requests
-	_, dataSent, _ := ServeContent(w, r, name, modtime, content)
+	_, dataSent, err := ServeContent(w, r, name, modtime, content)
+
+	if err != nil {
+		closeConnWithError(w, err)
+	}
 
 	if dataSent {
 		// Update metrics

--- a/core/corehttp/gateway_handler_car.go
+++ b/core/corehttp/gateway_handler_car.go
@@ -67,6 +67,7 @@ func (i *gatewayHandler) serveCAR(ctx context.Context, w http.ResponseWriter, r 
 
 	w.Header().Set("Content-Type", "application/vnd.ipld.car; version=1")
 	w.Header().Set("X-Content-Type-Options", "nosniff") // no funny business in the browsers :^)
+	w.Header().Set("Trailer", "X-Stream-Error")
 
 	// Same go-car settings as dag.export command
 	store := dagStore{dag: i.api.Dag(), ctx: ctx}

--- a/core/corehttp/gateway_handler_car.go
+++ b/core/corehttp/gateway_handler_car.go
@@ -76,7 +76,7 @@ func (i *gatewayHandler) serveCAR(ctx context.Context, w http.ResponseWriter, r 
 	car := gocar.NewSelectiveCar(ctx, store, []gocar.Dag{dag}, gocar.TraverseLinksOnlyOnce())
 
 	if err := car.Write(w); err != nil {
-		closeConnWithError(w, err)
+		abortConn(w)
 		return
 	}
 

--- a/core/corehttp/gateway_handler_tar.go
+++ b/core/corehttp/gateway_handler_tar.go
@@ -79,14 +79,6 @@ func (i *gatewayHandler) serveTAR(ctx context.Context, w http.ResponseWriter, r 
 
 	// The TAR has a top-level directory (or file) named by the CID.
 	if err := tarw.WriteFile(file, rootCid.String()); err != nil {
-		w.Header().Set("X-Stream-Error", err.Error())
-		// Trailer headers do not work in web browsers
-		// (see https://github.com/mdn/browser-compat-data/issues/14703)
-		// and we have limited options around error handling in browser contexts.
-		// To improve UX/DX, we finish response stream with error message, allowing client to
-		// (1) detect error by having corrupted TAR
-		// (2) be able to reason what went wrong by instecting the tail of TAR stream
-		_, _ = w.Write([]byte(err.Error()))
-		return
+		abortConn(w)
 	}
 }

--- a/core/corehttp/gateway_handler_unixfs_dir.go
+++ b/core/corehttp/gateway_handler_unixfs_dir.go
@@ -209,7 +209,7 @@ func (i *gatewayHandler) serveDirectory(ctx context.Context, w http.ResponseWrit
 	logger.Debugw("request processed", "tplDataDNSLink", dnslink, "tplDataSize", size, "tplDataBackLink", backLink, "tplDataHash", hash)
 
 	if err := listingTemplate.Execute(w, tplData); err != nil {
-		internalWebError(w, err)
+		closeConnWithError(w, err)
 		return
 	}
 

--- a/core/corehttp/gateway_handler_unixfs_dir.go
+++ b/core/corehttp/gateway_handler_unixfs_dir.go
@@ -209,7 +209,7 @@ func (i *gatewayHandler) serveDirectory(ctx context.Context, w http.ResponseWrit
 	logger.Debugw("request processed", "tplDataDNSLink", dnslink, "tplDataSize", size, "tplDataBackLink", backLink, "tplDataHash", hash)
 
 	if err := listingTemplate.Execute(w, tplData); err != nil {
-		closeConnWithError(w, err)
+		abortConn(w)
 		return
 	}
 

--- a/core/corehttp/gateway_handler_unixfs_file.go
+++ b/core/corehttp/gateway_handler_unixfs_file.go
@@ -97,7 +97,8 @@ func (i *gatewayHandler) serveFile(ctx context.Context, w http.ResponseWriter, r
 	_, dataSent, err := ServeContent(w, r, name, modtime, content)
 
 	if err != nil {
-		closeConnWithError(w, err)
+		abortConn(w)
+		return
 	}
 
 	// Was response successful?

--- a/core/corehttp/gateway_handler_unixfs_file.go
+++ b/core/corehttp/gateway_handler_unixfs_file.go
@@ -94,7 +94,11 @@ func (i *gatewayHandler) serveFile(ctx context.Context, w http.ResponseWriter, r
 
 	// ServeContent will take care of
 	// If-None-Match+Etag, Content-Length and range requests
-	_, dataSent, _ := ServeContent(w, r, name, modtime, content)
+	_, dataSent, err := ServeContent(w, r, name, modtime, content)
+
+	if err != nil {
+		closeConnWithError(w, err)
+	}
 
 	// Was response successful?
 	if dataSent {

--- a/test/sharness/t0122-gateway-tar.sh
+++ b/test/sharness/t0122-gateway-tar.sh
@@ -76,8 +76,7 @@ test_expect_success "Add CARs with relative paths to test with" '
 '
 
 test_expect_success "GET TAR with relative paths outside root fails" '
-  curl -o - "http://127.0.0.1:$GWAY_PORT/ipfs/$OUTSIDE_ROOT_CID?format=tar" > curl_output_filename &&
-  test_should_contain "relative UnixFS paths outside the root are now allowed" curl_output_filename
+  ! curl "http://127.0.0.1:$GWAY_PORT/ipfs/$OUTSIDE_ROOT_CID?format=tar"
 '
 
 test_expect_success "GET TAR with relative paths inside root works" '


### PR DESCRIPTION
While working on #9029, I noticed the `Trailer` HTTP header was missing on CAR responses. If there was an error, the client would likely miss it. `curl`, for example, would not show the trailing header on the output.

Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer

**Update**: see https://github.com/ipfs/kubo/pull/9333#issuecomment-1273348381