### PR TITLE
fix: docker image publishing and experimental gh workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Docker image and publish to Docker Hub

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get tags
         id: tags
         run: |
-          echo "value=<<EOF" >> $GITHUB_OUTPUT
+          echo "value<<EOF" >> $GITHUB_OUTPUT
           ./bin/get-docker-tags.sh "$(date -u +%F)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   runner:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    uses: ipfs/kubo/.github/workflows/runner.yml
+    uses: ipfs/kubo/.github/workflows/runner.yml@master
   gobuild:
     needs: [runner]
     runs-on: ${{ fromJSON(needs.runner.outputs.config).labels }}

--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   runner:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    uses: ipfs/kubo/.github/workflows/runner.yml
+    uses: ipfs/kubo/.github/workflows/runner.yml@master
   sharness:
     needs: [runner]
     runs-on: ${{ fromJSON(needs.runner.outputs.config).labels }}


### PR DESCRIPTION
Fixes:
- the way in which we set `tags` step output
- where runner.yml workflow is sourced from

Changes:
- where we retrieve `DOCKER_USERNAME` from