### PR TITLE
ci: set sensible timeouts on all gha jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
   prepare:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       TEST_NO_DOCKER: 1
       TEST_NO_FUSE: 1
@@ -40,6 +41,7 @@ jobs:
   ipfs-interop:
     needs: [prepare]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         suites:
@@ -83,6 +85,7 @@ jobs:
   go-ipfs-api:
     needs: [prepare]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       TEST_NO_DOCKER: 1
       TEST_NO_FUSE: 1
@@ -122,6 +125,7 @@ jobs:
   go-ipfs-http-client:
     needs: [prepare]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       TEST_NO_DOCKER: 1
       TEST_NO_FUSE: 1
@@ -154,6 +158,7 @@ jobs:
   ipfs-webui:
     needs: [prepare]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       NO_SANDBOX: true
       LIBP2P_TCP_REUSEPORT: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ jobs:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,7 @@ jobs:
   docker-build:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       IMAGE_NAME: ipfs/kubo
       WIP_IMAGE_TAG: wip

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     env:
       IMAGE_NAME: ipfs/kubo
       LEGACY_IMAGE_NAME: ipfs/go-ipfs

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -14,6 +14,7 @@ jobs:
   gobuild:
     needs: [runner]
     runs-on: ${{ fromJSON(needs.runner.outputs.config).labels }}
+    timeout-minutes: 20
     env:
       TEST_NO_DOCKER: 1
       TEST_VERBOSE: 1

--- a/.github/workflows/golang-analysis.yml
+++ b/.github/workflows/golang-analysis.yml
@@ -11,6 +11,7 @@ jobs:
   unit:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: All
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -11,6 +11,7 @@ jobs:
   golint:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       TEST_NO_DOCKER: 1
       TEST_NO_FUSE: 1

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -11,6 +11,7 @@ jobs:
   gotest:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       TEST_NO_DOCKER: 1
       TEST_NO_FUSE: 1

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   choose:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     outputs:
       config: ${{ steps.config.outputs.result }}
     steps:

--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -14,6 +14,7 @@ jobs:
   sharness:
     needs: [runner]
     runs-on: ${{ fromJSON(needs.runner.outputs.config).labels }}
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash

--- a/.github/workflows/sync-release-assets.yml
+++ b/.github/workflows/sync-release-assets.yml
@@ -13,6 +13,7 @@ jobs:
   sync-github-and-dist-ipfs-tech:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: "ubuntu-latest"
+    timeout-minutes: 5
     steps:
       - uses: ipfs/download-ipfs-distribution-action@v1
       - uses: ipfs/start-ipfs-daemon-action@v1


### PR DESCRIPTION
This PR sets timeouts on GHA jobs. The values are quite generous because we want the timeouts to only catch degenerate cases - tests never finishing for example - that would have otherwise keep running for 6 hours (I noticed that being the case for a sharness job and an interop job). I looked at https://protocollabs.grafana.net/d/gieYOhbVk/github-actions-ipfs-kubo?orgId=1&from=now-3d&to=now to come up with value proposals.