### PR TITLE
fix(config): skip nulls in ResourceMgr

### DIFF
--- a/config/swarm.go
+++ b/config/swarm.go
@@ -144,8 +144,8 @@ type ResourceMgr struct {
 	Enabled Flag               `json:",omitempty"`
 	Limits  *rcmgr.LimitConfig `json:",omitempty"`
 
-	MaxMemory          OptionalString  `json:",omitempty"`
-	MaxFileDescriptors OptionalInteger `json:",omitempty"`
+	MaxMemory          *OptionalString  `json:",omitempty"`
+	MaxFileDescriptors *OptionalInteger `json:",omitempty"`
 
 	// A list of multiaddrs that can bypass normal system limits (but are still
 	// limited by the allowlist scope). Convenience config around


### PR DESCRIPTION
This is a cosmetic fix that removes `null` values from the default config:

```json
    "ResourceMgr": {
      "MaxMemory": null,
      "MaxFileDescriptors": null
    }
```

```json
    "ResourceMgr": {}
```

:)