### PR TITLE
docs(0.18.1): guide users to clean up limits

### DIFF
--- a/docs/changelogs/v0.18.md
+++ b/docs/changelogs/v0.18.md
@@ -35,7 +35,17 @@ first time a message is seen, you can set `Pubsub.SeenMessagesStrategy` to
 
 #### Improving libp2p resource management integration
 
-This builds on the default protection nodes get against DoS (resource exhaustion) and eclipse attacks
+TL;DR: limit autoscaling improved, most users should start with default settings.
+If you have old configuration, switch to implicit defaults:
+
+```
+ipfs config --json -- Swarm.ResourceMgr '{}'
+ipfs config --json -- Swarm.ConnMgr '{}'
+```
+
+IF you run a server and want to utilize more than half of memory and file descriptors to p2p work, adjust [`Swarm.ResourceMgr.MaxMemory`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmresourcemgrmaxmemory) and [`Swarm.ResourceMgr.MaxFileDescriptors`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmresourcemgrmaxfiledescriptors).
+
+The 0.18.1 builds on the default protection nodes get against DoS (resource exhaustion) and eclipse attacks
 with the [go-libp2p Network Resource Manager/Accountant](https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md)
 that was fine-tuned in [Kubo 0.18](https://github.com/ipfs/kubo/blob/biglep/resource-manager-example-of-what-want/docs/changelogs/v0.18.md#improving-libp2p-resource-management-integration).
 


### PR DESCRIPTION
Every team I talk with has some random ResourceMgr limits set up, usually invalid.
It is way better if we ask  people to start fresh.