### PR TITLE
fix(ci): ipfs-interop and ipfs-webui

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -228,6 +228,8 @@ jobs:
       - image: cimg/go:1.19.1-node
     parallelism: 4
     resource_class: 2xlarge+
+    environment:
+      GO_IPFS_DIST_URL: https://dist-ipfs-tech.ipns.cf-ipfs.com # TODO remove this line when https://github.com/protocol/bifrost-infra/issues/2300 is closed
     steps:
       - *make_out_dirs
       - attach_workspace:
@@ -328,6 +330,8 @@ jobs:
   ipfs-webui:
     executor: node-browsers
     resource_class: 2xlarge+
+    environment:
+      GO_IPFS_DIST_URL: https://dist-ipfs-tech.ipns.cf-ipfs.com # TODO remove this line when https://github.com/protocol/bifrost-infra/issues/2300 is closed
     steps:
       - *make_out_dirs
       - attach_workspace:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
           LIBP2P_TCP_REUSEPORT: false
           LIBP2P_ALLOW_WEAK_RSA_KEYS: 1
           IPFS_GO_EXEC: ${{ github.workspace }}/cmd/ipfs/ipfs
+          GO_IPFS_DIST_URL: https://dist-ipfs-tech.ipns.cf-ipfs.com # TODO: remove this line when https://github.com/protocol/bifrost-infra/issues/2300 is closed
         working-directory: interop
   go-ipfs-api:
     needs: [prepare]
@@ -161,6 +162,7 @@ jobs:
       TRAVIS: 1
       GIT_PAGER: cat
       IPFS_CHECK_RCMGR_DEFAULTS: 1
+      GO_IPFS_DIST_URL: https://dist-ipfs-tech.ipns.cf-ipfs.com # TODO: remove this line when https://github.com/protocol/bifrost-infra/issues/2300 is closed
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This PR aims to fix [circleci failrues](https://app.circleci.com/pipelines/github/ipfs/kubo/8779/workflows/6d37de2b-7501-43dc-9204-31a22e23db43), but also update to the lastest version.

## TODO

- [x] fix interop
- [x] fix webui

### Problems

- ipfs-interop fails to download libp2p-relay-daemon for the [similar reason](https://app.circleci.com/pipelines/github/ipfs/kubo/8792/workflows/d898c874-bc0f-4c48-98ef-a45bd300da29/jobs/95234?invite=true&invite=true#step-105-88) – json does not have expected field.
- ipfs-webui fails due to npm-go-ipfs line: ``const data = await got(`${distUrl}/go-ipfs/${version}/dist.json`).json()``  which fails [here](https://app.circleci.com/pipelines/github/ipfs/kubo/8792/workflows/7a65fee9-a2da-4f0a-9010-d421953f29eb/jobs/95231?invite=true#step-105-88)

### Tried so far 

- bumped to the latest versions from upstream repo (https://github.com/ipfs/interop) just to be sure its not already fixed upstream
  - github passes with the latest version of interop (v10.0.0)
  - this  introduced [this error](https://app.circleci.com/pipelines/github/ipfs/kubo/8797/workflows/a40a3dad-c94f-48cf-904e-ff111895d2ec/jobs/95301/parallel-runs/3?filterBy=FAILED&invite=true#step-106-42)  which makes me think this is a caching problem specific to circleci setup
- original old errors remain, and  both failures are caused by circleci blocking HTTP request  to remote server, maybe it is hitting different gateway?
- set `GO_IPFS_DIST_URL` to avoid nodes with 0.18.0-rc2 bug → https://github.com/protocol/bifrost-infra/issues/2300#issuecomment-1398946009
