### PR TITLE
docs: add bifrost to early testers

### DIFF
--- a/docs/EARLY_TESTERS.md
+++ b/docs/EARLY_TESTERS.md
@@ -22,15 +22,15 @@ We will ask early testers to participate at two points in the process:
 
 ## Who has signed up?
 
-- [ ] pacman.store (@RubenKelevra)
+- [ ] Charity Engine (@rytiss, @tristanolive)
+- [ ] Fission (@bmann)
 - [ ] Infura (@MichaelMure)
-- [ ] Textile (@sanderpick)
+- [ ] OrbitDB (@aphelionz)
+- [ ] pacman.store (@RubenKelevra)
 - [ ] Pinata (@obo20)
 - [ ] RTrade (@postables)
 - [ ] Siderus (@koalalorenzo)
-- [ ] Charity Engine (@rytiss, @tristanolive)
-- [ ] Fission (@bmann)
-- [ ] OrbitDB (@aphelionz)
+- [ ] Textile (@sanderpick)
 
 ## How to sign up?
 

--- a/docs/EARLY_TESTERS.md
+++ b/docs/EARLY_TESTERS.md
@@ -28,6 +28,7 @@ We will ask early testers to participate at two points in the process:
 - [ ] OrbitDB (@aphelionz)
 - [ ] pacman.store (@RubenKelevra)
 - [ ] Pinata (@obo20)
+- [ ] PL EngRes bifrost (@gmasgras)
 - [ ] RTrade (@postables)
 - [ ] Siderus (@koalalorenzo)
 - [ ] Textile (@sanderpick)


### PR DESCRIPTION
This PR sorts early testers list and adds bifrost to it.

@gmasgras Early testers are mentioned in a comment in a Kubo release issue every time a new Kubo release (including RCs) is available. This signal is to replace the protocol/bifrost-infra issues that we've been creating in the past (related to https://github.com/ipfs/kubo/issues/9574).

Should we be mentioning anyone other bifrost team members? 