### PR TITLE
docs(readme): unofficial packages badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ $ ipfs get /ipns/dist.ipfs.tech/kubo/$VERSION/kubo_$VERSION_windows-amd64.zip   
 
 ### Unofficial Linux packages
 
+<a href="https://repology.org/project/kubo/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/kubo.svg" alt="Packaging status" align="right">
+</a>
+
 - [Arch Linux](#arch-linux)
 - [Nix](#nix-linux)
 - [Solus](#solus)


### PR DESCRIPTION
Adds a badge based on https://repology.org/project/kubo:

> ![2022-12-02_16-20](https://user-images.githubusercontent.com/157609/205326206-0d933dfb-afdd-40e7-8788-c10c413615f9.png)


Ref. https://repology.org/project/kubo/packages – interesting insight is that Alpine is stuck on 0.8.0, which may explain why  we see so many of  them on the DHT (cc @yiannisbot) 