### PR TITLE
fix: preserve Unlimited StreamsInbound in connmgr reconciliation

### DIFF
--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -459,6 +459,7 @@ func ensureConnMgrMakeSenseVsResourceMgr(concreteLimits rcmgr.ConcreteLimitConfi
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.
 resource manager System.Conns (%d) must be bigger than ConnMgr.HighWater (%d)
+See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.Conns, highWater)
 	}
 	if rcm.System.ConnsInbound != rcmgr.Unlimited && int64(rcm.System.ConnsInbound) <= highWater {
@@ -466,6 +467,7 @@ resource manager System.Conns (%d) must be bigger than ConnMgr.HighWater (%d)
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.
 resource manager System.ConnsInbound (%d) must be bigger than ConnMgr.HighWater (%d)
+See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.ConnsInbound, highWater)
 	}
 	if rcm.System.Streams != rcmgr.Unlimited && int64(rcm.System.Streams) <= highWater {
@@ -473,6 +475,7 @@ resource manager System.ConnsInbound (%d) must be bigger than ConnMgr.HighWater 
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.
 resource manager System.Streams (%d) must be bigger than ConnMgr.HighWater (%d)
+See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.Streams, highWater)
 	}
 	if rcm.System.StreamsInbound != rcmgr.Unlimited && int64(rcm.System.StreamsInbound) <= highWater {
@@ -480,6 +483,7 @@ resource manager System.Streams (%d) must be bigger than ConnMgr.HighWater (%d)
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.
 resource manager System.StreamsInbound (%d) must be bigger than ConnMgr.HighWater (%d)
+See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.StreamsInbound, highWater)
 	}
 	return nil

--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -454,7 +454,7 @@ func ensureConnMgrMakeSenseVsResourceMgr(concreteLimits rcmgr.ConcreteLimitConfi
 	rcm := concreteLimits.ToPartialLimitConfig()
 
 	highWater := cfg.ConnMgr.HighWater.WithDefault(config.DefaultConnMgrHighWater)
-	if rcm.System.Conns != rcmgr.Unlimited && int64(rcm.System.Conns) <= highWater {
+	if (rcm.System.Conns > rcmgr.DefaultLimit || rcm.System.Conns == rcmgr.BlockAllLimit) && int64(rcm.System.Conns) <= highWater {
 		// nolint
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.
@@ -462,7 +462,7 @@ resource manager System.Conns (%d) must be bigger than ConnMgr.HighWater (%d)
 See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.Conns, highWater)
 	}
-	if rcm.System.ConnsInbound != rcmgr.Unlimited && int64(rcm.System.ConnsInbound) <= highWater {
+	if (rcm.System.ConnsInbound > rcmgr.DefaultLimit || rcm.System.ConnsInbound == rcmgr.BlockAllLimit) && int64(rcm.System.ConnsInbound) <= highWater {
 		// nolint
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.
@@ -470,7 +470,7 @@ resource manager System.ConnsInbound (%d) must be bigger than ConnMgr.HighWater 
 See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.ConnsInbound, highWater)
 	}
-	if rcm.System.Streams != rcmgr.Unlimited && int64(rcm.System.Streams) <= highWater {
+	if rcm.System.Streams > rcmgr.DefaultLimit || rcm.System.Streams == rcmgr.BlockAllLimit && int64(rcm.System.Streams) <= highWater {
 		// nolint
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.
@@ -478,7 +478,7 @@ resource manager System.Streams (%d) must be bigger than ConnMgr.HighWater (%d)
 See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.Streams, highWater)
 	}
-	if rcm.System.StreamsInbound != rcmgr.Unlimited && int64(rcm.System.StreamsInbound) <= highWater {
+	if (rcm.System.StreamsInbound > rcmgr.DefaultLimit || rcm.System.StreamsInbound == rcmgr.BlockAllLimit) && int64(rcm.System.StreamsInbound) <= highWater {
 		// nolint
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -129,7 +129,9 @@ func createDefaultLimitConfig(cfg config.SwarmConfig) (limitConfig rcmgr.Concret
 		}
 
 		// Scale System.StreamsInbound as well, but use the existing ratio of StreamsInbound to ConnsInbound
-		partialLimits.System.StreamsInbound = rcmgr.LimitVal(maxInboundConns * int64(partialLimits.System.StreamsInbound) / int64(partialLimits.System.ConnsInbound))
+		if partialLimits.System.StreamsInbound != rcmgr.Unlimited {
+			partialLimits.System.StreamsInbound = rcmgr.LimitVal(maxInboundConns * int64(partialLimits.System.StreamsInbound) / int64(partialLimits.System.ConnsInbound))
+		}
 		partialLimits.System.ConnsInbound = rcmgr.LimitVal(maxInboundConns)
 	}
 

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -118,7 +118,7 @@ func createDefaultLimitConfig(cfg config.SwarmConfig) (limitConfig rcmgr.Concret
 	// There are ways to break this, but this should catch most problems already.
 	// We might improve this in the future.
 	// See: https://github.com/ipfs/kubo/issues/9545
-	if partialLimits.System.ConnsInbound != rcmgr.Unlimited && cfg.ConnMgr.Type.WithDefault(config.DefaultConnMgrType) != "none" {
+	if partialLimits.System.ConnsInbound > rcmgr.DefaultLimit && cfg.ConnMgr.Type.WithDefault(config.DefaultConnMgrType) != "none" {
 		maxInboundConns := int64(partialLimits.System.ConnsInbound)
 		if connmgrHighWaterTimesTwo := cfg.ConnMgr.HighWater.WithDefault(config.DefaultConnMgrHighWater) * 2; maxInboundConns < connmgrHighWaterTimesTwo {
 			maxInboundConns = connmgrHighWaterTimesTwo
@@ -129,7 +129,7 @@ func createDefaultLimitConfig(cfg config.SwarmConfig) (limitConfig rcmgr.Concret
 		}
 
 		// Scale System.StreamsInbound as well, but use the existing ratio of StreamsInbound to ConnsInbound
-		if partialLimits.System.StreamsInbound != rcmgr.Unlimited {
+		if partialLimits.System.StreamsInbound > rcmgr.DefaultLimit {
 			partialLimits.System.StreamsInbound = rcmgr.LimitVal(maxInboundConns * int64(partialLimits.System.StreamsInbound) / int64(partialLimits.System.ConnsInbound))
 		}
 		partialLimits.System.ConnsInbound = rcmgr.LimitVal(maxInboundConns)

--- a/test/cli/rcmgr_test.go
+++ b/test/cli/rcmgr_test.go
@@ -80,10 +80,10 @@ func TestRcmgr(t *testing.T) {
 			require.Equal(t, 0, res.ExitCode())
 			limits := unmarshalLimits(t, res.Stdout.Bytes())
 
-			if limits.System.ConnsInbound != rcmgr.Unlimited {
+			if limits.System.ConnsInbound > rcmgr.DefaultLimit {
 				assert.GreaterOrEqual(t, limits.System.ConnsInbound, 800)
 			}
-			if limits.System.StreamsInbound != rcmgr.Unlimited {
+			if limits.System.StreamsInbound > rcmgr.DefaultLimit {
 				assert.GreaterOrEqual(t, limits.System.StreamsInbound, 800)
 			}
 		})

--- a/test/cli/rcmgr_test.go
+++ b/test/cli/rcmgr_test.go
@@ -126,6 +126,22 @@ func TestRcmgr(t *testing.T) {
 		})
 	})
 
+	t.Run("smoke test unlimited System inbounds", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init()
+		node.UpdateUserSuppliedResourceManagerOverrides(func(overrides *rcmgr.PartialLimitConfig) {
+			overrides.System.StreamsInbound = rcmgr.Unlimited
+			overrides.System.ConnsInbound = rcmgr.Unlimited
+		})
+		node.StartDaemon()
+
+		res := node.RunIPFS("swarm", "resources", "--enc=json")
+		limits := unmarshalLimits(t, res.Stdout.Bytes())
+
+		assert.Equal(t, rcmgr.Unlimited, limits.System.ConnsInbound)
+		assert.Equal(t, rcmgr.Unlimited, limits.System.StreamsInbound)
+	})
+
 	t.Run("smoke test transient scope", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init()


### PR DESCRIPTION
Fixes #9695