### PR TITLE
fix: grant group read permission to config

### DIFF
--- a/config/serialize/serialize.go
+++ b/config/serialize/serialize.go
@@ -40,7 +40,7 @@ func WriteConfigFile(filename string, cfg interface{}) error {
 		return err
 	}
 
-	f, err := atomicfile.New(filename, 0600)
+	f, err := atomicfile.New(filename, 0640)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Disclaimer: I'm unfamiliar with ipfs's security model, and this PR could have security implications.

Without this, multi-user installations such as NixOS's are unable to read the config file:

```
$ ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme
Error: error loading plugins: open /var/lib/ipfs/config: permission denied

$ ls -lah /var/lib/ipfs/
total 32K
drwxr-xr-x 1 ipfs ipfs  138 Oct 22 12:02 .
drwxr-xr-x 1 root root  362 Oct 22 12:03 ..
-rw-r--r-- 1 ipfs ipfs   19 Oct 22 12:02 api
drwxr-xr-x 1 ipfs ipfs  166 Oct 22 12:10 blocks
-rw------- 1 ipfs ipfs 4.8K Oct 22 12:02 config
drwxr-xr-x 1 ipfs ipfs  140 Oct 22 12:02 datastore
-rw------- 1 ipfs ipfs  190 Oct 22 12:02 datastore_spec
-rw-r--r-- 1 ipfs ipfs   21 Oct 22 12:02 gateway
drwx------ 1 ipfs ipfs    0 Oct 22 12:02 keystore
-rw-r--r-- 1 ipfs ipfs    0 Oct 22 12:02 repo.lock
-rw-r--r-- 1 ipfs ipfs    3 Oct 22 12:02 version

$ sudo chmod g+r /var/lib/ipfs/config
$ ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme
Hello and Welcome to IPFS!
[...]
```

There are possible security implications with this, if the ipfs dir is owned by an overly broad group.

I see this permission was removed in https://github.com/ipfs/go-ipfs-config/pull/98.