### PR TITLE
feat: remove MPLEX by default

### DIFF
--- a/core/node/libp2p/smux.go
+++ b/core/node/libp2p/smux.go
@@ -52,15 +52,7 @@ func makeSmuxTransportOption(tptConfig config.Transports) (libp2p.Option, error)
 		}
 		return libp2p.ChainOptions(opts...), nil
 	} else {
-		return prioritizeOptions([]priorityOption{{
-			priority:        tptConfig.Multiplexers.Yamux,
-			defaultPriority: 100,
-			opt:             libp2p.Muxer(yamuxID, yamuxTransport()),
-		}, {
-			priority:        tptConfig.Multiplexers.Mplex,
-			defaultPriority: 200,
-			opt:             libp2p.Muxer(mplexID, mplex.DefaultTransport),
-		}}), nil
+		return libp2p.Muxer(yamuxID, yamuxTransport()), nil
 	}
 }
 


### PR DESCRIPTION
Mplex does not implement backpressure, our implementation will randomly reset streams if buffers overflow instead of risking deadlocks.

In the past we had a bug where kubo nodes would prefer mplex over yamux. Turning off mplex make our connections to thoses nodes negociate yamux.