### PR TITLE
docs: use fx.Decorate instead of fx.Replace in examples

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,14 +51,15 @@ plugin type is likely the best interim solution.
 ### fx (experimental)
 
 Fx plugins let you customize the [fx](https://pkg.go.dev/go.uber.org/fx) dependency graph and configuration,
-by customizing the`fx.Option`s that are passed to `fx` when the IPFS node is initialized.
+by customizing the`fx.Option`s that are passed to `fx` when the Kubo node is initialized.
 
-For example, you can inject custom implementations of interfaces such as [exchange.Interface](https://github.com/ipfs/go-ipfs-exchange-interface)
-or [pin.Pinner](https://github.com/ipfs/go-ipfs-pinner) by adding an option like `fx.Replace(fx.Annotate(customExchange, fx.As(new(exchange.Interface))))`.
+For example, you can override an interface such as [exchange.Interface](https://github.com/ipfs/go-ipfs-exchange-interface)
+or [pin.Pinner](https://github.com/ipfs/go-ipfs-pinner) with a custom implementation by appending an option like
+`fx.Decorate(func() exchange.Interface { return customExchange })`.
 
 Fx supports some advanced customization. Simple interface replacements like above are unlikely to break in the future, 
 but the more invasive your changes, the more likely they are to break between releases. Kubo cannot guarantee backwards
-compatibility for invasive `fx` customizations.
+compatibility for `fx` customizations.
 
 Fx options are applied across every execution of the `ipfs` binary, including:
 
@@ -68,7 +69,7 @@ Fx options are applied across every execution of the `ipfs` binary, including:
 - etc.
 
 So if you plug in a blockservice that disallows non-allowlisted CIDs, then this may break migrations
-that fetch migration code over IPFS.
+that fetch migration code over the IPFS network.
 
 ### Internal
 


### PR DESCRIPTION
In practice there are cases when fx.Replace doesn't work as expected, so this updates the documentation to recommend using fx.Decorate instead which is a bit easier to use.