### PR TITLE
fix: canonicalize user defined headers

### DIFF
--- a/core/corehttp/gateway_writable.go
+++ b/core/corehttp/gateway_writable.go
@@ -30,7 +30,7 @@ type writableGatewayHandler struct {
 
 func (i *writableGatewayHandler) addUserHeaders(w http.ResponseWriter) {
 	for k, v := range i.config.Headers {
-		w.Header()[k] = v
+		w.Header()[http.CanonicalHeaderKey(k)] = v
 	}
 }
 

--- a/core/corehttp/redirect.go
+++ b/core/corehttp/redirect.go
@@ -32,7 +32,7 @@ type redirectHandler struct {
 
 func (i *redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for k, v := range i.headers {
-		w.Header()[k] = v
+		w.Header()[http.CanonicalHeaderKey(k)] = v
 	}
 
 	http.Redirect(w, r, i.path, http.StatusFound)


### PR DESCRIPTION
@lidel I did not use `.Set` because that does not allow us to define multiple values, which the user can.

> Set sets the header entries associated with key to the single element value. It replaces any existing values associated with key. https://pkg.go.dev/net/http#Header.Set