### PR TITLE
feat: set Bitswap.ProviderSearchDelay to 0s

### DIFF
--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -22,7 +22,7 @@ const (
 	DefaultTaskWorkerCount             = 8
 	DefaultEngineTaskWorkerCount       = 8
 	DefaultMaxOutstandingBytesPerPeer  = 1 << 20
-	DefaultProviderSearchDelay         = 1000 * time.Millisecond
+	DefaultProviderSearchDelay         = 0 * time.Millisecond
 )
 
 type bitswapOptionsOut struct {

--- a/core/node/libp2p/routingopt.go
+++ b/core/node/libp2p/routingopt.go
@@ -89,7 +89,7 @@ func ConstructDefaultRouting(peerID string, addrs []string, privKey string) func
 				Router:       r,
 				IgnoreError:  true,             // https://github.com/ipfs/kubo/pull/9475#discussion_r1042507387
 				Timeout:      15 * time.Second, // 5x server value from https://github.com/ipfs/kubo/pull/9475#discussion_r1042428529
-				ExecuteAfter: 0,
+				ExecuteAfter: 1 * time.Second,  // https://github.com/ipfs/kubo/pull/9530#issuecomment-1385266880
 			})
 		}
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -972,11 +972,15 @@ Type: `optionalInteger` (byte count, `null` means default which is 1MB)
 
 ### `Internal.Bitswap.ProviderSearchDelay`
 
-This parameter determines how long to wait before looking for providers outside of bitswap.
-Other routing systems like the DHT are able to provide results in less than a second, so lowering 
-this number will allow faster peers lookups in some cases.
+Optional delay before looking for providers outside of bitswap,
+using routers configured in [`Routing`](#routing) (e.g., DHT, IPNI).
 
-Type: `optionalDuration` (`null` means default which is 1s)
+Setting to `1s` may decrease the number of DHT and IPNI queries at the cost of
+increased latency. It is advised to keep this unset unless you are confident
+the most of requested data will be provided by [`Peering.Peers`](#peering) over
+bitswap. More details in [kubo#8807](https://github.com/ipfs/kubo/issues/8807).
+
+Type: `optionalDuration` (`null` means default which is `0s`)
 
 ### `Internal.UnixFSShardingSizeThreshold`
 


### PR DESCRIPTION
This PR sets `Bitswap.ProviderSearchDelay` to `0s`, 
effectively removing the delay described in https://github.com/ipfs/kubo/issues/8807

## Rationale

Kubo 0.18 makes two changes that make `1s` no longer a viable default:

1. Connection manager will now aim to maintain ~100 peers instead of ~800 (https://github.com/ipfs/kubo/pull/9483), which makes bitswap-based routing less appealing (https://github.com/ipfs/kubo/issues/8807#issuecomment-1371902976)
1. Default `Routing.Type=auto` (https://github.com/ipfs/kubo/pull/9475) will now use both DHT and IPNI (HTTP router)  in parallel,  which makes non-bitswap routing more appealing, especially for content that is indexed by IPNI.   

This PR removes the delay by setting `Bitswap.ProviderSearchDelay` to `0s`.

## Why 0s and not 200ms

- By default, Kubo 0.18 will keep 8x fewer connections than 0.17.
  This means additional DHT/IPNI lookup cost (~4 additional requests per CID) is still less than the savings around bitswap spam being 1/8 of the old default (Kubo 0.18 NOT sending ~700 bitswap requests).
- Removing all artificial delays sound like a good rule of thumb. We can refine this after benchmarks are run with DHT+IPNI.


## TODO

- [x] set to `0s` 
- [x] update docs
- [x] fix flaky tests
  - tracked in https://github.com/ipfs/kubo/pull/9486

Closes #8807
cc @guillaumemichel @aschmahmann 