### PR TITLE
feat: add identify option to swarm peers command

### DIFF
--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -463,7 +463,7 @@ func (ci connInfos) Swap(i, j int) {
 	ci.Peers[i], ci.Peers[j] = ci.Peers[j], ci.Peers[i]
 }
 
-func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, error) {
+func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (*IdOutput, error) {
 	var info IdOutput
 	keyEnc, err := ke.KeyEncoderFromString(ke.OptionIPNSBase.Name())
 	if err != nil {
@@ -506,7 +506,7 @@ func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, erro
 		}
 	}
 
-	return info, nil
+	return &info, nil
 }
 
 // directionString transfers to string

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ipfs/kubo/commands"
 	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core/commands/cmdenv"
-	ke "github.com/ipfs/kubo/core/commands/keyencode"
 	"github.com/ipfs/kubo/core/node/libp2p"
 	"github.com/ipfs/kubo/repo"
 	"github.com/ipfs/kubo/repo/fsrepo"
@@ -465,12 +464,8 @@ func (ci connInfos) Swap(i, j int) {
 
 func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, error) {
 	var info IdOutput
-	keyEnc, err := ke.KeyEncoderFromString(ke.OptionIPNSBase.Name())
-	if err != nil {
-		return IdOutput{}, err
-	}
-	info.ID = keyEnc.FormatID(p)
-
+	info.ID = p.String()
+	
 	if pk := ps.PubKey(p); pk != nil {
 		pkb, err := ic.MarshalPublicKey(pk)
 		if err != nil {

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -465,7 +465,7 @@ func (ci connInfos) Swap(i, j int) {
 func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, error) {
 	var info IdOutput
 	info.ID = p.String()
-	
+
 	if pk := ps.PubKey(p); pk != nil {
 		pkb, err := ic.MarshalPublicKey(pk)
 		if err != nil {

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -300,7 +300,7 @@ var swarmPeersCmd = &cmds.Command{
 					return err
 				}
 				identifyResult, _ := ci.identifyPeer(n.Peerstore, c.ID())
-				ci.Identify = *identifyResult
+				ci.Identify = identifyResult
 			}
 			sort.Sort(&ci)
 			out.Peers = append(out.Peers, ci)
@@ -463,18 +463,18 @@ func (ci connInfos) Swap(i, j int) {
 	ci.Peers[i], ci.Peers[j] = ci.Peers[j], ci.Peers[i]
 }
 
-func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (*IdOutput, error) {
+func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, error) {
 	var info IdOutput
 	keyEnc, err := ke.KeyEncoderFromString(ke.OptionIPNSBase.Name())
 	if err != nil {
-		return nil, err
+		return IdOutput{}, err
 	}
 	info.ID = keyEnc.FormatID(p)
 
 	if pk := ps.PubKey(p); pk != nil {
 		pkb, err := ic.MarshalPublicKey(pk)
 		if err != nil {
-			return nil, err
+			return IdOutput{}, err
 		}
 		info.PublicKey = base64.StdEncoding.EncodeToString(pkb)
 	}
@@ -482,7 +482,7 @@ func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (*IdOutput, err
 	addrInfo := ps.PeerInfo(p)
 	addrs, err := peer.AddrInfoToP2pAddrs(&addrInfo)
 	if err != nil {
-		return nil, err
+		return IdOutput{}, err
 	}
 
 	for _, a := range addrs {
@@ -506,7 +506,7 @@ func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (*IdOutput, err
 		}
 	}
 
-	return &info, nil
+	return info, nil
 }
 
 // directionString transfers to string

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -490,9 +490,10 @@ func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, erro
 	}
 	sort.Strings(info.Addresses)
 
-	protocols, _ := ps.GetProtocols(p) // don't care about errors here.
-	info.Protocols = append(info.Protocols, protocols...)
-	sort.Slice(info.Protocols, func(i, j int) bool { return info.Protocols[i] < info.Protocols[j] })
+	if protocols, err := ps.GetProtocols(p); err == nil {
+		info.Protocols = append(info.Protocols, protocols...)
+		sort.Slice(info.Protocols, func(i, j int) bool { return info.Protocols[i] < info.Protocols[j] })
+	}
 
 	if v, err := ps.Get(p, "ProtocolVersion"); err == nil {
 		if vs, ok := v.(string); ok {

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -463,8 +463,8 @@ func (ci connInfos) Swap(i, j int) {
 	ci.Peers[i], ci.Peers[j] = ci.Peers[j], ci.Peers[i]
 }
 
-func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (*IdOutput, error) {
-	info := new(IdOutput)
+func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, error) {
+	var info IdOutput
 	keyEnc, err := ke.KeyEncoderFromString(ke.OptionIPNSBase.Name())
 	if err != nil {
 		return nil, err

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -425,13 +425,13 @@ type streamInfo struct {
 }
 
 type connInfo struct {
-	Addr      string
-	Peer      string
-	Latency   string
-	Muxer     string
-	Direction inet.Direction
-	Streams   []streamInfo
-	Identify  IdOutput
+	Addr      string         `json:",omitempty"`
+	Peer      string         `json:",omitempty"`
+	Latency   string         `json:",omitempty"`
+	Muxer     string         `json:",omitempty"`
+	Direction inet.Direction `json:",omitempty"`
+	Streams   []streamInfo   `json:",omitempty"`
+	Identify  IdOutput       `json:",omitempty"`
 }
 
 func (ci *connInfo) Less(i, j int) bool {

--- a/test/cli/harness/peering.go
+++ b/test/cli/harness/peering.go
@@ -14,7 +14,7 @@ type Peering struct {
 }
 
 func NewRandPort() int {
-	n:= rand.Int()
+	n := rand.Int()
 	return 3000 + (n % 1000)
 }
 
@@ -35,4 +35,3 @@ func CreatePeerNodes(t *testing.T, n int, peerings []Peering) (*Harness, Nodes) 
 
 	return h, nodes
 }
-

--- a/test/cli/harness/peering.go
+++ b/test/cli/harness/peering.go
@@ -13,7 +13,7 @@ type Peering struct {
 	To   int
 }
 
-func NewRandPort() int {
+func newRandPort() int {
 	n := rand.Int()
 	return 3000 + (n % 1000)
 }
@@ -24,7 +24,7 @@ func CreatePeerNodes(t *testing.T, n int, peerings []Peering) (*Harness, Nodes) 
 	nodes.ForEachPar(func(node *Node) {
 		node.UpdateConfig(func(cfg *config.Config) {
 			cfg.Routing.Type = config.NewOptionalString("none")
-			cfg.Addresses.Swarm = []string{fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", NewRandPort())}
+			cfg.Addresses.Swarm = []string{fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", newRandPort())}
 		})
 
 	})

--- a/test/cli/harness/peering.go
+++ b/test/cli/harness/peering.go
@@ -1,0 +1,38 @@
+package harness
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/ipfs/kubo/config"
+)
+
+type Peering struct {
+	From int
+	To   int
+}
+
+func NewRandPort() int {
+	n:= rand.Int()
+	return 3000 + (n % 1000)
+}
+
+func CreatePeerNodes(t *testing.T, n int, peerings []Peering) (*Harness, Nodes) {
+	h := NewT(t)
+	nodes := h.NewNodes(n).Init()
+	nodes.ForEachPar(func(node *Node) {
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.Routing.Type = config.NewOptionalString("none")
+			cfg.Addresses.Swarm = []string{fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", NewRandPort())}
+		})
+
+	})
+
+	for _, peering := range peerings {
+		nodes[peering.From].PeerWith(nodes[peering.To])
+	}
+
+	return h, nodes
+}
+

--- a/test/cli/peering_test.go
+++ b/test/cli/peering_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPeering(t *testing.T) {
 	t.Parallel()
-	
+
 	containsPeerID := func(p peer.ID, peers []peer.ID) bool {
 		for _, peerID := range peers {
 			if p == peerID {
@@ -55,7 +55,6 @@ func TestPeering(t *testing.T) {
 			assertPeered(h, nodes[peering.From], nodes[peering.To])
 		})
 	}
-
 
 	t.Run("bidirectional peering should work (simultaneous connect)", func(t *testing.T) {
 		t.Parallel()

--- a/test/cli/swarm_test.go
+++ b/test/cli/swarm_test.go
@@ -48,7 +48,7 @@ func TestSwarm(t *testing.T) {
 		res := node.RunIPFS("swarm", "peers", "--enc=json", "--identify")
 		var output expectedOutputType
 		err := json.Unmarshal(res.Stdout.Bytes(), &output)
-        assert.Nil(t, err)
+		assert.Nil(t, err)
 		actualID := output.Peers[0].Identify.ID
 		actualPublicKey := output.Peers[0].Identify.PublicKey
 		actualAgentVersion := output.Peers[0].Identify.AgentVersion
@@ -78,12 +78,12 @@ func TestSwarm(t *testing.T) {
 		otherNodeIDResponse := otherNode.RunIPFS("id", "--enc=json")
 		var otherNodeIDOutput identifyType
 		err := json.Unmarshal(otherNodeIDResponse.Stdout.Bytes(), &otherNodeIDOutput)
-        assert.Nil(t,err)
+		assert.Nil(t, err)
 		res := node.RunIPFS("swarm", "peers", "--enc=json", "--identify")
 
 		var output expectedOutputType
 		err = json.Unmarshal(res.Stdout.Bytes(), &output)
-        assert.Nil(t,err)
+		assert.Nil(t, err)
 		outputIdentify := output.Peers[0].Identify
 
 		assert.Equal(t, outputIdentify.ID, otherNodeIDOutput.ID)

--- a/test/cli/swarm_test.go
+++ b/test/cli/swarm_test.go
@@ -47,19 +47,19 @@ func TestSwarm(t *testing.T) {
 
 		res := node.RunIPFS("swarm", "peers", "--enc=json", "--identify")
 		var output expectedOutputType
-		json.Unmarshal(res.Stdout.Bytes(), &output)
-
-		actualId := output.Peers[0].Identify.ID
+		err := json.Unmarshal(res.Stdout.Bytes(), &output)
+        assert.Nil(t, err)
+		actualID := output.Peers[0].Identify.ID
 		actualPublicKey := output.Peers[0].Identify.PublicKey
 		actualAgentVersion := output.Peers[0].Identify.AgentVersion
 		actualAdresses := output.Peers[0].Identify.Addresses
 		actualProtocolVersion := output.Peers[0].Identify.ProtocolVersion
 		actualProtocols := output.Peers[0].Identify.Protocols
 
-		expectedId := otherNode.PeerID().String()
-		expectedAddresses := []string{fmt.Sprintf("%s/p2p/%s", otherNode.SwarmAddrs()[0], actualId)}
+		expectedID := otherNode.PeerID().String()
+		expectedAddresses := []string{fmt.Sprintf("%s/p2p/%s", otherNode.SwarmAddrs()[0], actualID)}
 
-		assert.Equal(t, actualId, expectedId)
+		assert.Equal(t, actualID, expectedID)
 		assert.NotNil(t, actualPublicKey)
 		assert.NotNil(t, actualAgentVersion)
 		assert.NotNil(t, actualProtocolVersion)
@@ -77,12 +77,13 @@ func TestSwarm(t *testing.T) {
 
 		otherNodeIDResponse := otherNode.RunIPFS("id", "--enc=json")
 		var otherNodeIDOutput identifyType
-		json.Unmarshal(otherNodeIDResponse.Stdout.Bytes(), &otherNodeIDOutput)
-
+		err := json.Unmarshal(otherNodeIDResponse.Stdout.Bytes(), &otherNodeIDOutput)
+        assert.Nil(t,err)
 		res := node.RunIPFS("swarm", "peers", "--enc=json", "--identify")
 
 		var output expectedOutputType
-		json.Unmarshal(res.Stdout.Bytes(), &output)
+		err = json.Unmarshal(res.Stdout.Bytes(), &output)
+        assert.Nil(t,err)
 		outputIdentify := output.Peers[0].Identify
 
 		assert.Equal(t, outputIdentify.ID, otherNodeIDOutput.ID)

--- a/test/cli/swarm_test.go
+++ b/test/cli/swarm_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TODO: Migrate the rest of the sharness swarm test.
 func TestSwarm(t *testing.T) {
 	type identifyType struct {
 		ID              string

--- a/test/cli/swarm_test.go
+++ b/test/cli/swarm_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,14 +11,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
-
 func TestSwarm(t *testing.T) {
 	type identifyType struct {
-		ID string
+		ID              string
+		PublicKey       string
+		Addresses       []string
+		AgentVersion    string
+		ProtocolVersion string
+		Protocols       []string
 	}
 	type peer struct {
-	   Identify identifyType
+		Identify identifyType
 	}
 	type expectedOutputType struct {
 		Peers []peer
@@ -25,30 +29,48 @@ func TestSwarm(t *testing.T) {
 
 	t.Parallel()
 
-	t.Run("ipfs swarm peers returns empty peers when a node is not connected to any peers", func (t *testing.T){
+	t.Run("ipfs swarm peers returns empty peers when a node is not connected to any peers", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init().StartDaemon()
-		res := node.RunIPFS("swarm","peers","--enc=json","--identify")
+		res := node.RunIPFS("swarm", "peers", "--enc=json", "--identify")
 		var output expectedOutputType
-		err := json.Unmarshal(res.Stdout.Bytes(),&output)
-		assert.Nil(t,err)
-		assert.Equal(t,0,len(output.Peers))
+		err := json.Unmarshal(res.Stdout.Bytes(), &output)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(output.Peers))
 
 	})
-	t.Run("ipfs swarm peers with flag identify outputs expected results", func(t *testing.T) {
+	t.Run("ipfs swarm peers with flag identify outputs expected identify information about connected peers", func(t *testing.T) {
 		t.Parallel()
 		peerings := []harness.Peering{{From: 0, To: 1}}
 		_, nodes := harness.CreatePeerNodes(t, 2, peerings)
+
 		nodes.StartDaemons()
-		assert.Eventuallyf(t,func () bool {
-			res := nodes[1].RunIPFS("swarm","peers","--enc=json","--identify")
+		assert.Eventuallyf(t, func() bool {
+			res := nodes[1].RunIPFS("swarm", "peers", "--enc=json", "--identify")
 			var output expectedOutputType
-			err := json.Unmarshal(res.Stdout.Bytes(),&output)
+			err := json.Unmarshal(res.Stdout.Bytes(), &output)
 			if len(output.Peers) == 0 || err != nil {
 				return false
 			}
-			return assert.Equal(t,output.Peers[0].Identify.ID,nodes[0].PeerID().String(),nodes[0].PeerID().String())  
-		},20*time.Second, 10*time.Millisecond, "not peered")
-	
+			actualId := output.Peers[0].Identify.ID
+			actualPublicKey := output.Peers[0].Identify.PublicKey
+			actualAgentVersion := output.Peers[0].Identify.AgentVersion
+			actualAdresses := output.Peers[0].Identify.Addresses
+			actualProtocolVersion := output.Peers[0].Identify.ProtocolVersion
+			actualProtocols := output.Peers[0].Identify.Protocols
+
+			expectedId := nodes[0].PeerID().String()
+			expectedAddresses := []string{fmt.Sprintf("%s/p2p/%s", nodes[0].SwarmAddrs()[0], actualId)}
+
+			isResultValid := assert.Equal(t, actualId, expectedId) &&
+				assert.NotNil(t, actualPublicKey) &&
+				assert.NotNil(t, actualAgentVersion) &&
+				assert.NotNil(t, actualProtocolVersion) &&
+				assert.Len(t, actualAdresses, 1) &&
+				assert.Equal(t, expectedAddresses[0], actualAdresses[0]) &&
+				assert.Greater(t, len(actualProtocols), 0)
+			return isResultValid
+		}, 20*time.Second, 10*time.Millisecond, "error obtaining peer info")
+
 	})
 }

--- a/test/cli/swarm_test.go
+++ b/test/cli/swarm_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ipfs/kubo/test/cli/harness"
+
+	"github.com/stretchr/testify/assert"
+)
+
+
+
+func TestSwarm(t *testing.T) {
+	type identifyType struct {
+		ID string
+	}
+	type peer struct {
+	   Identify identifyType
+	}
+	type expectedOutputType struct {
+		Peers []peer
+	}
+
+	t.Parallel()
+
+	t.Run("ipfs swarm peers returns empty peers when a node is not connected to any peers", func (t *testing.T){
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init().StartDaemon()
+		res := node.RunIPFS("swarm","peers","--enc=json","--identify")
+		var output expectedOutputType
+		err := json.Unmarshal(res.Stdout.Bytes(),&output)
+		assert.Nil(t,err)
+		assert.Equal(t,0,len(output.Peers))
+
+	})
+	t.Run("ipfs swarm peers with flag identify outputs expected results", func(t *testing.T) {
+		t.Parallel()
+		peerings := []harness.Peering{{From: 0, To: 1}}
+		_, nodes := harness.CreatePeerNodes(t, 2, peerings)
+		nodes.StartDaemons()
+		assert.Eventuallyf(t,func () bool {
+			res := nodes[1].RunIPFS("swarm","peers","--enc=json","--identify")
+			var output expectedOutputType
+			err := json.Unmarshal(res.Stdout.Bytes(),&output)
+			if len(output.Peers) == 0 || err != nil {
+				return false
+			}
+			return assert.Equal(t,output.Peers[0].Identify.ID,nodes[0].PeerID().String(),nodes[0].PeerID().String())  
+		},20*time.Second, 10*time.Millisecond, "not peered")
+	
+	})
+}


### PR DESCRIPTION
It adds the feature requested on [#9578](https://github.com/ipfs/kubo/issues/9578). This PR adds a new opt-in flag called identify that adds Identify values to the command output. 