### PR TITLE
fix(test): stabilize flaky provider tests

### DIFF
--- a/test/sharness/t0175-provider.sh
+++ b/test/sharness/t0175-provider.sh
@@ -22,7 +22,7 @@ test_expect_success 'use strategic providing' '
 startup_cluster ${NUM_NODES}
 
 test_expect_success 'add test object' '
-    HASH_0=$(echo "foo" | ipfsi 0 add -q)
+    HASH_0=$(date +"%FT%T.%N%z" | ipfsi 0 add -q)
 '
 
 findprovs_expect '$HASH_0' '$PEERID_0'

--- a/test/sharness/t0240-republisher.sh
+++ b/test/sharness/t0240-republisher.sh
@@ -74,7 +74,7 @@ num_test_nodes=4
 setup_iptb "$num_test_nodes"
 
 test_expect_success "publish succeeds" '
-  HASH=$(echo "foobar" | ipfsi 1 add -q) &&
+  HASH=$(date +"%FT%T.%N%z" | ipfsi 1 add -q) &&
   ipfsi 1 name publish -t 10s $HASH
 '
 
@@ -99,7 +99,7 @@ KEY2=`ipfsi 1 key gen beepboop --type ed25519`
 '
 
 test_expect_success "publish with new key succeeds" '
-  HASH=$(echo "barfoo" | ipfsi 1 add -q) &&
+  HASH=$(date +"%FT%T.%N%z" | ipfsi 1 add -q) &&
   ipfsi 1 name publish -t 10s -k "$KEY2" $HASH
 '
 

--- a/test/sharness/t0600-issues-and-regressions-online.sh
+++ b/test/sharness/t0600-issues-and-regressions-online.sh
@@ -34,15 +34,15 @@ test_expect_success "metrics work" '
 '
 
 test_expect_success "pin add api looks right - #3753" '
-  HASH=$(echo "foo" | ipfs add -q) &&
+  HASH=$(date +"%FT%T.%N%z" | ipfs add -q) &&
   curl -X POST "http://$API_ADDR/api/v0/pin/add/$HASH" > pinadd_out &&
-  echo "{\"Pins\":[\"QmYNmQKp6SuaVrpgWRsPTgCQCnpxUYGq76YEKBXuj2N4H6\"]}" > pinadd_exp &&
+  echo "{\"Pins\":[\"$HASH\"]}" > pinadd_exp &&
   test_cmp pinadd_out pinadd_exp
 '
 
 test_expect_success "pin add api looks right - #3753" '
   curl -X POST "http://$API_ADDR/api/v0/pin/rm/$HASH" > pinrm_out &&
-  echo "{\"Pins\":[\"QmYNmQKp6SuaVrpgWRsPTgCQCnpxUYGq76YEKBXuj2N4H6\"]}" > pinrm_exp &&
+  echo "{\"Pins\":[\"$HASH\"]}" > pinrm_exp &&
   test_cmp pinrm_out pinrm_exp
 '
 


### PR DESCRIPTION
This PR stabilizes some sharness tests by ensuring deterministic providers exist thanks to unique time-based CID (instead of hardcoded one). 

This should fix failing master.