### PR TITLE
docs(readme): improve tldr

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## What is Kubo?
 
-Kubo was the first IPFS implementation and is the most widely used one today. Implementing the *Interplanetary Filesystem* - the Web3 standard and contender to replace https. Thus powered by IPLD's data models and the libp2p for network communication. Kubo is written in Go.
+Kubo was the first IPFS implementation and is the most widely used one today. Implementing the *Interplanetary Filesystem* - the Web3 standard for content-addressing, interoperable with HTTP. Thus powered by IPLD's data models and the libp2p for network communication. Kubo is written in Go.
 
 Featureset
 - Runs an IPFS-Node as a network service


### PR DESCRIPTION
We really should remove all mentions of "IPFS will replace HTTP".  It distracts people from the killer features (content addressing, and full interop with HTTP).

