### PR TITLE
fix: expose agent-version-suffix via identify protocol

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -26,7 +26,6 @@ import (
 var logger = log.Logger("core:constructor")
 
 var BaseLibP2P = fx.Options(
-	fx.Provide(libp2p.UserAgent),
 	fx.Provide(libp2p.PNet),
 	fx.Provide(libp2p.ConnectionManager),
 	fx.Provide(libp2p.Host),
@@ -133,6 +132,9 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 	// Gather all the options
 	opts := fx.Options(
 		BaseLibP2P,
+
+		// identify's AgentVersion (incl. optional agent-version-suffix)
+		fx.Provide(libp2p.UserAgent()),
 
 		// Services (resource management)
 		fx.Provide(libp2p.ResourceManager(cfg.Swarm)),

--- a/core/node/libp2p/libp2p.go
+++ b/core/node/libp2p/libp2p.go
@@ -25,8 +25,6 @@ type Libp2pOpts struct {
 	Opts []libp2p.Option `group:"libp2p"`
 }
 
-var UserAgent = simpleOpt(libp2p.UserAgent(version.GetUserAgentVersion()))
-
 func ConnectionManager(low, high int, grace time.Duration) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
 		cm, err := connmgr.NewConnManager(low, high, connmgr.WithGracePeriod(grace))
@@ -44,6 +42,10 @@ func PstoreAddSelfKeys(id peer.ID, sk crypto.PrivKey, ps peerstore.Peerstore) er
 	}
 
 	return ps.AddPrivKey(id, sk)
+}
+
+func UserAgent() func() (opts Libp2pOpts, err error) {
+	return simpleOpt(libp2p.UserAgent(version.GetUserAgentVersion()))
 }
 
 func simpleOpt(opt libp2p.Option) func() (opts Libp2pOpts, err error) {


### PR DESCRIPTION
This PR fixes  #9456 and adds end-to-end test which confirms suffix is exposed over [identify](https://github.com/libp2p/specs/tree/master/identify) protocol.

Pinging bunch of folks for review / FYI.

## Sad details

`--agent-version-suffix` introduced in https://github.com/ipfs/kubo/pull/8419 was not applied when `libp2p.UserAgent` was initialized, which meant the suffix was always absent from libp2p's [identify](https://github.com/libp2p/specs/tree/master/identify) protocol.  


The result: [we were not getting information about `/brave` `/desktop` and `/docker` nodes :'(](https://user-images.githubusercontent.com/157609/205760808-8a1e0cb5-21f6-4ad4-8508-0d48d0591ab4.jpg)  
Good news is that Kubo 0.18.0-rc1 will have this fixed, unblocking https://github.com/protocol/network-measurements/issues/24


## TODO

- [x] fix
- [x] end-to-end test over libp2p identify protocol
- [x] CI is green (fix things that assumed old agentVersion)