### PR TITLE
feat: fast directory listings with DAG Size column

### DIFF
--- a/assets/dir-index-html/dir-index.html
+++ b/assets/dir-index-html/dir-index.html
@@ -53,9 +53,6 @@
           {{ .Hash }}
         </div>
         {{ end }}
-        <p style="margin-bottom: 0">
-          <a rel="nofollow, noindex" href="?format=json">Preview as JSON.</a> Download as: <a rel="nofollow, noindex" href="?format=car">CAR</a>, <a rel="nofollow, noindex" href="?format=tar">TAR</a>, <a rel="nofollow, noindex" href="?format=dag-json">DAG-JSON</a>, <a rel="nofollow, noindex" href="?format=dag-cbor">DAG-CBOR</a>.
-        </p>
       </div>
       {{ if .Size }}
       <div class="no-linebreak flex-shrink-1 ml-auto">

--- a/assets/dir-index-html/dir-index.html
+++ b/assets/dir-index-html/dir-index.html
@@ -53,10 +53,13 @@
           {{ .Hash }}
         </div>
         {{ end }}
+        <p style="margin-bottom: 0">
+          <a rel="nofollow, noindex" href="?format=json">Preview as JSON.</a> Download as: <a rel="nofollow, noindex" href="?format=car">CAR</a>, <a rel="nofollow, noindex" href="?format=tar">TAR</a>, <a rel="nofollow, noindex" href="?format=dag-json">DAG-JSON</a>, <a rel="nofollow, noindex" href="?format=dag-cbor">DAG-CBOR</a>.
+        </p>
       </div>
       {{ if .Size }}
       <div class="no-linebreak flex-shrink-1 ml-auto">
-        <strong>&nbsp;{{ .Size }}</strong>
+        <strong title="Cumulative size of IPFS DAG (data + metadata)">&nbsp;{{ .Size }}</strong>
       </div>
       {{ end }}
     </div>
@@ -89,7 +92,7 @@
           </a>
           {{ end }}
         </td>
-        <td class="no-linebreak">{{ .Size }}</td>
+        <td class="no-linebreak" title="Cumulative size of IPFS DAG (data + metadata)">{{ .Size }}</td>
       </tr>
       {{ end }}
     </table>

--- a/assets/dir-index-html/src/dir-index.html
+++ b/assets/dir-index-html/src/dir-index.html
@@ -52,10 +52,13 @@
           {{ .Hash }}
         </div>
         {{ end }}
+        <p style="margin-bottom: 0">
+          <a rel="nofollow, noindex" href="?format=json">Preview as JSON.</a> Download as: <a rel="nofollow, noindex" href="?format=car">CAR</a>, <a rel="nofollow, noindex" href="?format=tar">TAR</a>, <a rel="nofollow, noindex" href="?format=dag-json">DAG-JSON</a>, <a rel="nofollow, noindex" href="?format=dag-cbor">DAG-CBOR</a>.
+        </p>
       </div>
       {{ if .Size }}
       <div class="no-linebreak flex-shrink-1 ml-auto">
-        <strong>&nbsp;{{ .Size }}</strong>
+        <strong title="Cumulative size of IPFS DAG (data + metadata)">&nbsp;{{ .Size }}</strong>
       </div>
       {{ end }}
     </div>
@@ -88,7 +91,7 @@
           </a>
           {{ end }}
         </td>
-        <td class="no-linebreak">{{ .Size }}</td>
+        <td class="no-linebreak" title="Cumulative size of IPFS DAG (data + metadata)">{{ .Size }}</td>
       </tr>
       {{ end }}
     </table>

--- a/assets/dir-index-html/src/dir-index.html
+++ b/assets/dir-index-html/src/dir-index.html
@@ -52,9 +52,6 @@
           {{ .Hash }}
         </div>
         {{ end }}
-        <p style="margin-bottom: 0">
-          <a rel="nofollow, noindex" href="?format=json">Preview as JSON.</a> Download as: <a rel="nofollow, noindex" href="?format=car">CAR</a>, <a rel="nofollow, noindex" href="?format=tar">TAR</a>, <a rel="nofollow, noindex" href="?format=dag-json">DAG-JSON</a>, <a rel="nofollow, noindex" href="?format=dag-cbor">DAG-CBOR</a>.
-        </p>
       </div>
       {{ if .Size }}
       <div class="no-linebreak flex-shrink-1 ml-auto">

--- a/assets/dir-index-html/test/main.go
+++ b/assets/dir-index-html/test/main.go
@@ -12,15 +12,14 @@ const templateFile = "../dir-index.html"
 
 // Copied from go-ipfs/core/corehttp/gateway_indexPage.go
 type listingTemplateData struct {
-	GatewayURL            string
-	DNSLink               bool
-	Listing               []directoryItem
-	Size                  string
-	Path                  string
-	Breadcrumbs           []breadcrumb
-	BackLink              string
-	Hash                  string
-	FastDirIndexThreshold int
+	GatewayURL  string
+	DNSLink     bool
+	Listing     []directoryItem
+	Size        string
+	Path        string
+	Breadcrumbs []breadcrumb
+	BackLink    string
+	Hash        string
 }
 
 type directoryItem struct {

--- a/config/gateway.go
+++ b/config/gateway.go
@@ -45,14 +45,6 @@ type Gateway struct {
 	// PathPrefixes was removed: https://github.com/ipfs/go-ipfs/issues/7702
 	PathPrefixes []string
 
-	// FastDirIndexThreshold is the maximum number of items in a directory
-	// before the Gateway switches to a shallow, faster listing which only
-	// requires the root node. This allows for listing big directories fast,
-	// without the linear slowdown caused by reading size metadata from child
-	// nodes.
-	// Setting to 0 will enable fast listings for all directories.
-	FastDirIndexThreshold *OptionalInteger `json:",omitempty"`
-
 	// FIXME: Not yet implemented: https://github.com/ipfs/kubo/issues/8059
 	APICommands []string
 

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -18,9 +18,8 @@ import (
 )
 
 type GatewayConfig struct {
-	Headers               map[string][]string
-	Writable              bool
-	FastDirIndexThreshold int
+	Headers  map[string][]string
+	Writable bool
 }
 
 // NodeAPI defines the minimal set of API services required by a gateway handler
@@ -83,9 +82,8 @@ func GatewayOption(writable bool, paths ...string) ServeOption {
 		}
 
 		gateway := NewGatewayHandler(GatewayConfig{
-			Headers:               headers,
-			Writable:              writable,
-			FastDirIndexThreshold: int(cfg.Gateway.FastDirIndexThreshold.WithDefault(100)),
+			Headers:  headers,
+			Writable: writable,
 		}, api, offlineAPI)
 
 		gateway = otelhttp.NewHandler(gateway, "Gateway.Request")

--- a/core/corehttp/gateway_indexPage.go
+++ b/core/corehttp/gateway_indexPage.go
@@ -12,15 +12,14 @@ import (
 
 // structs for directory listing
 type listingTemplateData struct {
-	GatewayURL            string
-	DNSLink               bool
-	Listing               []directoryItem
-	Size                  string
-	Path                  string
-	Breadcrumbs           []breadcrumb
-	BackLink              string
-	Hash                  string
-	FastDirIndexThreshold int
+	GatewayURL  string
+	DNSLink     bool
+	Listing     []directoryItem
+	Size        string
+	Path        string
+	Breadcrumbs []breadcrumb
+	BackLink    string
+	Hash        string
 }
 
 type directoryItem struct {

--- a/docs/changelogs/v0.18.md
+++ b/docs/changelogs/v0.18.md
@@ -11,6 +11,7 @@ Below is an outline of all that is in this release, so you get a sense of all th
     - [Overview](#overview)
     - [🔦 Highlights](#-highlights)
       - [(DAG-)JSON and (DAG-)CBOR Response Formats on Gateways](#dag-json-and-dag-cbor-response-formats-on-gateways)
+      - [🐎 Fast directory listings with DAG sizes](#-fast-directory-listings-with-dag-sizes)
       - [Content Routing](#content-routing)
       - [Provider Record Republish and Expiration](#provider-record-republish-and-expiration)
       - [Lowered `ConnMgr`](#lowered-connmgr)
@@ -71,6 +72,16 @@ $ curl "http://127.0.0.1:8080/ipfs/$DIR_CID?format=dag-json" | jq
 }
 ```
 
+#### 🐎 Fast directory listings with DAG sizes
+
+Fast listings are now enabled for _all_ UnixFS directories: big and small.
+There is no linear slowdown caused by reading size metadata from child nodes,
+and the size of DAG representing child items is always present.
+
+As an example, the CID
+`bafybeiggvykl7skb2ndlmacg2k5modvudocffxjesexlod2pfvg5yhwrqm` represents UnixFS
+directory with over 10k (10100) of files. Listing big directories was fast
+since Kubo 0.13, but in this release it will also include the size column.
 
 #### Content Routing
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -672,7 +672,7 @@ Type: `string` (url)
 
 ### `Gateway.FastDirIndexThreshold`
 
-**REMOVED**: this option is [no longer necessary](https://github.com/ipfs/kubo/pull/9481).
+**REMOVED**: this option is [no longer necessary](https://github.com/ipfs/kubo/pull/9481). Ignored since  [Kubo 0.18](https://github.com/ipfs/kubo/blob/master/docs/changelogs/v0.18.md).
 
 ### `Gateway.Writable`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -672,17 +672,7 @@ Type: `string` (url)
 
 ### `Gateway.FastDirIndexThreshold`
 
-The maximum number of items in a directory before the Gateway switches
-to a shallow, faster listing which only requires the root node.
-
-This allows for fast listings of big directories, without the linear slowdown caused
-by reading size metadata from child nodes.
-
-Setting to 0 will enable fast listings for all directories.
-
-Default: `100`
-
-Type: `optionalInteger`
+**REMOVED**: this option is [no longer necessary](https://github.com/ipfs/kubo/pull/9481).
 
 ### `Gateway.Writable`
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -8,7 +8,7 @@ replace github.com/ipfs/kubo => ./../../..
 
 require (
 	github.com/ipfs/go-ipfs-files v0.2.0
-	github.com/ipfs/interface-go-ipfs-core v0.8.0
+	github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de
 	github.com/ipfs/kubo v0.14.0-rc1
 	github.com/libp2p/go-libp2p v0.24.1
 	github.com/multiformats/go-multiaddr v0.8.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -8,7 +8,7 @@ replace github.com/ipfs/kubo => ./../../..
 
 require (
 	github.com/ipfs/go-ipfs-files v0.2.0
-	github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de
+	github.com/ipfs/interface-go-ipfs-core v0.8.1
 	github.com/ipfs/kubo v0.14.0-rc1
 	github.com/libp2p/go-libp2p v0.24.1
 	github.com/multiformats/go-multiaddr v0.8.0

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -598,8 +598,8 @@ github.com/ipfs/go-unixfsnode v1.4.0/go.mod h1:qc7YFFZ8tABc58p62HnIYbUMwj9chhUuF
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
-github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de h1:kTwHlLEF+YvFh9vQe786MIP4S3Rzs4yRy7KDsvarHQE=
-github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
+github.com/ipfs/interface-go-ipfs-core v0.8.1 h1:nuFG0YJ429Wd5gtRb3ivlblpknZ5VfDVKZkmOG2TnNQ=
+github.com/ipfs/interface-go-ipfs-core v0.8.1/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
 github.com/ipld/edelweiss v0.2.0 h1:KfAZBP8eeJtrLxLhi7r3N0cBCo7JmwSRhOJp3WSpNjk=
 github.com/ipld/edelweiss v0.2.0/go.mod h1:FJAzJRCep4iI8FOFlRriN9n0b7OuX3T/S9++NpBDmA4=
 github.com/ipld/go-car v0.4.0 h1:U6W7F1aKF/OJMHovnOVdst2cpQE5GhmHibQkAixgNcQ=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -598,8 +598,8 @@ github.com/ipfs/go-unixfsnode v1.4.0/go.mod h1:qc7YFFZ8tABc58p62HnIYbUMwj9chhUuF
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
-github.com/ipfs/interface-go-ipfs-core v0.8.0 h1:pNs34l947fvNOh+XEjXnHW/GV6HXmEzJNeqZFhX4GoQ=
-github.com/ipfs/interface-go-ipfs-core v0.8.0/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
+github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de h1:kTwHlLEF+YvFh9vQe786MIP4S3Rzs4yRy7KDsvarHQE=
+github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
 github.com/ipld/edelweiss v0.2.0 h1:KfAZBP8eeJtrLxLhi7r3N0cBCo7JmwSRhOJp3WSpNjk=
 github.com/ipld/edelweiss v0.2.0/go.mod h1:FJAzJRCep4iI8FOFlRriN9n0b7OuX3T/S9++NpBDmA4=
 github.com/ipld/go-car v0.4.0 h1:U6W7F1aKF/OJMHovnOVdst2cpQE5GhmHibQkAixgNcQ=

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/ipfs/go-unixfs v0.4.1
 	github.com/ipfs/go-unixfsnode v1.4.0
 	github.com/ipfs/go-verifcid v0.0.2
-	github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de
+	github.com/ipfs/interface-go-ipfs-core v0.8.1
 	github.com/ipld/go-car v0.4.0
 	github.com/ipld/go-car/v2 v2.4.0
 	github.com/ipld/go-codec-dagpb v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/ipfs/go-unixfs v0.4.1
 	github.com/ipfs/go-unixfsnode v1.4.0
 	github.com/ipfs/go-verifcid v0.0.2
-	github.com/ipfs/interface-go-ipfs-core v0.8.0
+	github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de
 	github.com/ipld/go-car v0.4.0
 	github.com/ipld/go-car/v2 v2.4.0
 	github.com/ipld/go-codec-dagpb v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/ipfs/go-unixfsnode v1.4.0/go.mod h1:qc7YFFZ8tABc58p62HnIYbUMwj9chhUuF
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
-github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de h1:kTwHlLEF+YvFh9vQe786MIP4S3Rzs4yRy7KDsvarHQE=
-github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
+github.com/ipfs/interface-go-ipfs-core v0.8.1 h1:nuFG0YJ429Wd5gtRb3ivlblpknZ5VfDVKZkmOG2TnNQ=
+github.com/ipfs/interface-go-ipfs-core v0.8.1/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
 github.com/ipld/edelweiss v0.2.0 h1:KfAZBP8eeJtrLxLhi7r3N0cBCo7JmwSRhOJp3WSpNjk=
 github.com/ipld/edelweiss v0.2.0/go.mod h1:FJAzJRCep4iI8FOFlRriN9n0b7OuX3T/S9++NpBDmA4=
 github.com/ipld/go-car v0.4.0 h1:U6W7F1aKF/OJMHovnOVdst2cpQE5GhmHibQkAixgNcQ=

--- a/go.sum
+++ b/go.sum
@@ -625,8 +625,8 @@ github.com/ipfs/go-unixfsnode v1.4.0/go.mod h1:qc7YFFZ8tABc58p62HnIYbUMwj9chhUuF
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvTs=
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
-github.com/ipfs/interface-go-ipfs-core v0.8.0 h1:pNs34l947fvNOh+XEjXnHW/GV6HXmEzJNeqZFhX4GoQ=
-github.com/ipfs/interface-go-ipfs-core v0.8.0/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
+github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de h1:kTwHlLEF+YvFh9vQe786MIP4S3Rzs4yRy7KDsvarHQE=
+github.com/ipfs/interface-go-ipfs-core v0.8.1-0.20221212114405-7339703fa9de/go.mod h1:WYC2H6Mu7aGqhlupi/CVawcs0X1Me4uRvV0rcTlo3zM=
 github.com/ipld/edelweiss v0.2.0 h1:KfAZBP8eeJtrLxLhi7r3N0cBCo7JmwSRhOJp3WSpNjk=
 github.com/ipld/edelweiss v0.2.0/go.mod h1:FJAzJRCep4iI8FOFlRriN9n0b7OuX3T/S9++NpBDmA4=
 github.com/ipld/go-car v0.4.0 h1:U6W7F1aKF/OJMHovnOVdst2cpQE5GhmHibQkAixgNcQ=

--- a/test/sharness/t0115-gateway-dir-listing.sh
+++ b/test/sharness/t0115-gateway-dir-listing.sh
@@ -164,28 +164,6 @@ test_expect_success "dnslink gw: hash column should be a CID link to cid.ipfs.te
 '
 
 ## ============================================================================
-## Test dir listing of a big directory
-## ============================================================================
-
-test_expect_success "dir listing should resolve child sizes if under Gateway.FastDirIndexThreshold" '
-  curl -sD - http://127.0.0.1:$GWAY_PORT/ipfs/${DIR_CID}/ą/ę/ | tee list_response &&
-  test_should_contain "/ipfs/${FILE_CID}?filename" list_response &&
-  test_should_contain ">${FILE_SIZE} B</td>" list_response
-'
-
-# force fast dir index for all responses
-ipfs config --json Gateway.FastDirIndexThreshold 0
-# restart daemon to apply config changes
-test_kill_ipfs_daemon
-test_launch_ipfs_daemon
-
-test_expect_success "dir listing should not resolve child sizes beyond Gateway.FastDirIndexThreshold" '
-  curl -sD - http://127.0.0.1:$GWAY_PORT/ipfs/${DIR_CID}/ą/ę/ | tee list_response &&
-  test_should_contain "/ipfs/${FILE_CID}?filename" list_response &&
-  test_should_not_contain ">${FILE_SIZE} B</td>" list_response
-'
-
-## ============================================================================
 ## End of tests, cleanup
 ## ============================================================================
 


### PR DESCRIPTION
Closes #9058.

## Checklist

- [x] ~Use `.Dag.Get` instead of `.Unixfs.Ls` to fetch the directories (take into consideration sharded)~
	- [x] Instead, improved `Unixfs.Ls` with `UseCumulativeSize` to use the DAG Size, but skip remaining calculations. See [comment](https://github.com/ipfs/kubo/pull/9481#discussion_r1043420367).
- [x] Remove `Gateway.FastDirIndexThreshold` option as it is no longer relevant
- [x] <del>Add "Preview as" and "Download as" buttons to the listing header with multiple formats. </del> descoped  for now
- [x] Tooltip on Size with explanation.
- [x] https://github.com/ipfs/interface-go-ipfs-core/pull/95
	- [x] Approved, merged and released
	- [x] Dependency updated here

![image](https://user-images.githubusercontent.com/5447088/206458356-2495b22f-221a-42df-b80c-d510046356f2.png)

Loads `bafybeiggvykl7skb2ndlmacg2k5modvudocffxjesexlod2pfvg5yhwrqm` (10k items) extremely fast, and with size!