### PR TITLE
chore(ci): bigger box for webui and interop

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -224,7 +224,7 @@ jobs:
     docker:
       - image: cimg/go:1.19.1-node
     parallelism: 4
-    resource_class: large
+    resource_class: 2xlarge+
     steps:
       - *make_out_dirs
       - attach_workspace:
@@ -324,6 +324,7 @@ jobs:
             - ~/.cache/go-build/
   ipfs-webui:
     executor: node-browsers
+    resource_class: 2xlarge+
     steps:
       - *make_out_dirs
       - attach_workspace:


### PR DESCRIPTION
| before | after (this PR) | 
| ---- | ---- |
| ![2022-11-15_18-18](https://user-images.githubusercontent.com/157609/201984487-183a750b-cb75-4d7c-b21e-e0693fc9c15d.png) |  ![2022-11-15_19-05](https://user-images.githubusercontent.com/157609/201993460-5b78e1cb-8f9d-450c-b83b-b6719861e7cf.png)  |

- `webui` and `interop` tests take nearly as long as `sharness`
- `webui` flakiness will be addressed upstream in ipfs-webui repo (tracked in https://github.com/ipfs/ipfs-webui/issues/2065), but this PR should decrease how often it occurs + make CI faster (making the sharness the longest one again)