### PR TITLE
chore: deprecate remaining dht query command

### DIFF
--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -87,6 +87,7 @@ type kademlia interface {
 }
 
 var queryDhtCmd = &cmds.Command{
+	Status: cmds.Deprecated,
 	Helptext: cmds.HelpText{
 		Tagline:          "Find the closest Peer IDs to a given Peer ID by querying the DHT.",
 		ShortDescription: "Outputs a list of newline-delimited Peer IDs.",


### PR DESCRIPTION
We've already deprecated all other `ipfs dht` commands, let's do the same here so it is in "Deprecated" section at https://docs.ipfs.tech/reference/kubo/rpc/ and users are discouraged to build things that rely on it.