### PR TITLE
Removing QRI from early tester

### DIFF
--- a/docs/EARLY_TESTERS.md
+++ b/docs/EARLY_TESTERS.md
@@ -27,7 +27,6 @@ We will ask early testers to participate at two points in the process:
 - [ ] Textile (@sanderpick)
 - [ ] Pinata (@obo20)
 - [ ] RTrade (@postables)
-- [ ] QRI (@b5)
 - [ ] Siderus (@koalalorenzo)
 - [ ] Charity Engine (@rytiss, @tristanolive)
 - [ ] Fission (@bmann)


### PR DESCRIPTION
Removing QRI from early testers since the organization isn't operating.

This came up in https://github.com/ipfs/kubo/issues/9417#issuecomment-1349690750