### PR TITLE
fix(gateway): JSON when Accept is a list

### DIFF
--- a/test/sharness/t0123-gateway-json-cbor.sh
+++ b/test/sharness/t0123-gateway-json-cbor.sh
@@ -56,6 +56,11 @@ test_dag_pb_headers () {
     test_should_contain "Content-Type: application/$format" curl_output &&
     test_should_not_contain "Content-Type: application/vnd.ipld.dag-$format" curl_output
   '
+
+  test_expect_success "GET UnixFS as $name with 'Accept: foo, application/$format,bar' has expected Content-Type" '
+    curl -sD - -H "Accept: foo, application/$format,text/plain" "http://127.0.0.1:$GWAY_PORT/ipfs/$FILE_CID" > curl_output 2>&1 &&
+    test_should_contain "Content-Type: application/$format" curl_output
+  '
 }
 
 test_dag_pb_headers "DAG-JSON" "json" "inline"


### PR DESCRIPTION
This PR fixes #9520 by adding basic support for `Accept` headers with a list of content types (pick the first matching one).

cc @hacdias if you have time to eyeball – would like to include this in 0.18.

## Context

Block/CAR responses introduced in https://github.com/ipfs/go-ipfs/pull/8758 always had single explicit type, and we did not bother with implementing/testing lists.

With the introduction of JSON  added in https://github.com/ipfs/kubo/pull/9335 (Kubo 0.18) people started passing a list, as noted in #9520.  

Note: this PR does not implement weights because afaik  [golang still does not include this in standard library](https://groups.google.com/g/golang-dev/c/5pOqD2wKpN4/m/G5rfULC2KZ0J), and I wanted to avoid adding dependency like https://github.com/aohorodnyk/mimeheader.  Returning the first match should be good enough for now, as we don't have a use case where the user would like to mix CAR and JSON.

Closes #9520