### PR TITLE
docs: document /wss fix in 0.17 (go-libp2p 0.23.3)

### DIFF
--- a/docs/changelogs/v0.17.md
+++ b/docs/changelogs/v0.17.md
@@ -12,6 +12,7 @@ Below is an outline of all that is in this release, so you get a sense of all th
     - [TOC](#toc)
     - [🔦 Highlights](#-highlights)
       - [TAR Response Format on Gateways](#tar-response-format-on-gateways)
+      - [Dialling `/wss` peer behind a reverse proxy](#dialling-wss-peer-behind-a-reverse-proxy)
     - [Changelog](#changelog)
     - [Contributors](#contributors)
 
@@ -36,6 +37,14 @@ bafybeigccimv3zqm5g4jt363faybagywkvqbrismoquogimy7kvz2sj7sq/1 - Barrel - Part 1 
 bafybeigccimv3zqm5g4jt363faybagywkvqbrismoquogimy7kvz2sj7sq/1 - Barrel - Part 1 - transcript.txt
 bafybeigccimv3zqm5g4jt363faybagywkvqbrismoquogimy7kvz2sj7sq/1 - Barrel - Part 1.png
 ```
+
+#### Dialling `/wss` peer behind a reverse proxy
+
+This release resolves a regression introduced in Kubo 0.16, making it possible
+again to connect to a peer over a WebSockets endpoint (`/wss`) that is
+deployed behind a reverse proxy.
+
+More details in [go-libp2p release notes](https://github.com/libp2p/go-libp2p/releases/tag/v0.23.3).
 
 ### Changelog
 


### PR DESCRIPTION
Context https://github.com/libp2p/go-libp2p-relay-daemon/issues/18#issuecomment-1276212041 and https://github.com/libp2p/go-libp2p/pull/1834  – part of https://github.com/ipfs/kubo/issues/9319 and #9204