### PR TITLE
Simplifying rcmgr_defaults.go

### DIFF
--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -1,5 +1,6 @@
 package libp2p
 
+// maybe there are other imports that can be cleaned up?
 import (
 	"encoding/json"
 	"fmt"
@@ -10,8 +11,6 @@ import (
 	"github.com/ipfs/kubo/config"
 	"github.com/libp2p/go-libp2p"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
-
-	"github.com/wI2L/jsondiff"
 )
 
 // This file defines implicit limit defaults used when Swarm.ResourceMgr.Enabled
@@ -23,810 +22,95 @@ func adjustedDefaultLimits(cfg config.SwarmConfig) rcmgr.LimitConfig {
 	if os.Getenv("IPFS_CHECK_RCMGR_DEFAULTS") != "" {
 		checkImplicitDefaults()
 	}
-	defaultLimits := rcmgr.DefaultLimits
-	libp2p.SetDefaultServiceLimits(&defaultLimits)
-
-	// Adjust limits
-	// (based on https://github.com/filecoin-project/lotus/pull/8318/files)
-	// - if Swarm.ConnMgr.HighWater is too high, adjust Conn/FD/Stream limits
-
-	// Outbound conns and FDs are set very high to allow for the accelerated DHT client to (re)load its routing table.
-	// Currently it doesn't gracefully handle RM throttling--once it does we can lower these.
-	// High outbound conn limits are considered less of a DoS risk than high inbound conn limits.
-	// Also note that, due to the behavior of the accelerated DHT client, we don't need many streams, just conns.
-	if minOutbound := 65536; defaultLimits.SystemBaseLimit.ConnsOutbound < minOutbound {
-		defaultLimits.SystemBaseLimit.ConnsOutbound = minOutbound
+	
+	// Get or calculate maxMemory and maxFD 
+	// These can come in from config.
+	// If a user doesn't set these, then we can assume the same defaults as libp2p uses for its "AutoScale" function.
+	// 1. 1/8th of system memory
+	// 2. Math.max(1/2 of system FD limit, 4096)
+	// I don't know the right way to write this go code but I assume we can lift from
+	// lifting from https://github.com/libp2p/go-libp2p/blob/master/p2p/host/resource-manager/limit_defaults.go#L309-L310
+	// Note because we are determining the maxFD and maxMemory, we are going to call the "Scale" function and not "AutoScale" below.
+	
+	var noLimitIncrease = BaseLimitIncrease {
+		ConnsInbound:    0,
+		ConnsOutbound:   0,
+		Conns:           0,
+		StreamsInbound:  0,
+		StreamsOutbound: 0,
+		Streams:         0,
+		Memory:          0,
+		FDFraction:      0,
 	}
-	if minFD := 4096; defaultLimits.SystemBaseLimit.FD < minFD {
-		defaultLimits.SystemBaseLimit.FD = minFD
+	
+	var infiniteBaseLimit = BaseLimit{
+		Streams:         math.MaxInt,
+		StreamsInbound:  math.MaxInt,
+		StreamsOutbound: math.MaxInt,
+		Conns:           math.MaxInt,
+		ConnsInbound:    math.MaxInt,
+		ConnsOutbound:   math.MaxInt,
+		FD:              math.MaxInt,
+		Memory:          math.MaxInt64,
 	}
-	defaultLimitConfig := defaultLimits.AutoScale()
+	
+	// I assume I'm doing inccorect Go code here and not always using "=" vs. ":=" right.
+	scalingLimitConfig = ScalingLimitConfig {
+		SystemBaseLimit: BaseLimit{
+			// Use the input parameters on memory and FD
+			Memory:          maxMemory,
+			FD:              maxFD,
 
-	// Do we need to adjust due to Swarm.ConnMgr.HighWater?
+			Conns:           math.MaxInt, // just limit on the inbound
+			ConnsInbound:    rcmgr.DefaultLimits.SystemBaseLimit.ConnsInbound, // same as libp2p default
+			ConnsOutbound:   math.MaxInt,
+			// Don't limit streams.  Rely on connection and memory limits.
+			Streams:         math.MaxInt,
+			StreamsInbound:  math.MaxInt,
+			StreamsOutbound: math.MaxInt,
+		},
+		SystemLimitIncrease: noLimitIncrease,
+
+		// Just go with what libp2p does
+		// We could simplify this to only worry about Memory, FD, and ConnsInbound.
+		// I figure we shouldn't have resources in Transient state long so it's fine to have some limits here 
+		// because if they are getting hit, it's a problem
+		TransientBaseLimit: rcmgr.DefaultLimits.TransientBaseLimit,
+		TransientLimitIncrease: rcmgr.DefaultLimits.BaseLimitIncrease,
+
+		// Lets get out of the way of the allow list functionality.
+		// If someone specified "Swarm.ResourceMgr.Allowlist" we should let it go through.
+		AllowlistedSystemBaseLimit: infiniteBaseLimit,
+		AllowlistedSystemLimitIncrease: noLimitIncrease,
+		AllowlistedTransientBaseLimit: infiniteBaseLimit,
+		AllowlistedTransientLimitIncrease: noLimitIncrease,
+
+		// Keep it simple by not having Service, ServicePeer, Protocol, ProtocolPeer, Peer, Conn, or Stream limits.
+		ServiceBaseLimit: infiniteBaseLimit,
+		ServiceLimitIncrease: noLimitIncrease,
+		ServicePeerBaseLimit: infiniteBaseLimit,
+		ServicePeerLimitIncrease: noLimitIncrease,
+		ProtocolBaseLimit: infiniteBaseLimit,
+		ProtocolLimitIncrease: noLimitIncrease,
+		ProtocolPeerBaseLimit: infiniteBaseLimit,
+		ProtocolPeerLimitIncrease: noLimitIncrease,
+		PeerBaseLimit: infiniteBaseLimit,
+		PeerLimitIncrease: noLimitIncrease,
+		ConnBaseLimit: infiniteBaseLimit,
+		StreamBaseLimit: infiniteBaseLimit,
+	}
+	
+	// Whatever limits libp2p has specifically tuned for its protocols/services we'll apply.
+	libp2p.SetDefaultServiceLimits(&scalingLimitConfig)
+	
+	defaultLimitConfig = scalingLimitConfig.Scale(maxMemory, maxFD)
+
+	// If a high water mark is set, 
 	if cfg.ConnMgr.Type == "basic" {
-		maxconns := cfg.ConnMgr.HighWater
-		if 2*maxconns > defaultLimitConfig.System.ConnsInbound {
-			// adjust conns to 2x to allow for two conns per peer (TCP+QUIC)
-			defaultLimitConfig.System.ConnsInbound = logScale(2 * maxconns)
-			defaultLimitConfig.System.ConnsOutbound = logScale(2 * maxconns)
-			defaultLimitConfig.System.Conns = logScale(4 * maxconns)
-
-			defaultLimitConfig.System.StreamsInbound = logScale(16 * maxconns)
-			defaultLimitConfig.System.StreamsOutbound = logScale(64 * maxconns)
-			defaultLimitConfig.System.Streams = logScale(64 * maxconns)
-
-			if 2*maxconns > defaultLimitConfig.System.FD {
-				defaultLimitConfig.System.FD = logScale(2 * maxconns)
-			}
-
-			defaultLimitConfig.ServiceDefault.StreamsInbound = logScale(8 * maxconns)
-			defaultLimitConfig.ServiceDefault.StreamsOutbound = logScale(32 * maxconns)
-			defaultLimitConfig.ServiceDefault.Streams = logScale(32 * maxconns)
-
-			defaultLimitConfig.ProtocolDefault.StreamsInbound = logScale(8 * maxconns)
-			defaultLimitConfig.ProtocolDefault.StreamsOutbound = logScale(32 * maxconns)
-			defaultLimitConfig.ProtocolDefault.Streams = logScale(32 * maxconns)
-
-			log.Info("adjusted default resource manager limits")
-		}
-
+		// set the connection limit higher than high water mark so that the ConnMgr has "space and time" to close "least useful" connections.
+		defaultLimitConfig.System.Conns = 2*cfg.ConnMgr.HighWater 
+		log.Info("adjusted default resource manager System.Conns limits to match ConnMgr.HighWater value of %s", cfg.ConnMgr.HighWater)
 	}
 
 	return defaultLimitConfig
 }
-
-func logScale(val int) int {
-	bitlen := bits.Len(uint(val))
-	return 1 << bitlen
-}
-
-// checkImplicitDefaults compares libp2p defaults agains expected ones
-// and panics when they don't match. This ensures we are not surprised
-// by silent default limit changes when we update go-libp2p dependencies.
-func checkImplicitDefaults() {
-	ok := true
-
-	// Check 1: did go-libp2p-resource-manager's DefaultLimits change?
-	defaults, err := json.Marshal(rcmgr.DefaultLimits)
-	if err != nil {
-		log.Fatal(err)
-	}
-	changes, err := jsonDiff([]byte(expectedDefaultLimits), defaults)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if len(changes) > 0 {
-		ok = false
-		log.Errorf("===> OOF! go-libp2p-resource-manager changed DefaultLimits\n"+
-			"=> changes ('test' represents the old value):\n%s\n"+
-			"=> go-libp2p-resource-manager DefaultLimits update needs a review:\n"+
-			"Please inspect if changes impact go-ipfs users, and update expectedDefaultLimits in rcmgr_defaults.go to remove this message",
-			strings.Join(changes, "\n"),
-		)
-	}
-
-	// Check 2: did go-libp2p's SetDefaultServiceLimits change?
-	// We compare the baseline (min specs), and check if we went down in any limits.
-	l := rcmgr.DefaultLimits
-	libp2p.SetDefaultServiceLimits(&l)
-	limits := l.AutoScale()
-	testLimiter := rcmgr.NewFixedLimiter(limits)
-
-	serviceDefaults, err := json.Marshal(testLimiter)
-	if err != nil {
-		log.Fatal(err)
-	}
-	changes, err = jsonDiff([]byte(expectedDefaultServiceLimits), serviceDefaults)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if len(changes) > 0 {
-		oldState := map[string]int{}
-		type Op struct {
-			Op    string
-			Path  string
-			Value int
-		}
-		for _, changeStr := range changes {
-			change := Op{}
-			err := json.Unmarshal([]byte(changeStr), &change)
-			if err != nil {
-				continue
-			}
-			if change.Op == "test" {
-				oldState[change.Path] = change.Value
-			}
-		}
-
-		for _, changeStr := range changes {
-			change := Op{}
-			err := json.Unmarshal([]byte(changeStr), &change)
-			if err != nil {
-				continue
-			}
-			if change.Op == "replace" {
-				oldVal, okFound := oldState[change.Path]
-				if okFound && oldVal > change.Value {
-					ok = false
-					fmt.Printf("reduced value for %s. Old: %v; new: %v\n", change.Path, oldVal, change.Value)
-				}
-			}
-		}
-
-		if !ok {
-			log.Errorf("===> OOF! go-libp2p changed DefaultServiceLimits\n" +
-				"=> See the aboce reduced values for info.\n" +
-				"=> go-libp2p SetDefaultServiceLimits update needs a review:\n" +
-				"Please inspect if changes impact go-ipfs users, and update expectedDefaultServiceLimits in rcmgr_defaults.go to remove this message",
-			)
-		}
-	}
-	if !ok {
-		log.Fatal("daemon will refuse to run with the resource manager until this is resolved")
-	}
-}
-
-// jsonDiff compares two strings and returns diff in JSON Patch format
-func jsonDiff(old []byte, updated []byte) ([]string, error) {
-	// generate 'invertible' patch which includes old values as "test" op
-	patch, err := jsondiff.CompareJSONOpts(old, updated, jsondiff.Invertible())
-	changes := make([]string, len(patch))
-	if err != nil {
-		return changes, err
-	}
-	for i, op := range patch {
-		changes[i] = fmt.Sprintf("  %s", op)
-	}
-	return changes, nil
-}
-
-// https://github.com/libp2p/go-libp2p/blob/v0.22.0/p2p/host/resource-manager/limit_defaults.go#L343
-const expectedDefaultLimits = `{
-  "SystemBaseLimit": {
-    "Streams": 2048,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 2048,
-    "Conns": 128,
-    "ConnsInbound": 64,
-    "ConnsOutbound": 128,
-    "FD": 256,
-    "Memory": 134217728
-  },
-  "SystemLimitIncrease": {
-    "Streams": 2048,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 2048,
-    "Conns": 128,
-    "ConnsInbound": 64,
-    "ConnsOutbound": 128,
-    "Memory": 1073741824,
-    "FDFraction": 1
-  },
-  "TransientBaseLimit": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 64,
-    "ConnsInbound": 32,
-    "ConnsOutbound": 64,
-    "FD": 64,
-    "Memory": 33554432
-  },
-  "TransientLimitIncrease": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 32,
-    "ConnsInbound": 16,
-    "ConnsOutbound": 32,
-    "Memory": 134217728,
-    "FDFraction": 0.25
-  },
-  "AllowlistedSystemBaseLimit": {
-    "Streams": 2048,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 2048,
-    "Conns": 128,
-    "ConnsInbound": 64,
-    "ConnsOutbound": 128,
-    "FD": 256,
-    "Memory": 134217728
-  },
-  "AllowlistedSystemLimitIncrease": {
-    "Streams": 2048,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 2048,
-    "Conns": 128,
-    "ConnsInbound": 64,
-    "ConnsOutbound": 128,
-    "Memory": 1073741824,
-    "FDFraction": 1
-  },
-  "AllowlistedTransientBaseLimit": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 64,
-    "ConnsInbound": 32,
-    "ConnsOutbound": 64,
-    "FD": 64,
-    "Memory": 33554432
-  },
-  "AllowlistedTransientLimitIncrease": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 32,
-    "ConnsInbound": 16,
-    "ConnsOutbound": 32,
-    "Memory": 134217728,
-    "FDFraction": 0.25
-  },
-  "ServiceBaseLimit": {
-    "Streams": 4096,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 4096,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 67108864
-  },
-  "ServiceLimitIncrease": {
-    "Streams": 2048,
-    "StreamsInbound": 512,
-    "StreamsOutbound": 2048,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "Memory": 134217728,
-    "FDFraction": 0
-  },
-  "ServiceLimits": null,
-  "ServicePeerBaseLimit": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 16777216
-  },
-  "ServicePeerLimitIncrease": {
-    "Streams": 8,
-    "StreamsInbound": 4,
-    "StreamsOutbound": 8,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "Memory": 4194304,
-    "FDFraction": 0
-  },
-  "ServicePeerLimits": null,
-  "ProtocolBaseLimit": {
-    "Streams": 2048,
-    "StreamsInbound": 512,
-    "StreamsOutbound": 2048,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 67108864
-  },
-  "ProtocolLimitIncrease": {
-    "Streams": 512,
-    "StreamsInbound": 256,
-    "StreamsOutbound": 512,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "Memory": 171966464,
-    "FDFraction": 0
-  },
-  "ProtocolLimits": null,
-  "ProtocolPeerBaseLimit": {
-    "Streams": 256,
-    "StreamsInbound": 64,
-    "StreamsOutbound": 128,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 16777216
-  },
-  "ProtocolPeerLimitIncrease": {
-    "Streams": 16,
-    "StreamsInbound": 4,
-    "StreamsOutbound": 8,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "Memory": 4,
-    "FDFraction": 0
-  },
-  "ProtocolPeerLimits": null,
-  "PeerBaseLimit": {
-    "Streams": 512,
-    "StreamsInbound": 256,
-    "StreamsOutbound": 512,
-    "Conns": 8,
-    "ConnsInbound": 4,
-    "ConnsOutbound": 8,
-    "FD": 4,
-    "Memory": 67108864
-  },
-  "PeerLimitIncrease": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "Memory": 134217728,
-    "FDFraction": 0.015625
-  },
-  "PeerLimits": null,
-  "ConnBaseLimit": {
-    "Streams": 0,
-    "StreamsInbound": 0,
-    "StreamsOutbound": 0,
-    "Conns": 1,
-    "ConnsInbound": 1,
-    "ConnsOutbound": 1,
-    "FD": 1,
-    "Memory": 33554432
-  },
-  "ConnLimitIncrease": {
-    "Streams": 0,
-    "StreamsInbound": 0,
-    "StreamsOutbound": 0,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "Memory": 0,
-    "FDFraction": 0
-  },
-  "StreamBaseLimit": {
-    "Streams": 1,
-    "StreamsInbound": 1,
-    "StreamsOutbound": 1,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 16777216
-  },
-  "StreamLimitIncrease": {
-    "Streams": 0,
-    "StreamsInbound": 0,
-    "StreamsOutbound": 0,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "Memory": 0,
-    "FDFraction": 0
-  }
-}`
-
-// Generated from the default limits and scaling to 0 (base limit).
-const expectedDefaultServiceLimits = `{
-  "System": {
-    "Streams": 2048,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 2048,
-    "Conns": 128,
-    "ConnsInbound": 64,
-    "ConnsOutbound": 128,
-    "FD": 256,
-    "Memory": 134217728
-  },
-  "Transient": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 64,
-    "ConnsInbound": 32,
-    "ConnsOutbound": 64,
-    "FD": 64,
-    "Memory": 33554432
-  },
-  "AllowlistedSystem": {
-    "Streams": 2048,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 2048,
-    "Conns": 128,
-    "ConnsInbound": 64,
-    "ConnsOutbound": 128,
-    "FD": 256,
-    "Memory": 134217728
-  },
-  "AllowlistedTransient": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 64,
-    "ConnsInbound": 32,
-    "ConnsOutbound": 64,
-    "FD": 64,
-    "Memory": 33554432
-  },
-  "ServiceDefault": {
-    "Streams": 4096,
-    "StreamsInbound": 1024,
-    "StreamsOutbound": 4096,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 67108864
-  },
-  "Service": {
-    "libp2p.autonat": {
-      "Streams": 64,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "libp2p.holepunch": {
-      "Streams": 64,
-      "StreamsInbound": 32,
-      "StreamsOutbound": 32,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "libp2p.identify": {
-      "Streams": 128,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "libp2p.ping": {
-      "Streams": 64,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "libp2p.relay/v1": {
-      "Streams": 256,
-      "StreamsInbound": 256,
-      "StreamsOutbound": 256,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 16777216
-    },
-    "libp2p.relay/v2": {
-      "Streams": 256,
-      "StreamsInbound": 256,
-      "StreamsOutbound": 256,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 16777216
-    }
-  },
-  "ServicePeerDefault": {
-    "Streams": 256,
-    "StreamsInbound": 128,
-    "StreamsOutbound": 256,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 16777216
-  },
-  "ServicePeer": {
-    "libp2p.autonat": {
-      "Streams": 2,
-      "StreamsInbound": 2,
-      "StreamsOutbound": 2,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 1048576
-    },
-    "libp2p.holepunch": {
-      "Streams": 2,
-      "StreamsInbound": 2,
-      "StreamsOutbound": 2,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 1048576
-    },
-    "libp2p.identify": {
-      "Streams": 32,
-      "StreamsInbound": 16,
-      "StreamsOutbound": 16,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 1048576
-    },
-    "libp2p.ping": {
-      "Streams": 4,
-      "StreamsInbound": 2,
-      "StreamsOutbound": 3,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 8590458880
-    },
-    "libp2p.relay/v1": {
-      "Streams": 64,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 1048576
-    },
-    "libp2p.relay/v2": {
-      "Streams": 64,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 1048576
-    }
-  },
-  "ProtocolDefault": {
-    "Streams": 2048,
-    "StreamsInbound": 512,
-    "StreamsOutbound": 2048,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 67108864
-  },
-  "Protocol": {
-    "/ipfs/id/1.0.0": {
-      "Streams": 128,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "/ipfs/id/push/1.0.0": {
-      "Streams": 128,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "/ipfs/ping/1.0.0": {
-      "Streams": 64,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "/libp2p/autonat/1.0.0": {
-      "Streams": 64,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "/libp2p/circuit/relay/0.1.0": {
-      "Streams": 640,
-      "StreamsInbound": 640,
-      "StreamsOutbound": 640,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 16777216
-    },
-    "/libp2p/circuit/relay/0.2.0/hop": {
-      "Streams": 640,
-      "StreamsInbound": 640,
-      "StreamsOutbound": 640,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 16777216
-    },
-    "/libp2p/circuit/relay/0.2.0/stop": {
-      "Streams": 640,
-      "StreamsInbound": 640,
-      "StreamsOutbound": 640,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 16777216
-    },
-    "/libp2p/dcutr": {
-      "Streams": 64,
-      "StreamsInbound": 32,
-      "StreamsOutbound": 32,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    },
-    "/p2p/id/delta/1.0.0": {
-      "Streams": 128,
-      "StreamsInbound": 64,
-      "StreamsOutbound": 64,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 4194304
-    }
-  },
-  "ProtocolPeerDefault": {
-    "Streams": 256,
-    "StreamsInbound": 64,
-    "StreamsOutbound": 128,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 16777216
-  },
-  "ProtocolPeer": {
-    "/ipfs/id/1.0.0": {
-      "Streams": 32,
-      "StreamsInbound": 16,
-      "StreamsOutbound": 16,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 8590458880
-    },
-    "/ipfs/id/push/1.0.0": {
-      "Streams": 32,
-      "StreamsInbound": 16,
-      "StreamsOutbound": 16,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 8590458880
-    },
-    "/ipfs/ping/1.0.0": {
-      "Streams": 4,
-      "StreamsInbound": 2,
-      "StreamsOutbound": 3,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 8590458880
-    },
-    "/libp2p/autonat/1.0.0": {
-      "Streams": 2,
-      "StreamsInbound": 2,
-      "StreamsOutbound": 2,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 1048576
-    },
-    "/libp2p/circuit/relay/0.1.0": {
-      "Streams": 128,
-      "StreamsInbound": 128,
-      "StreamsOutbound": 128,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 33554432
-    },
-    "/libp2p/circuit/relay/0.2.0/hop": {
-      "Streams": 128,
-      "StreamsInbound": 128,
-      "StreamsOutbound": 128,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 33554432
-    },
-    "/libp2p/circuit/relay/0.2.0/stop": {
-      "Streams": 128,
-      "StreamsInbound": 128,
-      "StreamsOutbound": 128,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 33554432
-    },
-    "/libp2p/dcutr": {
-      "Streams": 2,
-      "StreamsInbound": 2,
-      "StreamsOutbound": 2,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 1048576
-    },
-    "/p2p/id/delta/1.0.0": {
-      "Streams": 32,
-      "StreamsInbound": 16,
-      "StreamsOutbound": 16,
-      "Conns": 0,
-      "ConnsInbound": 0,
-      "ConnsOutbound": 0,
-      "FD": 0,
-      "Memory": 8590458880
-    }
-  },
-  "PeerDefault": {
-    "Streams": 512,
-    "StreamsInbound": 256,
-    "StreamsOutbound": 512,
-    "Conns": 8,
-    "ConnsInbound": 4,
-    "ConnsOutbound": 8,
-    "FD": 4,
-    "Memory": 67108864
-  },
-  "Conn": {
-    "Streams": 0,
-    "StreamsInbound": 0,
-    "StreamsOutbound": 0,
-    "Conns": 1,
-    "ConnsInbound": 1,
-    "ConnsOutbound": 1,
-    "FD": 1,
-    "Memory": 1048576
-  },
-  "Stream": {
-    "Streams": 1,
-    "StreamsInbound": 1,
-    "StreamsOutbound": 1,
-    "Conns": 0,
-    "ConnsInbound": 0,
-    "ConnsOutbound": 0,
-    "FD": 0,
-    "Memory": 16777216
-  }
-}`


### PR DESCRIPTION
The goal of this PR is to show an easier set of defaults for resource manager to reason about. This is an attempt help address https://github.com/ipfs/kubo/issues/9322 .  This PR is not intended to be merged as is.  It's not complete, undoubtedly has syntax errors, I haven't run tests, etc.  It was done as a starting point to communicate specifically on how I think we can simplify the default story.

The basic idea is:

1. Get/create these inputs:
 - maxMemory: can be set by user or default 1/8th the system memory
 - maxFD: can be set by user or default 1/2 the system limit
 - maxConns: can be set as the connection manager high water mark or defaults to infinity

2. Only set limits at the system and transient scope, and even there, mostly just focus on memory, FD, and inbound connections.  Limits are set based on the inputs.  We generally ignore outbound connections and stream limits.

3. Apply any limits that libp2p has for its protocols/services.
