### PR TITLE
fix: typo in documentation for install path

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -118,7 +118,7 @@ help:
 	@echo '  all          - print this help message'
 	@echo '  build        - Build binary at ./cmd/ipfs/ipfs'
 	@echo '  nofuse       - Build binary with no fuse support'
-	@echo '  install      - Build binary and install into $$GOPATH/bin'
+	@echo '  install      - Build binary and install into $$GOBIN'
 #	@echo '  dist_install - TODO: c.f. ./cmd/ipfs/dist/README.md'
 	@echo ''
 	@echo 'CLEANING TARGETS:'


### PR DESCRIPTION
By default, `go install` will install go $GOBIN and not $GOPATH. In most cases there is no functional difference -- `go install` falls back to $GOPATH when $GOBIN is empty.