### PR TITLE
fix: Only limit resources per peer

### DIFF
--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -61,58 +61,21 @@ func createDefaultLimitConfig(cfg config.SwarmConfig) (rcmgr.LimitConfig, error)
 			Memory: int64(maxMemory),
 			FD:     int(numFD),
 
-			// By default, we just limit connections on the inbound side.
 			Conns:         bigEnough,
-			ConnsInbound:  rcmgr.DefaultLimits.SystemBaseLimit.ConnsInbound, // same as libp2p default
+			ConnsInbound:  bigEnough,
 			ConnsOutbound: bigEnough,
 
 			// We limit streams since they not only take up memory and CPU.
 			// The Memory limit protects us on the memory side,
 			// but a StreamsInbound limit helps protect against unbound CPU consumption from stream processing.
 			Streams:         bigEnough,
-			StreamsInbound:  rcmgr.DefaultLimits.SystemBaseLimit.StreamsInbound,
+			StreamsInbound:  bigEnough,
 			StreamsOutbound: bigEnough,
 		},
-		// Most limits don't see an increase because they're already infinite/bigEnough or at their max value.
-		// The values that should scale based on the amount of memory allocated to libp2p need to increase accordingly.
-		SystemLimitIncrease: rcmgr.BaseLimitIncrease{
-			Memory:     rcmgr.DefaultLimits.SystemLimitIncrease.Memory,
-			FDFraction: rcmgr.DefaultLimits.SystemLimitIncrease.FDFraction,
+		SystemLimitIncrease: noLimitIncrease,
 
-			Conns:         0,
-			ConnsInbound:  rcmgr.DefaultLimits.SystemLimitIncrease.ConnsInbound,
-			ConnsOutbound: 0,
-
-			Streams:         0,
-			StreamsInbound:  rcmgr.DefaultLimits.SystemLimitIncrease.StreamsInbound,
-			StreamsOutbound: 0,
-		},
-
-		TransientBaseLimit: rcmgr.BaseLimit{
-			Memory: rcmgr.DefaultLimits.TransientBaseLimit.Memory,
-			FD:     rcmgr.DefaultLimits.TransientBaseLimit.FD,
-
-			Conns:         bigEnough,
-			ConnsInbound:  rcmgr.DefaultLimits.TransientBaseLimit.ConnsInbound,
-			ConnsOutbound: bigEnough,
-
-			Streams:         bigEnough,
-			StreamsInbound:  rcmgr.DefaultLimits.TransientBaseLimit.StreamsInbound,
-			StreamsOutbound: bigEnough,
-		},
-
-		TransientLimitIncrease: rcmgr.BaseLimitIncrease{
-			Memory:     rcmgr.DefaultLimits.TransientLimitIncrease.Memory,
-			FDFraction: rcmgr.DefaultLimits.TransientLimitIncrease.FDFraction,
-
-			Conns:         0,
-			ConnsInbound:  rcmgr.DefaultLimits.TransientLimitIncrease.ConnsInbound,
-			ConnsOutbound: 0,
-
-			Streams:         0,
-			StreamsInbound:  rcmgr.DefaultLimits.TransientLimitIncrease.StreamsInbound,
-			StreamsOutbound: 0,
-		},
+		TransientBaseLimit:     infiniteBaseLimit,
+		TransientLimitIncrease: noLimitIncrease,
 
 		// Lets get out of the way of the allow list functionality.
 		// If someone specified "Swarm.ResourceMgr.Allowlist" we should let it go through.

--- a/core/node/libp2p/rcmgr_logging.go
+++ b/core/node/libp2p/rcmgr_logging.go
@@ -50,11 +50,11 @@ func (n *loggingResourceManager) start(ctx context.Context) {
 				n.limitExceededErrs = make(map[string]int)
 
 				for e, count := range errs {
-					n.logger.Errorf("Resource limits were exceeded %d times with error %q.", count, e)
+					n.logger.Warnf("Resource limits were exceeded %d times with error %q.", count, e)
 				}
 
 				if len(errs) != 0 {
-					n.logger.Errorf("Consider inspecting logs and raising the resource manager limits. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmresourcemgr")
+					n.logger.Warnf("Consider inspecting logs and raising the resource manager limits. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmresourcemgr")
 				}
 
 				n.mut.Unlock()


### PR DESCRIPTION
We are removing system and transient limits by default when ResourceManager is active. We will never be able to define sane defaults for all the cases, and RM is difficult to configure for most users.

Limiting resources per peer is enough to avoid a DoS attack.

Logs are changed to Warn level. Example:

```
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 228 times with error "peer:12D3KooWAwJn4B1TDmw2M6Fx7ueGM9NAjHDUmp5x99xCxnfYm8Rx: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 148 times with error "peer:12D3KooWJWuTqC64UMd1sGKPxk7G9R6wy6GtzYnxwVpBwG2KQP4E: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 173 times with error "peer:12D3KooWRqk15Ep9iMEhAESdMaRmrs5ZR1UjFKehDJctyVnu74NT: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 55 times with error "peer:12D3KooWM5sNTkwTG1a9ZMmpbhoY6cCJkH1ciYCGjKhDWq64QPt2: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 144 times with error "peer:12D3KooWQ9ydrk2cQ18tL3GjjsDBdJtHgJAUcVYCuh3qRhZurX4T: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 73 times with error "peer:12D3KooWRSwBCxSqPsnor88RUyMPU1KhEATcZKsarKYJXTvn7d6v: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 249 times with error "peer:12D3KooWK4xPjV19Nm2YWxhk95RjbSLkdCM4wJSxaEWfnU1nVxK1: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 36 times with error "peer:12D3KooWHYecdfScc8uASPUF57WDMXYKkrcvhEN1KgUJeNPnVmsH: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 175 times with error "peer:12D3KooWDForzWi8v63RuEdbV1BSYf497uwvedGr2tECx7i98koN: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 269 times with error "peer:12D3KooWAmTLXf6R94meS5QwY6E5PNxojr8wJ2eWaUSLN2MQgsAm: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 423 times with error "peer:12D3KooWB5ZghciXT1r8y4X1mBqrxSzgEKVpcXqoPgy91T9uJaCU: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 205 times with error "peer:12D3KooWRRMnA99zavmn7ZC3eVYwDfQHpRT9jEMhGLW8BQmGNddX: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:53	Resource limits were exceeded 294 times with error "peer:12D3KooWQBeqmfAmB1yRvLBMRLmc8oPSGsiL9Roqo57y9cjbU7fM: cannot reserve inbound stream: resource limit exceeded".
2022-12-01T18:35:26.983+0100	WARN	resourcemanager	libp2p/rcmgr_logging.go:57	Consider inspecting logs and raising the resource manager limits. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmresourcemgr
```


Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>