### PR TITLE
Simplify libp2p ResourceMgr computed defaults (no System.StreamsInbound limits and allow more System.ConnsInbound per MB)

### DIFF
--- a/docs/changelogs/v0.18.1
+++ b/docs/changelogs/v0.18.1
@@ -1,0 +1,36 @@
+# Kubo changelog v0.18
+
+## v0.18.1
+
+### Overview
+
+Below is an outline of all that is in this release, so you get a sense of all that's included.
+
+<!-- TOC depthfrom:3 -->
+
+- [Overview](#overview)
+- [🔦 Highlights](#-highlights)
+    - [Improving libp2p resource management integration](#improving-libp2p-resource-management-integration)
+- [📝 Changelog](#-changelog)
+- [👨‍👩‍👧‍👦 Contributors](#-contributors)
+
+<!-- /TOC -->
+
+### 🔦 Highlights
+
+#### Improving libp2p resource management integration
+This builds on the default protection nodes get against DoS (resource exhaustion) and eclipse attacks
+with the [go-libp2p Network Resource Manager/Accountant](https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md)
+that was fine-tuned in [Kubo 0.18](https://github.com/ipfs/kubo/blob/biglep/resource-manager-example-of-what-want/docs/changelogs/v0.18.md#improving-libp2p-resource-management-integration).
+
+Adding default hard-limits from the Resource Manager/Accountant after the fact is tricky,
+and some additional improvements have been made to improve the [computed defaults](https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#computed-default-limits).
+As much as possible, the aim is for a user to only think about how much memory they want to bound libp2p to, 
+and not need to think about translating that to hard numbers for connections, streams, etc.
+More updates are likely in future Kubo releases, but with this release: 
+1.``System.StreamsInbound`` is no longer bounded directly
+2. ``System.ConnsInbound`` has higher default computed values.
+
+### 📝 Changelog
+
+### 👨‍👩‍👧‍👦 Contributors

--- a/docs/changelogs/v0.18.1
+++ b/docs/changelogs/v0.18.1
@@ -28,8 +28,8 @@ and some additional improvements have been made to improve the [computed default
 As much as possible, the aim is for a user to only think about how much memory they want to bound libp2p to, 
 and not need to think about translating that to hard numbers for connections, streams, etc.
 More updates are likely in future Kubo releases, but with this release: 
-1.``System.StreamsInbound`` is no longer bounded directly
-2. ``System.ConnsInbound`` has higher default computed values.
+1. ``System.StreamsInbound`` is no longer bounded directly
+2. ``System.ConnsInbound``, ``Transient.Memory``, ``Transiet.ConnsInbound`` have higher default computed values.
 
 ### 📝 Changelog
 

--- a/docs/libp2p-resource-management.md
+++ b/docs/libp2p-resource-management.md
@@ -70,8 +70,7 @@ The reason these scopes are chosen is because:
 
 Within these scopes, limits are just set on
 [memory](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager#memory),
-[file descriptors (FD)](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager#file-descriptors), [*inbound* connections](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager#connections),
-and [*inbound* streams](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager#streams).
+[file descriptors (FD)](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager#file-descriptors), and [*inbound* connections](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager#connections).
 Limits are set based on the `Swarm.ResourceMgr.MaxMemory` and `Swarm.ResourceMgr.MaxFileDescriptors` inputs above.
 
 There are also some special cases where minimum values are enforced.
@@ -88,7 +87,6 @@ Once Kubo has the [Computed Default Limits](#computed-default-limits), it then a
 These become the [active limits](#how-does-one-see-the-active-limits).
 
 While `Swarm.ResourceMgr.Limits` can be edited directly, it is also possible to use `ipfs swarm limit` command to inspect and tweak specific limits at runtime.
-
 
 To see all resources that are close to hitting their respective limit:
 


### PR DESCRIPTION
This is in response to https://github.com/libp2p/go-libp2p/issues/2010 for simplification I think we want to be able to do for Kubo.  

I believe will allow the resource manager to get out of the way more but still protect against script-kiddies opening many connections/streams against a node.

In order for this work, established (non-transient) connections will need register memory usage with the resource manager/accountant, ideally across all transports and muxers.  Per https://github.com/libp2p/go-libp2p/issues/2010#issuecomment-1404280736, there are some cases where an established libp2p connection doesn't increase memory accounted for by the resource manager/accountant.  In the meantime we can set System.ConssInbound based on ResourceMgr.MaxMemory and then strip this out when https://github.com/libp2p/go-libp2p/issues/2010 lands.