### PR TITLE
docs: pin remote arg

### DIFF
--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -129,7 +129,7 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path", true, false, "Path to object(s) to be pinned."),
+		cmds.StringArg("ipfs-path", true, false, "CID or Path to be pinned."),
 	},
 	Options: []cmds.Option{
 		pinServiceNameOption,


### PR DESCRIPTION
It accepts only one arg, and it is usually a CID.