### PR TITLE
Fix: RM: Improve init RM message and fix final memory value.

### DIFF
--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -112,7 +112,7 @@ func ResourceManager(cfg config.SwarmConfig) interface{} {
 			lrm.start(helpers.LifecycleCtx(mctx, lc))
 			manager = lrm
 		} else {
-			log.Debug("libp2p resource manager is disabled")
+			fmt.Println("go-libp2p resource manager protection disabled")
 			manager = network.NullResourceManager
 		}
 

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -58,7 +58,7 @@ func createDefaultLimitConfig(cfg config.SwarmConfig) (rcmgr.LimitConfig, error)
 
 	// We want to see this message on startup, that's why we are using fmt instead of log.
 	fmt.Printf(`
-Computing default go-libp2p Resource Manager limits based on: 
+Computing default go-libp2p Resource Manager limits based on:
     - 'Swarm.ResourceMgr.MaxMemory': %q
     - 'Swarm.ResourceMgr.MaxFileDescriptors': %d
 

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -1,6 +1,8 @@
 package libp2p
 
 import (
+	"fmt"
+
 	"github.com/dustin/go-humanize"
 	"github.com/libp2p/go-libp2p"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
@@ -54,10 +56,21 @@ func createDefaultLimitConfig(cfg config.SwarmConfig) (rcmgr.LimitConfig, error)
 
 	numFD := cfg.ResourceMgr.MaxFileDescriptors.WithDefault(int64(fd.GetNumFDs()) / 2)
 
+	// We want to see this message on startup, that's why we are using fmt instead of log.
+	fmt.Printf(`
+Computing default go-libp2p Resource Manager limits based on: 
+    - 'Swarm.ResourceMgr.MaxMemory': %q
+    - 'Swarm.ResourceMgr.MaxFileDescriptors': %d
+
+Applying any user-supplied overrides on top.
+Run 'ipfs swarm limit all' to see the resulting limits.
+
+`, maxMemoryString, numFD)
+
 	scalingLimitConfig := rcmgr.ScalingLimitConfig{
 		SystemBaseLimit: rcmgr.BaseLimit{
-			Memory: int64(maxMemory),
-			FD:     int(numFD),
+			Memory: rcmgr.DefaultLimits.SystemBaseLimit.Memory,
+			FD:     rcmgr.DefaultLimits.SystemBaseLimit.FD,
 
 			// By default, we just limit connections on the inbound side.
 			Conns:         bigEnough,

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -69,8 +69,8 @@ Run 'ipfs swarm limit all' to see the resulting limits.
 
 	scalingLimitConfig := rcmgr.ScalingLimitConfig{
 		SystemBaseLimit: rcmgr.BaseLimit{
-			Memory: rcmgr.DefaultLimits.SystemBaseLimit.Memory,
-			FD:     rcmgr.DefaultLimits.SystemBaseLimit.FD,
+			Memory: int64(maxMemory),
+			FD:     int(numFD),
 
 			// By default, we just limit connections on the inbound side.
 			Conns:         bigEnough,
@@ -87,8 +87,8 @@ Run 'ipfs swarm limit all' to see the resulting limits.
 		// Most limits don't see an increase because they're already infinite/bigEnough or at their max value.
 		// The values that should scale based on the amount of memory allocated to libp2p need to increase accordingly.
 		SystemLimitIncrease: rcmgr.BaseLimitIncrease{
-			Memory:     rcmgr.DefaultLimits.SystemLimitIncrease.Memory,
-			FDFraction: rcmgr.DefaultLimits.SystemLimitIncrease.FDFraction,
+			Memory:     0,
+			FDFraction: 0,
 
 			Conns:         0,
 			ConnsInbound:  rcmgr.DefaultLimits.SystemLimitIncrease.ConnsInbound,

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -76,6 +76,12 @@ test_expect_success "ipfs daemon output looks good" '
   STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" &&
   echo "Initializing daemon..." >expected_daemon &&
   ipfs version --all >> expected_daemon &&
+  echo "Computing default go-libp2p Resource Manager limits based on:" >>expected_daemon &&
+  echo "    - 'Swarm.ResourceMgr.MaxMemory': \"4.2 GB\"" >>expected_daemon &&
+  echo "    - 'Swarm.ResourceMgr.MaxFileDescriptors': 1024" >>expected_daemon &&
+  echo "" >>expected_daemon &&
+  echo "Applying any user-supplied overrides on top." >>expected_daemon &&
+  echo "Run 'ipfs swarm limit all' to see the resulting limits." >>expected_daemon &&
   sed "s/^/Swarm listening on /" listen_addrs >>expected_daemon &&
   sed "s/^/Swarm announcing /" local_addrs >>expected_daemon &&
   echo "API server listening on '$API_MADDR'" >>expected_daemon &&

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -43,6 +43,10 @@ test_expect_success "cleanup repo" '
 '
 
 test_init_ipfs
+test_expect_success "set Resource Manager variables showed at startup" '
+    ipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 1024 &&
+    ipfs config Swarm.ResourceMgr.MaxMemory 4GB
+'
 test_launch_ipfs_daemon
 
 # this errors if we didn't --init $IPFS_PATH correctly
@@ -73,15 +77,17 @@ test_expect_success "ipfs gateway works with the correct allowed origin port" '
 '
 
 test_expect_success "ipfs daemon output looks good" '
-  STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" &&
+  STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" 
   echo "Initializing daemon..." >expected_daemon &&
   ipfs version --all >> expected_daemon &&
+  echo "" >>expected_daemon &&
   echo "Computing default go-libp2p Resource Manager limits based on:" >>expected_daemon &&
-  echo "    - '"'"'Swarm.ResourceMgr.MaxMemory'"'"': \"4.2 GB\"" >>expected_daemon &&
+  echo "    - '"'"'Swarm.ResourceMgr.MaxMemory'"'"': \"4GB\"" >>expected_daemon &&
   echo "    - '"'"'Swarm.ResourceMgr.MaxFileDescriptors'"'"': 1024" >>expected_daemon &&
   echo "" >>expected_daemon &&
   echo "Applying any user-supplied overrides on top." >>expected_daemon &&
   echo "Run '"'"'ipfs swarm limit all'"'"' to see the resulting limits." >>expected_daemon &&
+  echo "" >>expected_daemon &&
   sed "s/^/Swarm listening on /" listen_addrs >>expected_daemon &&
   sed "s/^/Swarm announcing /" local_addrs >>expected_daemon &&
   echo "API server listening on '$API_MADDR'" >>expected_daemon &&

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -77,11 +77,11 @@ test_expect_success "ipfs daemon output looks good" '
   echo "Initializing daemon..." >expected_daemon &&
   ipfs version --all >> expected_daemon &&
   echo "Computing default go-libp2p Resource Manager limits based on:" >>expected_daemon &&
-  echo "    - 'Swarm.ResourceMgr.MaxMemory': \"4.2 GB\"" >>expected_daemon &&
-  echo "    - 'Swarm.ResourceMgr.MaxFileDescriptors': 1024" >>expected_daemon &&
+  echo "    - '"'"'Swarm.ResourceMgr.MaxMemory'"'"': \"4.2 GB\"" >>expected_daemon &&
+  echo "    - '"'"'Swarm.ResourceMgr.MaxFileDescriptors'"'"': 1024" >>expected_daemon &&
   echo "" >>expected_daemon &&
   echo "Applying any user-supplied overrides on top." >>expected_daemon &&
-  echo "Run 'ipfs swarm limit all' to see the resulting limits." >>expected_daemon &&
+  echo "Run '"'"'ipfs swarm limit all'"'"' to see the resulting limits." >>expected_daemon &&
   sed "s/^/Swarm listening on /" listen_addrs >>expected_daemon &&
   sed "s/^/Swarm announcing /" local_addrs >>expected_daemon &&
   echo "API server listening on '$API_MADDR'" >>expected_daemon &&

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -77,7 +77,7 @@ test_expect_success "ipfs gateway works with the correct allowed origin port" '
 '
 
 test_expect_success "ipfs daemon output looks good" '
-  STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" 
+  STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" &&
   echo "Initializing daemon..." >expected_daemon &&
   ipfs version --all >> expected_daemon &&
   echo "" >>expected_daemon &&


### PR DESCRIPTION
Improved init message explaining what RM is doing. Output example:
```
Initializing daemon...
Kubo version: 0.18.0-dev-a3913d9f9-dirty
Repo version: 12
System version: amd64/linux
Golang version: go1.19.3

Computing default go-libp2p Resource Manager limits based on: 
    - 'Swarm.ResourceMgr.MaxMemory': "8GB"
    - 'Swarm.ResourceMgr.MaxFileDescriptors': 524288

Applying any user-supplied overrides on top.
Run 'ipfs swarm limit all' to see the resulting limits.

Swarm listening on /ip4/127.0.0.1/tcp/4001
Swarm listening on /ip4/127.0.0.1/udp/4001/quic
Swarm listening on /ip4/16.0.0.1/tcp/4001
Swarm listening on /ip4/16.0.0.1/udp/4001/quic
Swarm listening on /ip4/16.1.0.1/tcp/4001
Swarm listening on /ip4/16.1.0.1/udp/4001/quic
Swarm listening on /ip4/16.10.0.1/tcp/4001
Swarm listening on /ip4/16.10.0.1/udp/4001/quic
Swarm listening on /ip4/16.11.0.1/tcp/4001
Swarm listening on /ip4/16.11.0.1/udp/4001/quic
Swarm listening on /ip4/16.12.0.1/tcp/4001
Swarm listening on /ip4/16.12.0.1/udp/4001/quic
```

Also fixed the computed memory value. When calling `Scale(int64(maxMemory), int(numFD))` method we were adding that memory to the previously configured one at System level. Setting System memory and FD to libp2p default ones. Output example using 8GB as set memory now:

```
ipfs swarm limit system
{
  "Conns": 4611686018427388000,
  "ConnsInbound": 540,
  "ConnsOutbound": 4611686018427388000,
  "FD": 524288,
  "Memory": 8133804032,
  "Streams": 4611686018427388000,
  "StreamsInbound": 8653,
  "StreamsOutbound": 4611686018427388000
}
```

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>