### PR TITLE
feat: Swarm.RelayService.InfiniteLimits

### DIFF
--- a/config/swarm.go
+++ b/config/swarm.go
@@ -67,7 +67,7 @@ type RelayClient struct {
 }
 
 // RelayService configures the resources of the circuit v2 relay.
-// For every field a reasonable default will be defined in go-ipfs.
+// For every field a reasonable default will be defined in Kubo.
 type RelayService struct {
 	// Enables the limited relay service for other peers (circuit v2 relay).
 	Enabled Flag `json:",omitempty"`
@@ -93,6 +93,14 @@ type RelayService struct {
 	MaxReservationsPerIP *OptionalInteger `json:",omitempty"`
 	// MaxReservationsPerASN is the maximum number of reservations origination from the same ASN.
 	MaxReservationsPerASN *OptionalInteger `json:",omitempty"`
+
+	// InfiniteLimits effectively removes all limits. Enabling this option also
+	// doesn't apply any filter for which protocols can be used, allowing for
+	// expensive things like bitswap over a relayed connection.
+	// Do this only if you know what you are doing. Exposing relay like this to
+	// the public may lead to resource exhausion, use with care, as a static
+	// relay in controlled environments.
+	InfiniteLimits Flag `json:",omitempty"`
 }
 
 type Transports struct {

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -25,6 +25,12 @@ func RelayTransport(enableRelay bool) func() (opts Libp2pOpts, err error) {
 func RelayService(enable bool, relayOpts config.RelayService) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
 		if enable {
+			// If user explicitly removed limits
+			if relayOpts.InfiniteLimits.WithDefault(false) {
+				opts.Opts = append(opts.Opts, libp2p.EnableRelayService(relay.WithInfiniteLimits()))
+				return
+			}
+
 			def := relay.DefaultResources()
 			// Real defaults live in go-libp2p.
 			// Here we apply any overrides from user config.

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -63,10 +63,7 @@ func MaybeAutoRelay(staticRelays []string, cfgPeering config.Peering, enabled bo
 					}
 					static = append(static, *addr)
 				}
-				opts.Opts = append(opts.Opts, libp2p.EnableAutoRelayWithStaticRelays(
-					static,
-					autorelay.WithCircuitV1Support(),
-				))
+				opts.Opts = append(opts.Opts, libp2p.EnableAutoRelayWithStaticRelays(static))
 			}
 			return
 		})

--- a/docs/config.md
+++ b/docs/config.md
@@ -123,9 +123,8 @@ config file at runtime.
       - [`Swarm.RelayClient.StaticRelays`](#swarmrelayclientstaticrelays)
     - [`Swarm.RelayService`](#swarmrelayservice)
       - [`Swarm.RelayService.Enabled`](#swarmrelayserviceenabled)
-      - [`Swarm.RelayService.Limit`](#swarmrelayservicelimit)
-        - [`Swarm.RelayService.ConnectionDurationLimit`](#swarmrelayserviceconnectiondurationlimit)
-        - [`Swarm.RelayService.ConnectionDataLimit`](#swarmrelayserviceconnectiondatalimit)
+      - [`Swarm.RelayService.ConnectionDurationLimit`](#swarmrelayserviceconnectiondurationlimit)
+      - [`Swarm.RelayService.ConnectionDataLimit`](#swarmrelayserviceconnectiondatalimit)
       - [`Swarm.RelayService.ReservationTTL`](#swarmrelayservicereservationttl)
       - [`Swarm.RelayService.MaxReservations`](#swarmrelayservicemaxreservations)
       - [`Swarm.RelayService.MaxCircuits`](#swarmrelayservicemaxcircuits)
@@ -133,6 +132,7 @@ config file at runtime.
       - [`Swarm.RelayService.MaxReservationsPerPeer`](#swarmrelayservicemaxreservationsperpeer)
       - [`Swarm.RelayService.MaxReservationsPerIP`](#swarmrelayservicemaxreservationsperip)
       - [`Swarm.RelayService.MaxReservationsPerASN`](#swarmrelayservicemaxreservationsperasn)
+      - [`Swarm.RelayService.InfiniteLimits`](#swarmrelayserviceinfinitelimits)
     - [`Swarm.EnableRelayHop`](#swarmenablerelayhop)
     - [`Swarm.DisableRelay`](#swarmdisablerelay)
     - [`Swarm.EnableAutoNATService`](#swarmenableautonatservice)
@@ -237,7 +237,7 @@ documented in `ipfs config profile --help`.
     smaller than several gigabytes. If you run IPFS with `--enable-gc`, you plan on storing very little data in
     your IPFS node, and disk usage is more critical than performance, consider using
     `flatfs`.
-  - This datastore uses up to several gigabytes of memory.  
+  - This datastore uses up to several gigabytes of memory.
   - Good for medium-size datastores, but may run into performance issues if your dataset is bigger than a terabyte.
   - The current implementation is based on old badger 1.x which is no longer supported by the upstream team.
 
@@ -682,7 +682,7 @@ Type: `string` (url)
 
 ### `Gateway.Writable`
 
-**DEPRECATED**: Enables legacy PUT/POST request handling. 
+**DEPRECATED**: Enables legacy PUT/POST request handling.
 
 This API is not standardized, and should not be used for new projects.
 We are working on a modern replacement. IPIP can be tracked in [ipfs/specs#375](https://github.com/ipfs/specs/issues/375).
@@ -901,7 +901,7 @@ Type: `string` (base64 encoded)
 
 ## `Internal`
 
-This section includes internal knobs for various subsystems to allow advanced users with big or private infrastructures to fine-tune some behaviors without the need to recompile Kubo.  
+This section includes internal knobs for various subsystems to allow advanced users with big or private infrastructures to fine-tune some behaviors without the need to recompile Kubo.
 
 **Be aware that making informed change here requires in-depth knowledge and most users should leave these untouched. All knobs listed here are subject to breaking changes between versions.**
 
@@ -977,7 +977,7 @@ Type: `optionalInteger` (byte count, `null` means default which is 1MB)
 ### `Internal.Bitswap.ProviderSearchDelay`
 
 This parameter determines how long to wait before looking for providers outside of bitswap.
-Other routing systems like the DHT are able to provide results in less than a second, so lowering 
+Other routing systems like the DHT are able to provide results in less than a second, so lowering
 this number will allow faster peers lookups in some cases.
 
 Type: `optionalDuration` (`null` means default which is 1s)
@@ -1644,15 +1644,7 @@ Default: `true`
 
 Type: `flag`
 
-#### `Swarm.RelayService.Limit`
-
-Limits applied to every relayed connection.
-
-Default: `{}`
-
-Type: `object[string -> string]`
-
-##### `Swarm.RelayService.ConnectionDurationLimit`
+#### `Swarm.RelayService.ConnectionDurationLimit`
 
 Time limit before a relayed connection is reset.
 
@@ -1660,7 +1652,7 @@ Default: `"2m"`
 
 Type: `duration`
 
-##### `Swarm.RelayService.ConnectionDataLimit`
+#### `Swarm.RelayService.ConnectionDataLimit`
 
 Limit of data relayed (in each direction) before a relayed connection is reset.
 
@@ -1729,6 +1721,22 @@ Maximum number of reservations originating from the same ASN.
 Default: `32`
 
 Type: `optionalInteger`
+
+#### `Swarm.RelayService.InfiniteLimits`
+
+**EXPERIMENTAL:** use with care
+
+Removes all limits. Enabling this option also doesn't apply any filter for
+which protocols can be used, allowing for expensive things like bitswap over a
+relayed connection.
+
+NOTE: Do this only if you know what you are doing. Exposing relay like this to
+the public may lead to resource exhausion, use with care, as a static relay in
+controlled environments.
+
+Default: `false`
+
+Type: `flag`
 
 ### `Swarm.EnableRelayHop`
 

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-doh-resolver v0.4.0
-	github.com/libp2p/go-libp2p v0.25.2-0.20230217230459-32f2f255292d
+	github.com/libp2p/go-libp2p v0.25.2-0.20230222220431-c03190e1ca4f
 	github.com/libp2p/go-libp2p-http v0.4.0
 	github.com/libp2p/go-libp2p-kad-dht v0.21.0
 	github.com/libp2p/go-libp2p-kbucket v0.5.0
@@ -208,9 +208,9 @@ require (
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-18 v0.2.0 // indirect
-	github.com/quic-go/qtls-go1-19 v0.2.0 // indirect
-	github.com/quic-go/qtls-go1-20 v0.1.0 // indirect
-	github.com/quic-go/quic-go v0.32.0 // indirect
+	github.com/quic-go/qtls-go1-19 v0.2.1 // indirect
+	github.com/quic-go/qtls-go1-20 v0.1.1 // indirect
+	github.com/quic-go/quic-go v0.33.0 // indirect
 	github.com/quic-go/webtransport-go v0.5.1 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-doh-resolver v0.4.0
-	github.com/libp2p/go-libp2p v0.25.1
+	github.com/libp2p/go-libp2p v0.25.2-0.20230217230459-32f2f255292d
 	github.com/libp2p/go-libp2p-http v0.4.0
 	github.com/libp2p/go-libp2p-kad-dht v0.21.0
 	github.com/libp2p/go-libp2p-kbucket v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -761,6 +761,8 @@ github.com/libp2p/go-libp2p v0.8.1/go.mod h1:QRNH9pwdbEBpx5DTJYg+qxcVaDMAz3Ee/qD
 github.com/libp2p/go-libp2p v0.14.3/go.mod h1:d12V4PdKbpL0T1/gsUNN8DfgMuRPDX8bS2QxCZlwRH0=
 github.com/libp2p/go-libp2p v0.25.2-0.20230217230459-32f2f255292d h1:OjHCu6qL/KM3824vKv/tVdM4SVJim8OEi29u1liNZKY=
 github.com/libp2p/go-libp2p v0.25.2-0.20230217230459-32f2f255292d/go.mod h1:7po3PEsmCs7rXOg7u1sbvsuROpMBq4MVg6LSTAHU1h0=
+github.com/libp2p/go-libp2p v0.25.2-0.20230222220431-c03190e1ca4f h1:nu10GjX7i3VzDu0RRldOg0iEFZ7N7BaUlo/ydFl4xEc=
+github.com/libp2p/go-libp2p v0.25.2-0.20230222220431-c03190e1ca4f/go.mod h1:R8N+XhwPDPLNb4TKboKJKnDeg9vPw8+zlC6g793dTGw=
 github.com/libp2p/go-libp2p-asn-util v0.2.0 h1:rg3+Os8jbnO5DxkC7K/Utdi+DkY3q/d1/1q+8WeNAsw=
 github.com/libp2p/go-libp2p-asn-util v0.2.0/go.mod h1:WoaWxbHKBymSN41hWSq/lGKJEca7TNm58+gGJi2WsLI=
 github.com/libp2p/go-libp2p-autonat v0.1.0/go.mod h1:1tLf2yXxiE/oKGtDwPYWTSYG3PtvYlJmg7NeVtPRqH8=
@@ -1224,10 +1226,16 @@ github.com/quic-go/qtls-go1-18 v0.2.0 h1:5ViXqBZ90wpUcZS0ge79rf029yx0dYB0McyPJwq
 github.com/quic-go/qtls-go1-18 v0.2.0/go.mod h1:moGulGHK7o6O8lSPSZNoOwcLvJKJ85vVNc7oJFD65bc=
 github.com/quic-go/qtls-go1-19 v0.2.0 h1:Cvn2WdhyViFUHoOqK52i51k4nDX8EwIh5VJiVM4nttk=
 github.com/quic-go/qtls-go1-19 v0.2.0/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
+github.com/quic-go/qtls-go1-19 v0.2.1 h1:aJcKNMkH5ASEJB9FXNeZCyTEIHU1J7MmHyz1Q1TSG1A=
+github.com/quic-go/qtls-go1-19 v0.2.1/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
 github.com/quic-go/qtls-go1-20 v0.1.0 h1:d1PK3ErFy9t7zxKsG3NXBJXZjp/kMLoIb3y/kV54oAI=
 github.com/quic-go/qtls-go1-20 v0.1.0/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
+github.com/quic-go/qtls-go1-20 v0.1.1 h1:KbChDlg82d3IHqaj2bn6GfKRj84Per2VGf5XV3wSwQk=
+github.com/quic-go/qtls-go1-20 v0.1.1/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
 github.com/quic-go/quic-go v0.32.0 h1:lY02md31s1JgPiiyfqJijpu/UX/Iun304FI3yUqX7tA=
 github.com/quic-go/quic-go v0.32.0/go.mod h1:/fCsKANhQIeD5l76c2JFU+07gVE3KaA0FP+0zMWwfwo=
+github.com/quic-go/quic-go v0.33.0 h1:ItNoTDN/Fm/zBlq769lLJc8ECe9gYaW40veHCCco7y0=
+github.com/quic-go/quic-go v0.33.0/go.mod h1:YMuhaAV9/jIu0XclDXwZPAsP/2Kgr5yMYhe9oxhhOFA=
 github.com/quic-go/webtransport-go v0.5.1 h1:1eVb7WDWCRoaeTtFHpFBJ6WDN1bSrPrRoW6tZgSw0Ow=
 github.com/quic-go/webtransport-go v0.5.1/go.mod h1:OhmmgJIzTTqXK5xvtuX0oBpLV2GkLWNDA+UeTGJXErU=
 github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=

--- a/go.sum
+++ b/go.sum
@@ -759,8 +759,8 @@ github.com/libp2p/go-libp2p v0.7.0/go.mod h1:hZJf8txWeCduQRDC/WSqBGMxaTHCOYHt2xS
 github.com/libp2p/go-libp2p v0.7.4/go.mod h1:oXsBlTLF1q7pxr+9w6lqzS1ILpyHsaBPniVO7zIHGMw=
 github.com/libp2p/go-libp2p v0.8.1/go.mod h1:QRNH9pwdbEBpx5DTJYg+qxcVaDMAz3Ee/qDKwXujH5o=
 github.com/libp2p/go-libp2p v0.14.3/go.mod h1:d12V4PdKbpL0T1/gsUNN8DfgMuRPDX8bS2QxCZlwRH0=
-github.com/libp2p/go-libp2p v0.25.1 h1:YK+YDCHpYyTvitKWVxa5PfElgIpOONU01X5UcLEwJGA=
-github.com/libp2p/go-libp2p v0.25.1/go.mod h1:xnK9/1d9+jeQCVvi/f1g12KqtVi/jP/SijtKV1hML3g=
+github.com/libp2p/go-libp2p v0.25.2-0.20230217230459-32f2f255292d h1:OjHCu6qL/KM3824vKv/tVdM4SVJim8OEi29u1liNZKY=
+github.com/libp2p/go-libp2p v0.25.2-0.20230217230459-32f2f255292d/go.mod h1:7po3PEsmCs7rXOg7u1sbvsuROpMBq4MVg6LSTAHU1h0=
 github.com/libp2p/go-libp2p-asn-util v0.2.0 h1:rg3+Os8jbnO5DxkC7K/Utdi+DkY3q/d1/1q+8WeNAsw=
 github.com/libp2p/go-libp2p-asn-util v0.2.0/go.mod h1:WoaWxbHKBymSN41hWSq/lGKJEca7TNm58+gGJi2WsLI=
 github.com/libp2p/go-libp2p-autonat v0.1.0/go.mod h1:1tLf2yXxiE/oKGtDwPYWTSYG3PtvYlJmg7NeVtPRqH8=


### PR DESCRIPTION
This PR needs https://github.com/ipfs/kubo/pull/9656 to land first.

## Context 

Allowing users to switch from additional v1 relays to built-in v2 in Kubo.

The idea here is to expose https://github.com/libp2p/go-libp2p/pull/2125 as an experimental, opt-in configuration option, 
for running an unlimited relay in controlled environments (when relay and clients are managed by the same entity). 

We want to fix/update tutorial from https://github.com/ipfs/ipfs-docs/issues/1459. If we can remove the need for asking people to run a separate [libp2p-relay-daemon v1](https://github.com/libp2p/go-libp2p-relay-daemon)), and only run Kubo, that it is a big  win and reduction in complexity and DX/UX win.

## TODO

- [ ] rebase after https://github.com/ipfs/kubo/pull/9656 lands
- [ ] confirm bitswap works and this option helps with https://github.com/ipfs/ipfs-docs/issues/1459 
- [ ] add tests (tbd if sharness, or https://github.com/ipfs/interop/, need to sync with Alex about relays and Helia)

cc @2color  @thediscordian for visibility 