### PR TITLE
fix: restore wire format for /api/v0/routing/get

### DIFF
--- a/test/sharness/t0170-routing-dht.sh
+++ b/test/sharness/t0170-routing-dht.sh
@@ -84,7 +84,7 @@ test_dht() {
   test_expect_success 'routing get --enc=json has correct properties' '
     HASH="$(echo "hello world" | ipfsi 2 add -q)" &&
     ipfsi 2 name publish "/ipfs/$HASH" &&
-    ipfsi 1 routing get --enc=json "/ipns/$PEERID_2" | jq -e 'has("Extra") and has("Type")'
+    ipfsi 1 routing get --enc=json "/ipns/$PEERID_2" | jq -e "has(\"Extra\") and has(\"Type\")"
   '
 
   # ipfs dht query <peerID>


### PR DESCRIPTION
Partially addresses #9638. I can only revert the wire format for `routing/get`. For `put`, we would need more information from the `.Routing.Put` to tell us in which peers the record was stored. However, that implies we would need to change the interface yet again. I would rather not do it, or do it in a different PR.


Closes #9638