### PR TITLE
Partial Revert "Revert "fix: ensure hasher is registered when using a hashing function""

### DIFF
--- a/test/sharness/t0042-add-skip.sh
+++ b/test/sharness/t0042-add-skip.sh
@@ -93,6 +93,10 @@ EOF
     test_cmp expected actual
   '
 
+  test_expect_failure "'ipfs add' with an unregistered hash and wrapped leaves fails without crashing" '
+    ipfs add --hash poseidon-bls12_381-a2-fc1 --raw-leaves=false -r mountdir/planets
+  '
+
 }
 
 # should work offline


### PR DESCRIPTION


I was too much trigger happy and caught #9297's regression test in the workaround revert.