### PR TITLE
test: fix flaky rcmgr test

### DIFF
--- a/test/cli/rcmgr_test.go
+++ b/test/cli/rcmgr_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core/node/libp2p"
 	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/ipfs/kubo/test/cli/testutils"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
@@ -209,7 +210,10 @@ func TestRcmgr(t *testing.T) {
 				Args: []string{"swarm", "connect", node1.SwarmAddrsWithPeerIDs()[0].String()},
 			})
 			assert.Equal(t, 1, res.ExitCode())
-			assert.Contains(t, res.Stderr.String(), "failed to find any peer in table")
+			testutils.AssertStringContainsOneOf(t, res.Stderr.String(),
+				"failed to find any peer in table",
+				"resource limit exceeded",
+			)
 
 			res = node0.RunIPFS("ping", "-n2", peerID1)
 			assert.Equal(t, 1, res.ExitCode())

--- a/test/cli/testutils/asserts.go
+++ b/test/cli/testutils/asserts.go
@@ -1,0 +1,15 @@
+package testutils
+
+import (
+	"strings"
+	"testing"
+)
+
+func AssertStringContainsOneOf(t *testing.T, str string, ss ...string) {
+	for _, s := range ss {
+		if strings.Contains(str, s) {
+			return
+		}
+	}
+	t.Errorf("%q does not contain one of %v", str, ss)
+}


### PR DESCRIPTION
example flake: https://app.circleci.com/pipelines/github/ipfs/kubo/9370/workflows/f817e02d-3d2a-43ab-b090-e95a5bcd34b5/jobs/101311
