### PR TITLE
fix: error when using huge json limit file

### DIFF
--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -422,7 +422,10 @@ Changes made via command line are persisted in the Swarm.ResourceMgr.Limits fiel
 				if file == nil {
 					return errors.New("expected a JSON file")
 				}
-				if err := json.NewDecoder(file).Decode(&newLimit); err != nil {
+
+				r := io.LimitReader(file, 32*1024*1024) // 32MiB
+
+				if err := json.NewDecoder(r).Decode(&newLimit); err != nil {
 					return fmt.Errorf("decoding JSON as ResourceMgrScopeConfig: %w", err)
 				}
 				return libp2p.NetSetLimit(node.ResourceManager, node.Repo, scope, newLimit)


### PR DESCRIPTION
This error nicely instead of ooming when trying to use a json file so big it would oom.