### PR TITLE
fix: error when replacing config with huge json file

### DIFF
--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -332,7 +332,7 @@ can't be undone.
 		}
 		defer file.Close()
 
-		return replaceConfig(r, file)
+		return replaceConfig(r, io.LimitReader(file, 32*1024*1024)) // 32MiB
 	},
 }
 


### PR DESCRIPTION
This error nicely instead of ooming when trying to replace config with json file so big it would oom.