### PR TITLE
Remove the alpha software warning in assets/init-doc/readme

### DIFF
--- a/assets/init-doc/readme
+++ b/assets/init-doc/readme
@@ -10,13 +10,6 @@ Hello and Welcome to IPFS!
 If you're seeing this, you have successfully installed
 IPFS and are now interfacing with the ipfs merkledag!
 
- -------------------------------------------------------
-| Warning:                                              |
-|   This is alpha software. Use at your own discretion! |
-|   Much is missing or lacking polish. There are bugs.  |
-|   Not yet secure. Read the security notes for more.   |
- -------------------------------------------------------
-
 Check out some of the other files in this directory:
 
   ./about


### PR DESCRIPTION
In [this docs PR to edit a Kubo tutorial](https://github.com/ipfs/ipfs-docs/pull/1444) (currently in progress), @2color pointed out that we should probably remove the alpha software warning in `assets/init-doc/readme` https://github.com/ipfs/ipfs-docs/pull/1444#discussion_r1086532870 because the software is no longer in alpha (right?) so that would give users the wrong impression in situations like step 3 of https://bafybeidvobdv5i3pjscvsityfe6kzpkaqmdze6jyk5irmzydmaf7yex2ea.on.fleek.co/how-to/command-line-quick-start/#initialize-the-repository

@2color anything else you'd suggest updating here?