### PR TITLE
feat: add delegated routing metrics

### DIFF
--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/ipfs/go-cid v0.3.2 // indirect
 	github.com/ipfs/go-cidutil v0.1.0 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect
-	github.com/ipfs/go-delegated-routing v0.6.0 // indirect
+	github.com/ipfs/go-delegated-routing v0.7.0 // indirect
 	github.com/ipfs/go-ds-badger v0.3.0 // indirect
 	github.com/ipfs/go-ds-flatfs v0.5.1 // indirect
 	github.com/ipfs/go-ds-leveldb v0.5.0 // indirect

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -497,8 +497,8 @@ github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh7
 github.com/ipfs/go-datastore v0.5.1/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
 github.com/ipfs/go-datastore v0.6.0 h1:JKyz+Gvz1QEZw0LsX1IBn+JFCJQH4SJVFtM4uWU0Myk=
 github.com/ipfs/go-datastore v0.6.0/go.mod h1:rt5M3nNbSO/8q1t4LNkLyUwRs8HupMeN/8O4Vn9YAT8=
-github.com/ipfs/go-delegated-routing v0.6.0 h1:+M1siyTB2H4mHzEnbWjepQxlmKbapVWdbYLexSDODpg=
-github.com/ipfs/go-delegated-routing v0.6.0/go.mod h1:FJjhCChfcWK9z6OXo2jwKKJoxq1JlEWG7YTvwaA7UbI=
+github.com/ipfs/go-delegated-routing v0.7.0 h1:43FyMnKA+8XnyX68Fwg6aoGkqrf8NS5aG7p644s26PU=
+github.com/ipfs/go-delegated-routing v0.7.0/go.mod h1:u4zxjUWIe7APUW5ds9CfD0tJX3vM9JhIeNqA8kE4vHE=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ds-badger v0.0.2/go.mod h1:Y3QpeSFWQf6MopLTiZD+VT6IC1yZqaGmjvRcKeSGij8=

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 
 require (
 	github.com/benbjohnson/clock v1.3.0
-	github.com/ipfs/go-delegated-routing v0.6.0
+	github.com/ipfs/go-delegated-routing v0.7.0
 	github.com/ipfs/go-ipfs-redirects-file v0.1.1
 	github.com/ipfs/go-log/v2 v2.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/ipfs/go-datastore v0.4.5/go.mod h1:eXTcaaiN6uOlVCLS9GjJUJtlvJfM3xk23w
 github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
 github.com/ipfs/go-datastore v0.6.0 h1:JKyz+Gvz1QEZw0LsX1IBn+JFCJQH4SJVFtM4uWU0Myk=
 github.com/ipfs/go-datastore v0.6.0/go.mod h1:rt5M3nNbSO/8q1t4LNkLyUwRs8HupMeN/8O4Vn9YAT8=
-github.com/ipfs/go-delegated-routing v0.6.0 h1:+M1siyTB2H4mHzEnbWjepQxlmKbapVWdbYLexSDODpg=
-github.com/ipfs/go-delegated-routing v0.6.0/go.mod h1:FJjhCChfcWK9z6OXo2jwKKJoxq1JlEWG7YTvwaA7UbI=
+github.com/ipfs/go-delegated-routing v0.7.0 h1:43FyMnKA+8XnyX68Fwg6aoGkqrf8NS5aG7p644s26PU=
+github.com/ipfs/go-delegated-routing v0.7.0/go.mod h1:u4zxjUWIe7APUW5ds9CfD0tJX3vM9JhIeNqA8kE4vHE=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ds-badger v0.0.2/go.mod h1:Y3QpeSFWQf6MopLTiZD+VT6IC1yZqaGmjvRcKeSGij8=

--- a/routing/delegated.go
+++ b/routing/delegated.go
@@ -23,6 +23,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/routing"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multicodec"
+	"go.opencensus.io/stats/view"
 )
 
 var log = logging.Logger("routing/delegated")
@@ -177,6 +178,11 @@ func reframeRoutingFromConfig(conf config.Router, extraReframe *ExtraReframePara
 	}
 
 	var c *drc.Client
+
+	err = view.Register(drc.DefaultViews...)
+	if err != nil {
+		return nil, fmt.Errorf("registering delegated routing views: %w", err)
+	}
 
 	// this path is for tests only
 	if extraReframe == nil {


### PR DESCRIPTION
Example log output:

Enable warn level:
```
$ ipfs log level 'service/client/delegatedrouting' WARN
```

Output:
```
2022-10-19T08:22:28.009-0400    WARN    service/client/delegatedrouting client/metrics.go:51    received delegated routing error        {"Error": "sending HTTP request: Get \"http://127.0.0.1:5098/reframe?q=...\": dial tcp 127.0.0.1:5098: connect: connection refused"}
```



Metrics:

```
$ curl -s http://127.0.01:5001/debug/metrics/prometheus | grep -i delegated
# HELP delegated_routing_duration The time to complete an entire request
# TYPE delegated_routing_duration histogram
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="1"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="2"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="5"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="10"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="20"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="50"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="100"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="200"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="500"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="1000"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="2000"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="5000"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="10000"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="20000"} 1
delegated_routing_duration_bucket{error="Net",name="ContentRoutingClient.FindProvidersAsync",le="+Inf"} 1
delegated_routing_duration_sum{error="Net",name="ContentRoutingClient.FindProvidersAsync"} 0
delegated_routing_duration_count{error="Net",name="ContentRoutingClient.FindProvidersAsync"} 1
# HELP delegated_routing_requests The number of requests made
# TYPE delegated_routing_requests counter
delegated_routing_requests{error="Net",name="ContentRoutingClient.FindProvidersAsync"} 1
```