### PR TITLE
docs: Swarm.AddrFilters ip address example fix

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1514,7 +1514,7 @@ another node, even if this other node is on a different network. This may
 trigger netscan alerts on some hosting providers or cause strain in some setups.
 
 The `server` configuration profile fills up this list with sensible defaults,
-preventing dials to all non-routable IP addresses (e.g., `192.168.0.0/16`) but
+preventing dials to all non-routable IP addresses (e.g., `/ip4/192.168.0.0/ipcidr/16`) but
 you should always check settings against your own network and/or hosting
 provider.
 


### PR DESCRIPTION
The current example `192.168.0.0/16` is wrong:

```
2022-11-08T08:47:41.660+0800	ERROR	core	core/builder.go:157	constructing the node: could not build arguments for function "github.com/ipfs/kubo/core/node".PeerWith.func1 (/home/m/go/pkg/mod/github.com/ipfs/kubo@v0.16.0/core/node/peering.go:29): failed to build *peering.PeeringService: could not build arguments for function "github.com/ipfs/kubo/core/node".Peering (/home/m/go/pkg/mod/github.com/ipfs/kubo@v0.16.0/core/node/peering.go:14): failed to build host.Host: could not build arguments for function "github.com/ipfs/kubo/core/node/libp2p".Host (/home/m/go/pkg/mod/github.com/ipfs/kubo@v0.16.0/core/node/libp2p/host.go:40): could not build value group []config.Option[group="libp2p"]: received non-nil error from function "github.com/ipfs/kubo/core/node/libp2p".AddrFilters.func1 (/home/m/go/pkg/mod/github.com/ipfs/kubo@v0.16.0/core/node/libp2p/addrs.go:14): incorrectly formatted address filter in config: 192.168.0.0/16
```

`/ip4/192.168.0.0/ipcidr/16` is correct.