### PR TITLE
feat: adjust ConnMgr to 32/96

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -96,11 +96,11 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 
 // DefaultConnMgrHighWater is the default value for the connection managers
 // 'high water' mark
-const DefaultConnMgrHighWater = 150
+const DefaultConnMgrHighWater = 96
 
 // DefaultConnMgrLowWater is the default value for the connection managers 'low
 // water' mark
-const DefaultConnMgrLowWater = 50
+const DefaultConnMgrLowWater = 32
 
 // DefaultConnMgrGracePeriod is the default value for the connection managers
 // grace period

--- a/docs/config.md
+++ b/docs/config.md
@@ -1774,7 +1774,7 @@ The connection manager considers a connection idle if:
 LowWater is the number of connections that the basic connection manager will
 trim down to.
 
-Default: `50`
+Default: `32`
 
 Type: `optionalInteger`
 
@@ -1784,7 +1784,7 @@ HighWater is the number of connections that, when exceeded, will trigger a
 connection GC operation. Note: protected/recently formed connections don't count
 towards this limit.
 
-Default: `150`
+Default: `96`
 
 Type: `optionalInteger`
 


### PR DESCRIPTION
This is follow-up for https://github.com/ipfs/kubo/pull/9467

## Rationale

https://github.com/ipfs/kubo/pull/9467#issuecomment-1341678826 from @BigLep :

>  I sanity checked the number of Low=50, High=150
> 
> By default if a Kubo node has 8GB of total memory, a maxMemory for libp2p will be set to 2GB.  That will cause System.ConnsInbound to be 128 I believe (looks like 64 per GB of memory here: https://github.com/libp2p/go-libp2p/blob/master/p2p/host/resource-manager/limit_defaults.go#L345 since Kubo is using those same libp2p defaults: https://github.com/ipfs/kubo/blob/master/core/node/libp2p/rcmgr_defaults.go#L94).  As a result, in this particular setup, our high water mark may not get hit (unless there are sufficient outbound connections).  I know there isn't a perfect number here and we have no stats on the systems that folks are using.  I would be in favor of dropping the ConnMgr.High to 120 instead.