### PR TITLE
fix(gateway): do not convert unixfs/raw into dag-* unless explicit

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -422,7 +422,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		switch resolvedPath.Cid().Prefix().Codec {
 		case uint64(mc.Json), uint64(mc.DagJson), uint64(mc.Cbor), uint64(mc.DagCbor):
 			logger.Debugw("serving codec", "path", contentPath)
-			i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat)
+			i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat, logger)
 		default:
 			logger.Debugw("serving unixfs", "path", contentPath)
 			i.serveUnixFS(r.Context(), w, r, resolvedPath, contentPath, begin, logger)
@@ -444,7 +444,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	case "application/json", "application/vnd.ipld.dag-json",
 		"application/cbor", "application/vnd.ipld.dag-cbor":
 		logger.Debugw("serving codec", "path", contentPath)
-		i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat)
+		i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat, logger)
 		return
 	default: // catch-all for unsuported application/vnd.*
 		err := fmt.Errorf("unsupported format %q", responseFormat)

--- a/test/sharness/t0123-gateway-json-cbor.sh
+++ b/test/sharness/t0123-gateway-json-cbor.sh
@@ -43,23 +43,21 @@ test_dag_pb_headers () {
     test_should_not_contain "Content-Type: application/$format" curl_output
   '
 
-  test_expect_success "GET UnixFS as $name with format=$format has expected Content-Type" '
+  test_expect_success "GET UnixFS as $name with 'Accept: foo, application/vnd.ipld.dag-$format,bar' has expected Content-Type" '
+    curl -sD - -H "Accept: foo, application/vnd.ipld.dag-$format,text/plain" "http://127.0.0.1:$GWAY_PORT/ipfs/$FILE_CID" > curl_output 2>&1 &&
+    test_should_contain "Content-Type: application/vnd.ipld.dag-$format" curl_output
+  '
+
+  test_expect_success "GET UnixFS with format=$format returns raw (no conversion)" '
     curl -sD - "http://127.0.0.1:$GWAY_PORT/ipfs/$FILE_CID?format=$format" > curl_output 2>&1 &&
-    test_should_contain "Content-Disposition: ${disposition}\; filename=\"${FILE_CID}.${format}\"" curl_output &&
-    test_should_contain "Content-Type: application/$format" curl_output &&
+    test_should_not_contain "Content-Type: application/$format" curl_output &&
     test_should_not_contain "Content-Type: application/vnd.ipld.dag-$format" curl_output
   '
 
-  test_expect_success "GET UnixFS as $name with 'Accept: application/$format' has expected Content-Type" '
+  test_expect_success "GET UnixFS with 'Accept: application/$format' returns raw (no conversion)" '
     curl -sD - -H "Accept: application/$format" "http://127.0.0.1:$GWAY_PORT/ipfs/$FILE_CID" > curl_output 2>&1 &&
-    test_should_contain "Content-Disposition: ${disposition}\; filename=\"${FILE_CID}.${format}\"" curl_output &&
-    test_should_contain "Content-Type: application/$format" curl_output &&
+    test_should_not_contain "Content-Type: application/$format" curl_output &&
     test_should_not_contain "Content-Type: application/vnd.ipld.dag-$format" curl_output
-  '
-
-  test_expect_success "GET UnixFS as $name with 'Accept: foo, application/$format,bar' has expected Content-Type" '
-    curl -sD - -H "Accept: foo, application/$format,text/plain" "http://127.0.0.1:$GWAY_PORT/ipfs/$FILE_CID" > curl_output 2>&1 &&
-    test_should_contain "Content-Type: application/$format" curl_output
   '
 }
 
@@ -80,12 +78,6 @@ test_dag_pb () {
     curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$DIR_CID?format=dag-$format" > curl_output 2>&1 &&
     ipfs dag get --output-codec dag-$format $DIR_CID > ipfs_dag_get_output 2>&1 &&
     test_cmp ipfs_dag_get_output curl_output
-  '
-
-  test_expect_success "GET UnixFS as $name with format=dag-$format and format=$format produce same output" '
-    curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$DIR_CID?format=dag-$format" > curl_output_1 2>&1 &&
-    curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$DIR_CID?format=$format" > curl_output_2 2>&1 &&
-    test_cmp curl_output_1 curl_output_2
   '
 }
 
@@ -148,17 +140,17 @@ test_cmp_dag_get "CBOR" "cbor" "attachment"
 
 ## Lossless conversion between JSON and CBOR
 
-test_expect_success "GET JSON as CBOR produces DAG-CBOR output" '
+test_expect_success "GET JSON as CBOR produces CBOR output" '
   CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec json) &&
   curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=cbor" > curl_output 2>&1 &&
-  ipfs dag get --output-codec dag-cbor $CID > ipfs_dag_get_output 2>&1 &&
+  ipfs dag get --output-codec cbor $CID > ipfs_dag_get_output 2>&1 &&
   test_cmp ipfs_dag_get_output curl_output
 '
 
-test_expect_success "GET CBOR as JSON produces DAG-JSON output" '
+test_expect_success "GET CBOR as JSON produces JSON output" '
   CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec cbor) &&
   curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=json" > curl_output 2>&1 &&
-  ipfs dag get --output-codec dag-json $CID > ipfs_dag_get_output 2>&1 &&
+  ipfs dag get --output-codec json $CID > ipfs_dag_get_output 2>&1 &&
   test_cmp ipfs_dag_get_output curl_output
 '
 
@@ -203,12 +195,6 @@ test_expect_success "GET DAG-CBOR traverses multiple links" '
   echo "{ \"hello\": \"this is not a link\" }" | jq --sort-keys . > expected &&
   test_cmp expected actual
 '
-
-# test_expect_success "GET DAG-PB has expected output" '
-#   curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$DAG_PB_CID?format=dag-json" > curl_output 2>&1 &&
-#   jq --sort-keys . curl_output > actual &&
-#   test_cmp ../t0123-gateway-json-cbor/dag-pb.json actual
-# '
 
 
 ## NATIVE TESTS:
@@ -302,18 +288,11 @@ test_native_dag () {
     test_should_contain "Content-Type: application/vnd.ipld.dag-$format" output &&
     test_should_contain "Content-Length: " output
   '
-  test_expect_success "HEAD $name with an explicit JSON format returns HTTP 200" '
-    curl -I "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=json" -o output &&
+  test_expect_success "HEAD $name with an explicit DAG-JSON format returns HTTP 200" '
+    curl -I "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=dag-json" -o output &&
     test_should_contain "HTTP/1.1 200 OK" output &&
-    test_should_contain "Etag: \"$CID.json\"" output &&
-    test_should_contain "Content-Type: application/json" output &&
-    test_should_contain "Content-Length: " output
-  '
-  test_expect_success "HEAD dag-pb with ?format=$format returns HTTP 200" '
-    curl -I "http://127.0.0.1:$GWAY_PORT/ipfs/$FILE_CID?format=$format" -o output &&
-    test_should_contain "HTTP/1.1 200 OK" output &&
-    test_should_contain "Etag: \"$FILE_CID.$format\"" output &&
-    test_should_contain "Content-Type: application/$format" output &&
+    test_should_contain "Etag: \"$CID.dag-json\"" output &&
+    test_should_contain "Content-Type: application/vnd.ipld.dag-json" output &&
     test_should_contain "Content-Length: " output
   '
   test_expect_success "HEAD $name with only-if-cached for missing block returns HTTP 412 Precondition Failed" '


### PR DESCRIPTION
**Note:**: I also made an alternative version of this PR that includes **less** changes overall to achieve the same result #9566.

In the spirit of https://github.com/protocol/bifrost-infra/issues/2290 and https://github.com/ipfs/specs/pull/328#pullrequestreview-1254267132, this PR removes IPLD Logical Format conversion via `?format=json|cbor` (and respective `Accept` headers). Now we need to explicitly indicate `dag-json|dag-cbor`.  The table of the output type for input\request combos:

| **Input \ Requested** | **DAG-JSON** | **DAG-CBOR** | **JSON** | **CBOR** |
|:---------------------:|--------------|--------------|----------|----------|
|        **Raw**        | DAG-JSON     | DAG-CBOR     |  Ignore (`serveUnixFs`)      | Ignore (`serveUnixFs`)      |
|       **UnixFS**      | DAG-JSON     | DAG-CBOR     | Ignore (`serveUnixFs`)      | Ignore (`serveUnixFs`)      |
|      **DAG-JSON**     | DAG-JSON     | DAG-CBOR     | Ignore (`serveUnixFs`)      | Ignore (`serveUnixFs`)      |
|      **DAG-CBOR**     | DAG-JSON     | DAG-CBOR     | Ignore (`serveUnixFs`)      | Ignore (`serveUnixFs`)      |
|        **JSON**       | DAG-JSON     | DAG-CBOR     | JSON     | CBOR     |
|        **CBOR**       | DAG-JSON     | DAG-CBOR     | JSON     | CBOR     |

I'm not exactly confident that this is simpler than the implementation we had before, or if it is a good idea. I think we should keep being able to retrieve JSON and CBOR CIDs from the Gateway, as well as converting between both formats. Then, we cannot convert DAG-JSON and DAG-CBOR to JSON/CBOR because of the links that are not supported in regular JSON and CBOR. 



The CI is failing on unrelated things that I did not change. It seems that there may be some NPM/Network errors.