### PR TITLE
fix(gateway): undesired conversions to dag-json and friends

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -418,7 +418,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 
 	// Support custom response formats passed via ?format or Accept HTTP header
 	switch responseFormat {
-	case "":
+	case "", "application/json", "application/cbor":
 		switch mc.Code(resolvedPath.Cid().Prefix().Codec) {
 		case mc.Json, mc.DagJson, mc.Cbor, mc.DagCbor:
 			logger.Debugw("serving codec", "path", contentPath)
@@ -447,7 +447,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		return
 	default: // catch-all for unsuported application/vnd.*
 		err := fmt.Errorf("unsupported format %q", responseFormat)
-		webError(w, "failed respond with requested content type", err, http.StatusBadRequest)
+		webError(w, "failed to respond with requested content type", err, http.StatusBadRequest)
 		return
 	}
 }
@@ -877,6 +877,10 @@ func customResponseFormat(r *http.Request) (mediaType string, params map[string]
 			return "application/vnd.ipld.car", nil, nil
 		case "tar":
 			return "application/x-tar", nil, nil
+		case "json":
+			return "application/json", nil, nil
+		case "cbor":
+			return "application/cbor", nil, nil
 		case "dag-json":
 			return "application/vnd.ipld.dag-json", nil, nil
 		case "dag-cbor":
@@ -903,6 +907,8 @@ func customResponseFormat(r *http.Request) (mediaType string, params map[string]
 			}
 		}
 	}
+	// If none of special-cased content types is found, return empty string
+	// to indicate default, implicit UnixFS response should be prepared
 	return "", nil, nil
 }
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -420,7 +420,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	switch responseFormat {
 	case "":
 		switch resolvedPath.Cid().Prefix().Codec {
-		case uint64(mc.Json), uint64(mc.DagJson), uint64(mc.Cbor), uint64(mc.DagCbor):
+		case uint64(mc.DagJson), uint64(mc.DagCbor):
 			logger.Debugw("serving codec", "path", contentPath)
 			i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, logger, responseFormat)
 		default:
@@ -441,8 +441,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		logger.Debugw("serving tar file", "path", contentPath)
 		i.serveTAR(r.Context(), w, r, resolvedPath, contentPath, begin, logger)
 		return
-	case "application/json", "application/vnd.ipld.dag-json",
-		"application/cbor", "application/vnd.ipld.dag-cbor":
+	case "application/vnd.ipld.dag-json", "application/vnd.ipld.dag-cbor":
 		logger.Debugw("serving codec", "path", contentPath)
 		i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, logger, responseFormat)
 		return

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -422,7 +422,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		switch resolvedPath.Cid().Prefix().Codec {
 		case uint64(mc.Json), uint64(mc.DagJson), uint64(mc.Cbor), uint64(mc.DagCbor):
 			logger.Debugw("serving codec", "path", contentPath)
-			i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat)
+			i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, logger, responseFormat)
 		default:
 			logger.Debugw("serving unixfs", "path", contentPath)
 			i.serveUnixFS(r.Context(), w, r, resolvedPath, contentPath, begin, logger)
@@ -444,7 +444,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	case "application/json", "application/vnd.ipld.dag-json",
 		"application/cbor", "application/vnd.ipld.dag-cbor":
 		logger.Debugw("serving codec", "path", contentPath)
-		i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat)
+		i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, logger, responseFormat)
 		return
 	default: // catch-all for unsuported application/vnd.*
 		err := fmt.Errorf("unsupported format %q", responseFormat)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -419,10 +419,10 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	// Support custom response formats passed via ?format or Accept HTTP header
 	switch responseFormat {
 	case "":
-		switch resolvedPath.Cid().Prefix().Codec {
-		case uint64(mc.DagJson), uint64(mc.DagCbor):
+		switch mc.Code(resolvedPath.Cid().Prefix().Codec) {
+		case mc.Json, mc.DagJson, mc.Cbor, mc.DagCbor:
 			logger.Debugw("serving codec", "path", contentPath)
-			i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, logger, responseFormat)
+			i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat)
 		default:
 			logger.Debugw("serving unixfs", "path", contentPath)
 			i.serveUnixFS(r.Context(), w, r, resolvedPath, contentPath, begin, logger)
@@ -443,7 +443,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		return
 	case "application/vnd.ipld.dag-json", "application/vnd.ipld.dag-cbor":
 		logger.Debugw("serving codec", "path", contentPath)
-		i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, logger, responseFormat)
+		i.serveCodec(r.Context(), w, r, resolvedPath, contentPath, begin, responseFormat)
 		return
 	default: // catch-all for unsuported application/vnd.*
 		err := fmt.Errorf("unsupported format %q", responseFormat)
@@ -879,12 +879,8 @@ func customResponseFormat(r *http.Request) (mediaType string, params map[string]
 			return "application/x-tar", nil, nil
 		case "dag-json":
 			return "application/vnd.ipld.dag-json", nil, nil
-		case "json":
-			return "application/json", nil, nil
 		case "dag-cbor":
 			return "application/vnd.ipld.dag-cbor", nil, nil
-		case "cbor":
-			return "application/cbor", nil, nil
 		}
 	}
 	// Browsers and other user agents will send Accept header with generic types like:

--- a/core/corehttp/gateway_handler_codec.go
+++ b/core/corehttp/gateway_handler_codec.go
@@ -31,11 +31,8 @@ var codecToContentType = map[mc.Code]string{
 	mc.DagCbor: "application/vnd.ipld.dag-cbor",
 }
 
-// contentTypeToCodecs maps the HTTP Content Type to the respective
-// possible codecs. If the original data is in one of those codecs,
-// we stream the raw bytes. Otherwise, we encode in the last codec
-// of the list.
-var contentTypeToCodecs = map[string]mc.Code{
+// contentTypeToCodec maps the HTTP Content Type to the respective codec.
+var contentTypeToCodec = map[string]mc.Code{
 	"application/vnd.ipld.dag-json": mc.DagJson,
 	"application/vnd.ipld.dag-cbor": mc.DagCbor,
 }
@@ -99,7 +96,7 @@ func (i *gatewayHandler) serveCodec(ctx context.Context, w http.ResponseWriter, 
 
 	// Otherwise, the user has requested a specific content type. Let's first get
 	// the codecs that can be used with this content type.
-	toCodec, ok := contentTypeToCodecs[requestedContentType]
+	toCodec, ok := contentTypeToCodec[requestedContentType]
 	if !ok {
 		// This is never supposed to happen unless function is called with wrong parameters.
 		err := fmt.Errorf("unsupported content type: %s", requestedContentType)

--- a/docs/changelogs/v0.18.md
+++ b/docs/changelogs/v0.18.md
@@ -64,19 +64,74 @@ Learn more in the [`Reprovider` config](https://github.com/ipfs/go-ipfs/blob/mas
 
 ##### (DAG-)JSON and (DAG-)CBOR response formats
 
-Implemented [IPIP-328](https://github.com/ipfs/specs/pull/328) which adds support
-for DAG-JSON and DAG-CBOR, as well as their non-DAG variants, to the gateway. Now,
-CIDs that encode JSON, CBOR, DAG-JSON and DAG-CBOR objects can be retrieved, and
-traversed thanks to the [special meaning of CBOR Tag 42](https://github.com/ipld/cid-cbor/).
+The IPFS project has reserved the corresponding media types at IANA:
+- [`application/vnd.ipld.dag-json`](https://www.iana.org/assignments/media-types/application/vnd.ipld.dag-json)
+- [`application/vnd.ipld.dag-cbor`](https://www.iana.org/assignments/media-types/application/vnd.ipld.dag-cbor)
 
-HTTP clients can request JSON, CBOR, DAG-JSON, and DAG-CBOR responses by either
-passing the query parameter `?format` or setting the `Accept` HTTP header to the
-following values:
+This release implements them as part of [IPIP-328](https://github.com/ipfs/specs/pull/328)
+and adds Gateway support for CIDs with `json` (0x0200), `cbor` (0x51),
+[`dag-json`](https://ipld.io/specs/codecs/dag-json/) (0x0129)
+and [`dag-cbor`](https://ipld.io/specs/codecs/dag-cbor/spec/) (0x71) codecs.
 
-- JSON: `?format=json`, or `Accept: application/json`
-- CBOR: `?format=cbor`, or `Accept: application/cbor`
-- DAG-JSON: `?format=dag-json`, or `Accept: application/vnd.ipld.dag-json`
-- DAG-JSON: `?format=dag-cbor`, or `Accept: application/vnd.ipld.dag-cbor`
+To specify the response `Content-Type` explicitly, the HTTP client can override
+the codec present in the CID by using the `format` parameter
+or setting the `Accept` HTTP header:
+
+- Plain JSON: `?format=json` or `Accept: application/json`
+- Plain CBOR: `?format=cbor` or `Accept: application/cbor`
+- DAG-JSON: `?format=dag-json` or `Accept: application/vnd.ipld.dag-json`
+- DAG-CBOR: `?format=dag-cbor` or `Accept: application/vnd.ipld.dag-cbor`
+
+In addition, when DAG-JSON or DAG-CBOR is requested with the `Accept` header
+set to `text/html`, the Gateway will return a basic HTML page with download
+options, improving the user experience in web browsers.
+
+###### Example 1: DAG-CBOR and DAG-JSON Conversion on Gateway
+
+The Gateway supports conversion between DAG-CBOR and DAG-JSON for efficient
+end-to-end data structure management: author in CBOR or JSON, store as binary
+CBOR and retrieve as JSON via HTTP:
+
+```console
+$ echo '{"test": "json"}' | ipfs dag put # implicit --input-codec dag-json --store-codec dag-cbor
+bafyreico7mjtqtqhvawro3yud5uqn6sc33nzqb7b5j2d7pdmzer5nab4t4
+
+$ ipfs block get bafyreico7mjtqtqhvawro3yud5uqn6sc33nzqb7b5j2d7pdmzer5nab4t4 | xxd
+00000000: a164 7465 7374 646a 736f 6e              .dtestdjson
+
+$ ipfs dag get bafyreico7mjtqtqhvawro3yud5uqn6sc33nzqb7b5j2d7pdmzer5nab4t4 # implicit --output-codec dag-json
+{"test":"json"}
+
+$ curl "http://127.0.0.1:8080/ipfs/bafyreico7mjtqtqhvawro3yud5uqn6sc33nzqb7b5j2d7pdmzer5nab4t4?format=dag-json"
+{"test":"json"}
+```
+
+###### Example 2: Traversing CBOR DAGs
+
+Placing a CID in [CBOR Tag 42](https://github.com/ipld/cid-cbor/) enables the
+creation of arbitrary DAGs. The equivalent DAG-JSON notation for linking
+to different blocks is represented by `{ "/": "cid" }`.
+
+The Gateway supports traversing these links, enabling access to data
+referenced by structures other than regular UnixFS directories:
+
+```console
+$ echo '{"test.jpg": {"/": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"}}' | ipfs dag put
+bafyreihspwy3zlkzgphmec5d3xb5g5njrqwotd46lyubnelbzktnmsxkq4 # dag-cbor document linking to unixfs file
+
+$ ipfs resolve /ipfs/bafyreihspwy3zlkzgphmec5d3xb5g5njrqwotd46lyubnelbzktnmsxkq4/test.jpg
+/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+
+$ ipfs dag stat bafyreihspwy3zlkzgphmec5d3xb5g5njrqwotd46lyubnelbzktnmsxkq4
+Size: 119827, NumBlocks: 2
+
+$ curl "http://127.0.0.1:8080/ipfs/bafyreihspwy3zlkzgphmec5d3xb5g5njrqwotd46lyubnelbzktnmsxkq4/test.jpg" > test.jpg
+```
+
+###### Example 3: UnixFS directory listing as JSON
+
+Finally, Gateway now supports the same [logical format projection](https://ipld.io/specs/codecs/dag-pb/spec/#logical-format) from
+DAG-PB to DAG-JSON as the `ipfs dag get` command, enabling the retrieval of directory listings as JSON instead of HTML:
 
 ```console
 $ export DIR_CID=bafybeigccimv3zqm5g4jt363faybagywkvqbrismoquogimy7kvz2sj7sq
@@ -112,6 +167,8 @@ $ curl "http://127.0.0.1:8080/ipfs/$DIR_CID?format=dag-json" | jq
     }
   ]
 }
+$ ipfs dag get $DIR_CID
+{"Data":{"/":{"bytes":"CAE"}},"Links":[{"Hash":{"/":"Qmc3zqKcwzbbvw3MQm3hXdg8BQoFjGdZiGdAfXAyAGGdLi"},"Name":"1 - Barrel - Part 1 - alt.txt","Tsize":21},{"Hash":{"/":"QmdMxMx29KVYhHnaCc1icWYxQqXwUNCae6t1wS2NqruiHd"},"Name":"1 - Barrel - Part 1 - transcript.txt","Tsize":195},{"Hash":{"/":"QmawceGscqN4o8Y8Fv26UUmB454kn2bnkXV5tEQYc4jBd6"},"Name":"1 - Barrel - Part 1.png","Tsize":24862}]}
 ```
 
 ##### 🐎 Fast directory listings with DAG sizes

--- a/test/sharness/t0123-gateway-json-cbor.sh
+++ b/test/sharness/t0123-gateway-json-cbor.sh
@@ -91,34 +91,6 @@ test_cmp_dag_get () {
   format=$2
   disposition=$3
 
-  test_expect_success "GET $name without Accept or format= has expected Content-Type" '
-    CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
-    curl -sD - "http://127.0.0.1:$GWAY_PORT/ipfs/$CID" > curl_output 2>&1 &&
-    test_should_contain "Content-Disposition: ${disposition}\; filename=\"${CID}.${format}\"" curl_output &&
-    test_should_contain "Content-Type: application/$format" curl_output
-  '
-
-  test_expect_success "GET $name without Accept or format= produces correct output" '
-    CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
-    curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$CID" > curl_output 2>&1 &&
-    ipfs dag get --output-codec $format $CID > ipfs_dag_get_output 2>&1 &&
-    test_cmp ipfs_dag_get_output curl_output
-  '
-
-  test_expect_success "GET $name with format=$format produces expected Content-Type" '
-    CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
-    curl -sD- "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=$format" > curl_output 2>&1 &&
-    test_should_contain "Content-Disposition: ${disposition}\; filename=\"${CID}.${format}\"" curl_output &&
-    test_should_contain "Content-Type: application/$format" curl_output
-  '
-
-  test_expect_success "GET $name with format=$format produces correct output" '
-    CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
-    curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=$format" > curl_output 2>&1 &&
-    ipfs dag get --output-codec $format $CID > ipfs_dag_get_output 2>&1 &&
-    test_cmp ipfs_dag_get_output curl_output
-  '
-
   test_expect_success "GET $name with format=dag-$format produces expected Content-Type" '
     CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
     curl -sD- "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=dag-$format" > curl_output 2>&1 &&
@@ -136,23 +108,6 @@ test_cmp_dag_get () {
 
 test_cmp_dag_get "JSON" "json" "inline"
 test_cmp_dag_get "CBOR" "cbor" "attachment"
-
-
-## Lossless conversion between JSON and CBOR
-
-test_expect_success "GET JSON as CBOR produces DAG-CBOR output" '
-  CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec json) &&
-  curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=cbor" > curl_output 2>&1 &&
-  ipfs dag get --output-codec dag-cbor $CID > ipfs_dag_get_output 2>&1 &&
-  test_cmp ipfs_dag_get_output curl_output
-'
-
-test_expect_success "GET CBOR as JSON produces DAG-JSON output" '
-  CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec cbor) &&
-  curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=json" > curl_output 2>&1 &&
-  ipfs dag get --output-codec dag-json $CID > ipfs_dag_get_output 2>&1 &&
-  test_cmp ipfs_dag_get_output curl_output
-'
 
 
 ## Pathing, traversal

--- a/test/sharness/t0123-gateway-json-cbor.sh
+++ b/test/sharness/t0123-gateway-json-cbor.sh
@@ -91,6 +91,20 @@ test_cmp_dag_get () {
   format=$2
   disposition=$3
 
+  test_expect_success "GET $name without Accept or format= has expected Content-Type" '
+    CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
+    curl -sD - "http://127.0.0.1:$GWAY_PORT/ipfs/$CID" > curl_output 2>&1 &&
+    test_should_contain "Content-Disposition: ${disposition}\; filename=\"${CID}.${format}\"" curl_output &&
+    test_should_contain "Content-Type: application/$format" curl_output
+  '
+
+  test_expect_success "GET $name without Accept or format= produces correct output" '
+    CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
+    curl -s "http://127.0.0.1:$GWAY_PORT/ipfs/$CID" > curl_output 2>&1 &&
+    ipfs dag get --output-codec $format $CID > ipfs_dag_get_output 2>&1 &&
+    test_cmp ipfs_dag_get_output curl_output
+  '
+
   test_expect_success "GET $name with format=dag-$format produces expected Content-Type" '
     CID=$(echo "{ \"test\": \"json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
     curl -sD- "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=dag-$format" > curl_output 2>&1 &&

--- a/test/sharness/t0123-gateway-json-cbor.sh
+++ b/test/sharness/t0123-gateway-json-cbor.sh
@@ -117,6 +117,26 @@ test_plain_codec () {
     test_should_contain "Content-Type: application/$format" headers
   '
 
+  # explicit format still gives correct output, just codec in CID
+  test_expect_success "GET $name with ?format= has expected $format Content-Type and body as-is" '
+    CID=$(echo "{ \"test\": \"plain json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
+    curl -sD headers "http://127.0.0.1:$GWAY_PORT/ipfs/$CID?format=$format" > curl_output 2>&1 &&
+    ipfs block get $CID > ipfs_block_output 2>&1 &&
+    test_cmp ipfs_block_output curl_output &&
+    test_should_contain "Content-Disposition: ${disposition}\; filename=\"${CID}.${format}\"" headers &&
+    test_should_contain "Content-Type: application/$format" headers
+  '
+
+  # explicit format still gives correct output, just codec in CID
+  test_expect_success "GET $name with Accept has expected $format Content-Type and body as-is" '
+    CID=$(echo "{ \"test\": \"plain json\" }" | ipfs dag put --input-codec json --store-codec $format) &&
+    curl -sD headers -H "Accept: application/$format" "http://127.0.0.1:$GWAY_PORT/ipfs/$CID" > curl_output 2>&1 &&
+    ipfs block get $CID > ipfs_block_output 2>&1 &&
+    test_cmp ipfs_block_output curl_output &&
+    test_should_contain "Content-Disposition: ${disposition}\; filename=\"${CID}.${format}\"" headers &&
+    test_should_contain "Content-Type: application/$format" headers
+  '
+
   # explicit dag-* format passed, attempt to parse as dag* variant
   ## Note: this works only for simple JSON that can be upgraded to  DAG-JSON.
   test_expect_success "GET $name with format=dag-$format interprets $format as dag-* variant and produces expected Content-Type and body" '


### PR DESCRIPTION
In the spirit of https://github.com/protocol/bifrost-infra/issues/2290 and https://github.com/ipfs/specs/pull/328#pullrequestreview-1254267132, this PR removes implicit conversion from UnixFS/RAW to DAG-* when `json` is requested, and performs the conversion only when expliti `dag-json`  is present in the request.

We also fixed handling of CID with `json` and `cbor` codecs + added more tests.

Weird, unrelated things, are happening in the CI. – tracked in https://github.com/ipfs/kubo/pull/9570