### PR TITLE
fix(rcmgr): improve error phrasing

### DIFF
--- a/core/node/libp2p/rcmgr_logging.go
+++ b/core/node/libp2p/rcmgr_logging.go
@@ -50,7 +50,7 @@ func (n *loggingResourceManager) start(ctx context.Context) {
 				n.limitExceededErrs = make(map[string]int)
 
 				for e, count := range errs {
-					n.logger.Errorf("Resource limits were exceeded %d times with error %q.", count, e)
+					n.logger.Errorf("Protected from exceeding resource limits %d times: %q.", count, e)
 				}
 
 				if len(errs) != 0 {

--- a/core/node/libp2p/rcmgr_logging_test.go
+++ b/core/node/libp2p/rcmgr_logging_test.go
@@ -55,7 +55,7 @@ func TestLoggingResourceManager(t *testing.T) {
 			if oLogs.Len() == 0 {
 				continue
 			}
-			require.Equal(t, "Resource limits were exceeded 2 times with error \"system: cannot reserve inbound connection: resource limit exceeded\".", oLogs.All()[0].Message)
+			require.Equal(t, "Protected from exceeding resource limits 2 times: \"system: cannot reserve inbound connection: resource limit exceeded\".", oLogs.All()[0].Message)
 			return
 		}
 	}


### PR DESCRIPTION
This PR makes a cosmetic change to message produced by ResourceMgr as suggested in https://github.com/ipfs/kubo/issues/9432#issuecomment-1334160936:


BEFORE:
```
ERROR resourcemanager libp2p/rcmgr_logging.go:53    Resource limits were exceeded 2 times with error "system: cannot reserve inbound connection: resource limit exceeded".
```

AFTER:
```
ERROR resourcemanager libp2p/rcmgr_logging.go:53    Protected from exceeding resource limits 2 times: "system: cannot reserve inbound connection: resource limit exceeded".
```
