### PR TITLE
feat: ipfs-webui 2.20.0

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,11 +1,12 @@
 package corehttp
 
 // TODO: move to IPNS
-const WebUIPath = "/ipfs/bafybeiavrvt53fks6u32n5p2morgblcmck4bh4ymf4rrwu7ah5zsykmqqa" // v2.19.0
+const WebUIPath = "/ipfs/bafybeibjbq3tmmy7wuihhhwvbladjsd3gx3kfjepxzkq6wylik6wc3whzy" // v2.20.0
 
 // WebUIPaths is a list of all past webUI paths.
 var WebUIPaths = []string{
 	WebUIPath,
+	"/ipfs/bafybeiavrvt53fks6u32n5p2morgblcmck4bh4ymf4rrwu7ah5zsykmqqa",
 	"/ipfs/bafybeiageaoxg6d7npaof6eyzqbwvbubyler7bq44hayik2hvqcggg7d2y",
 	"/ipfs/bafybeidb5eryh72zajiokdggzo7yct2d6hhcflncji5im2y5w26uuygdsm",
 	"/ipfs/bafybeibozpulxtpv5nhfa2ue3dcjx23ndh3gwr5vwllk7ptoyfwnfjjr4q",


### PR DESCRIPTION
Release Notes: https://github.com/ipfs/ipfs-webui/releases/tag/v2.20.0

This includes two important things for Kubo 0.17-rc1 (https://github.com/ipfs/kubo/issues/9319):
- updated geoip database for Peers screen (https://github.com/ipfs-shipyard/ipfs-geoip/pull/97)
- support for `/webtransport` on Status page (https://github.com/ipfs/ipfs-webui/issues/2033).