### PR TITLE
feat(connmgr): lower the default connection pool

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -96,11 +96,11 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 
 // DefaultConnMgrHighWater is the default value for the connection managers
 // 'high water' mark
-const DefaultConnMgrHighWater = 900
+const DefaultConnMgrHighWater = 150
 
 // DefaultConnMgrLowWater is the default value for the connection managers 'low
 // water' mark
-const DefaultConnMgrLowWater = 600
+const DefaultConnMgrLowWater = 50
 
 // DefaultConnMgrGracePeriod is the default value for the connection managers
 // grace period

--- a/docs/config.md
+++ b/docs/config.md
@@ -1768,7 +1768,7 @@ The connection manager considers a connection idle if:
 LowWater is the number of connections that the basic connection manager will
 trim down to.
 
-Default: `600`
+Default: `50`
 
 Type: `optionalInteger`
 
@@ -1778,7 +1778,7 @@ HighWater is the number of connections that, when exceeded, will trigger a
 connection GC operation. Note: protected/recently formed connections don't count
 towards this limit.
 
-Default: `900`
+Default: `150`
 
 Type: `optionalInteger`
 


### PR DESCRIPTION
This PR aims to close #9420 by lowering the implicit defaults for `Swarm.ConnMgr`.

## Rationale

It will not only help with https://github.com/ipfs/kubo/issues/9442 but also decrease bitswap gossip.

To apply change to legacy nodes that were initialized before https://github.com/ipfs/kubo/pull/8913, we need to perform config migration described in https://github.com/ipfs/kubo/pull/8913#pullrequestreview-1176651149

## TODO

- [x] lower high water (50 for now)
- [x] lower low water  (150 for now)
- [x] update docs
- [ ] create  config migration (set `Swarm.ConnMgr` to `{}` if values match old defaults)
  - this has to be done in https://github.com/ipfs/fs-repo-migrations – not blocking review of this PR
