### PR TITLE
Fix: Resource Manager: Filter stats correctly by %

### DIFF
--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -360,6 +360,11 @@ The output of this command is JSON.
 
 		percentage, _ := req.Options[swarmUsedResourcesPercentageName].(int)
 		scope := req.Arguments[0]
+
+		if percentage != 0 && scope != "all" {
+			return fmt.Errorf("%q can only be used when scope is %q", swarmUsedResourcesPercentageName, "all")
+		}
+
 		result, err := libp2p.NetStat(node.ResourceManager, scope, percentage)
 		if err != nil {
 			return err

--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -309,7 +309,7 @@ func abovePercentage(v1, v2, percentage int) bool {
 		return false
 	}
 
-	return int((v1/v2))*100 >= percentage
+	return int((float64(v1)/float64(v2))*100) >= percentage
 }
 
 func NetLimitAll(mgr network.ResourceManager) (*NetStatOut, error) {

--- a/core/node/libp2p/rcmgr_test.go
+++ b/core/node/libp2p/rcmgr_test.go
@@ -1,0 +1,12 @@
+package libp2p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPercentage(t *testing.T) {
+	require.True(t, abovePercentage(10, 100, 10))
+	require.True(t, abovePercentage(100, 100, 99))
+}

--- a/test/sharness/t0139-swarm-rcmgr.sh
+++ b/test/sharness/t0139-swarm-rcmgr.sh
@@ -62,6 +62,11 @@ test_expect_success 'ResourceMgr enabled: swarm limit reset' '
   test_cmp reset actual
 '
 
+test_expect_success 'Swarm stats system with filter should fail' '
+  test_expect_code 1 ipfs swarm stats system --min-used-limit-perc=99 2> actual &&
+  test_should_contain "Error: \"min-used-limit-perc\" can only be used when scope is \"all\"" actual
+'
+
 test_expect_success 'ResourceMgr enabled: swarm limit reset on map values' '
   ipfs swarm limit peer:12D3KooWL7i1T9VSPeF8AgQApbyM51GNKZsYPvNvL347aMDmvNzG --reset --enc=json 2> reset &&
   ipfs swarm limit peer:12D3KooWL7i1T9VSPeF8AgQApbyM51GNKZsYPvNvL347aMDmvNzG --enc=json 2> actual &&


### PR DESCRIPTION
As per https://github.com/ipfs/kubo/issues/9001 `min-used-limit-perc` was intended to be used only on the `all` scope.

Fixed the percentage calculation to be more precise and added a sharness test checking error output.

It closes https://github.com/ipfs/kubo/issues/9473

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>