### PR TITLE
all: do `timer.Reset` after check the timer is stopped

### DIFF
--- a/cmd/ipfs/pinmfs.go
+++ b/cmd/ipfs/pinmfs.go
@@ -95,6 +95,9 @@ func pinMFSOnChange(configPollInterval time.Duration, cctx pinMFSContext, node p
 		if tmo == nil {
 			tmo = time.NewTimer(configPollInterval)
 		} else {
+			if !tmo.Stop() {
+				<-tmo.C
+			}
 			tmo.Reset(configPollInterval)
 		}
 		select {

--- a/cmd/ipfs/pinmfs.go
+++ b/cmd/ipfs/pinmfs.go
@@ -95,9 +95,6 @@ func pinMFSOnChange(configPollInterval time.Duration, cctx pinMFSContext, node p
 		if tmo == nil {
 			tmo = time.NewTimer(configPollInterval)
 		} else {
-			if !tmo.Stop() {
-				<-tmo.C
-			}
 			tmo.Reset(configPollInterval)
 		}
 		select {

--- a/peering/peering.go
+++ b/peering/peering.go
@@ -126,6 +126,9 @@ func (ph *peerHandler) reconnect() {
 		if ph.reconnectTimer != nil {
 			// Only counts if the reconnectTimer still exists. If not, a
 			// connection _was_ somehow established.
+			if !ph.reconnectTimer.Stop() {
+				<-ph.reconnectTimer.C
+			}
 			ph.reconnectTimer.Reset(ph.nextBackoff())
 		}
 		// Otherwise, someone else has stopped us so we can assume that


### PR DESCRIPTION
According to `go/time package`, the correctly way that call timer.Reset is receive 'timer.C' before reset.

ref: https://github.com/golang/go/blob/19309779ac5e2f5a2fd3cbb34421dafb2855ac21/src/time/sleep.go#L100-L140