### PR TITLE
fix: do not download saxon in parallel

### DIFF
--- a/test/sharness/Rules.mk
+++ b/test/sharness/Rules.mk
@@ -47,12 +47,17 @@ $(d)/test-results/sharness.xml: $(T_$(d))
 	@(cd $(@D)/.. && ./lib/test-aggregate-junit-reports.sh)
 .PHONY: $(d)/test-results/sharness.xml
 
-$(d)/test-results/sharness-html: $(d)/test-results/sharness.xml
+$(d)/download-saxon:
+	@echo "*** $@ ***"
+	@(cd $(@D) && ./lib/download-saxon.sh)
+.PHONY: $(d)/download-saxon
+
+$(d)/test-results/sharness-html: $(d)/test-results/sharness.xml $(d)/download-saxon
 	@echo "*** $@ ***"
 	@(cd $(@D)/.. && ./lib/test-generate-junit-html.sh frames)
 .PHONY: $(d)/test-results/sharness-html
 
-$(d)/test-results/sharness.html: $(d)/test-results/sharness.xml
+$(d)/test-results/sharness.html: $(d)/test-results/sharness.xml $(d)/download-saxon
 	@echo "*** $@ ***"
 	@(cd $(@D)/.. && ./lib/test-generate-junit-html.sh no-frames)
 .PHONY: $(d)/test-results/sharness.html

--- a/test/sharness/lib/download-saxon.sh
+++ b/test/sharness/lib/download-saxon.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+dependencies=(
+  "url=https://sourceforge.net/projects/saxon/files/Saxon-HE/11/Java/SaxonHE11-4J.zip;md5=8a4783d307c32c898f8995b8f337fd6b"
+  "url=https://raw.githubusercontent.com/pl-strflt/ant/c781f7d79b92cc55530245d9554682a47f46851e/src/etc/junit-frames-saxon.xsl;md5=6eb013566903a91e4959413f6ff144d0"
+  "url=https://raw.githubusercontent.com/pl-strflt/ant/c781f7d79b92cc55530245d9554682a47f46851e/src/etc/junit-noframes-saxon.xsl;md5=8d54882d5f9d32a7743ec675cc2e30ac"
+)
+
+dependenciesdir="lib/dependencies"
+mkdir -p "$dependenciesdir"
+
+get_md5() {
+  md5sum "$1" | cut -d ' ' -f 1
+}
+
+for dependency in "${dependencies[@]}"; do
+  url="$(echo "$dependency" | cut -d ';' -f 1 | cut -d '=' -f 2)"
+  md5="$(echo "$dependency" | cut -d ';' -f 2 | cut -d '=' -f 2)"
+  filename="$(basename "$url")"
+  if test -f "$dependenciesdir/$filename" && test "$(get_md5 "$dependenciesdir/$filename")" = "$md5"; then
+    echo "Using cached $filename"
+  else
+    echo "Downloading $filename"
+    curl -L --max-redirs 5 --retry 5 --no-progress-meter --output "$dependenciesdir/$filename" "$url"
+    actual_md5="$(get_md5 "$dependenciesdir/$filename")"
+    if test "$actual_md5" != "$md5"; then
+      echo "Downloaded $filename has wrong md5sum ('$actual_md5' != '$md5')"
+      exit 1
+    fi
+    dirname=${filename%.*}
+    extension=${filename#$dirname.}
+    if test "$extension" = "zip"; then
+      echo "Removing old $dependenciesdir/$dirname"
+      rm -rf "$dependenciesdir/$dirname"
+      echo "Unzipping $dependenciesdir/$filename"
+      unzip "$dependenciesdir/$filename" -d "$dependenciesdir/$dirname"
+    fi
+  fi
+done

--- a/test/sharness/lib/test-generate-junit-html.sh
+++ b/test/sharness/lib/test-generate-junit-html.sh
@@ -1,43 +1,5 @@
 #!/bin/bash
 
-dependencies=(
-  "url=https://sourceforge.net/projects/saxon/files/Saxon-HE/11/Java/SaxonHE11-4J.zip;md5=8a4783d307c32c898f8995b8f337fd6b"
-  "url=https://raw.githubusercontent.com/pl-strflt/ant/c781f7d79b92cc55530245d9554682a47f46851e/src/etc/junit-frames-saxon.xsl;md5=6eb013566903a91e4959413f6ff144d0"
-  "url=https://raw.githubusercontent.com/pl-strflt/ant/c781f7d79b92cc55530245d9554682a47f46851e/src/etc/junit-noframes-saxon.xsl;md5=8d54882d5f9d32a7743ec675cc2e30ac"
-)
-
-dependenciesdir="lib/dependencies"
-mkdir -p "$dependenciesdir"
-
-get_md5() {
-  md5sum "$1" | cut -d ' ' -f 1
-}
-
-for dependency in "${dependencies[@]}"; do
-  url="$(echo "$dependency" | cut -d ';' -f 1 | cut -d '=' -f 2)"
-  md5="$(echo "$dependency" | cut -d ';' -f 2 | cut -d '=' -f 2)"
-  filename="$(basename "$url")"
-  if test -f "$dependenciesdir/$filename" && test "$(get_md5 "$dependenciesdir/$filename")" = "$md5"; then
-    echo "Using cached $filename"
-  else
-    echo "Downloading $filename"
-    curl -L --max-redirs 5 --retry 5 --no-progress-meter --output "$dependenciesdir/$filename" "$url"
-    actual_md5="$(get_md5 "$dependenciesdir/$filename")"
-    if test "$actual_md5" != "$md5"; then
-      echo "Downloaded $filename has wrong md5sum ('$actual_md5' != '$md5')"
-      exit 1
-    fi
-    dirname=${filename%.*}
-    extension=${filename#$dirname.}
-    if test "$extension" = "zip"; then
-      echo "Removing old $dependenciesdir/$dirname"
-      rm -rf "$dependenciesdir/$dirname"
-      echo "Unzipping $dependenciesdir/$filename"
-      unzip "$dependenciesdir/$filename" -d "$dependenciesdir/$dirname"
-    fi
-  fi
-done
-
 case "$1" in
   "frames")
     java -jar lib/dependencies/SaxonHE11-4J/saxon-he-11.4.jar \


### PR DESCRIPTION
Fixes #9551

My theory is that the problems with HTML report generation were caused by the fact that we generate both a multi-page report and a single-page report. Two separate tasks generate those. They both download Saxon. I think, sometimes, the errors were happening when the first task finished the download and started generation, while the second one only just started downloading and was trying to replace Saxon while the first task was using it.

This PR extracts Saxon downloading to a separate task that the generation tasks will depend on.