### PR TITLE
Allow injecting custom path resolvers.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -21,6 +21,7 @@ import (
 	exchange "github.com/ipfs/boxo/exchange"
 	"github.com/ipfs/boxo/fetcher"
 	mfs "github.com/ipfs/boxo/mfs"
+	pathresolver "github.com/ipfs/boxo/path/resolver"
 	provider "github.com/ipfs/boxo/provider"
 	"github.com/ipfs/go-graphsync"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -87,18 +88,20 @@ type IpfsNode struct {
 	RecordValidator      record.Validator
 
 	// Online
-	PeerHost        p2phost.Host               `optional:"true"` // the network host (server+client)
-	Peering         *peering.PeeringService    `optional:"true"`
-	Filters         *ma.Filters                `optional:"true"`
-	Bootstrapper    io.Closer                  `optional:"true"` // the periodic bootstrapper
-	Routing         irouting.ProvideManyRouter `optional:"true"` // the routing system. recommend ipfs-dht
-	DNSResolver     *madns.Resolver            // the DNS resolver
-	Exchange        exchange.Interface         // the block exchange + strategy (bitswap)
-	Namesys         namesys.NameSystem         // the name system, resolves paths to hashes
-	Provider        provider.System            // the value provider system
-	IpnsRepub       *ipnsrp.Republisher        `optional:"true"`
-	GraphExchange   graphsync.GraphExchange    `optional:"true"`
-	ResourceManager network.ResourceManager    `optional:"true"`
+	PeerHost           p2phost.Host               `optional:"true"` // the network host (server+client)
+	Peering            *peering.PeeringService    `optional:"true"`
+	Filters            *ma.Filters                `optional:"true"`
+	Bootstrapper       io.Closer                  `optional:"true"` // the periodic bootstrapper
+	Routing            irouting.ProvideManyRouter `optional:"true"` // the routing system. recommend ipfs-dht
+	DNSResolver        *madns.Resolver            // the DNS resolver
+	IPLDPathResolver   pathresolver.Resolver      `name:"ipldPathResolver"`   // The IPLD path resolver
+	UnixFSPathResolver pathresolver.Resolver      `name:"unixFSPathResolver"` // The UnixFS path resolver
+	Exchange           exchange.Interface         // the block exchange + strategy (bitswap)
+	Namesys            namesys.NameSystem         // the name system, resolves paths to hashes
+	Provider           provider.System            // the value provider system
+	IpnsRepub          *ipnsrp.Republisher        `optional:"true"`
+	GraphExchange      graphsync.GraphExchange    `optional:"true"`
+	ResourceManager    network.ResourceManager    `optional:"true"`
 
 	PubSub   *pubsub.PubSub             `optional:"true"`
 	PSRouter *psrouter.PubsubValueStore `optional:"true"`

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -26,6 +26,7 @@ import (
 	offlinexch "github.com/ipfs/boxo/exchange/offline"
 	"github.com/ipfs/boxo/fetcher"
 	dag "github.com/ipfs/boxo/ipld/merkledag"
+	pathresolver "github.com/ipfs/boxo/path/resolver"
 	pin "github.com/ipfs/boxo/pinning/pinner"
 	provider "github.com/ipfs/boxo/provider"
 	offlineroute "github.com/ipfs/boxo/routing/offline"
@@ -65,9 +66,11 @@ type CoreAPI struct {
 	recordValidator      record.Validator
 	exchange             exchange.Interface
 
-	namesys     namesys.NameSystem
-	routing     routing.Routing
-	dnsResolver *madns.Resolver
+	namesys            namesys.NameSystem
+	routing            routing.Routing
+	dnsResolver        *madns.Resolver
+	ipldPathResolver   pathresolver.Resolver
+	unixFSPathResolver pathresolver.Resolver
 
 	provider provider.System
 
@@ -179,13 +182,15 @@ func (api *CoreAPI) WithOptions(opts ...options.ApiOption) (coreiface.CoreAPI, e
 		ipldFetcherFactory:   n.IPLDFetcherFactory,
 		unixFSFetcherFactory: n.UnixFSFetcherFactory,
 
-		peerstore:       n.Peerstore,
-		peerHost:        n.PeerHost,
-		namesys:         n.Namesys,
-		recordValidator: n.RecordValidator,
-		exchange:        n.Exchange,
-		routing:         n.Routing,
-		dnsResolver:     n.DNSResolver,
+		peerstore:          n.Peerstore,
+		peerHost:           n.PeerHost,
+		namesys:            n.Namesys,
+		recordValidator:    n.RecordValidator,
+		exchange:           n.Exchange,
+		routing:            n.Routing,
+		dnsResolver:        n.DNSResolver,
+		ipldPathResolver:   n.IPLDPathResolver,
+		unixFSPathResolver: n.UnixFSPathResolver,
 
 		provider: n.Provider,
 

--- a/core/coreapi/path.go
+++ b/core/coreapi/path.go
@@ -13,7 +13,6 @@ import (
 
 	coreiface "github.com/ipfs/boxo/coreiface"
 	path "github.com/ipfs/boxo/coreiface/path"
-	"github.com/ipfs/boxo/fetcher"
 	ipfspath "github.com/ipfs/boxo/path"
 	ipfspathresolver "github.com/ipfs/boxo/path/resolver"
 	"github.com/ipfs/go-cid"
@@ -63,13 +62,12 @@ func (api *CoreAPI) ResolvePath(ctx context.Context, p path.Path) (path.Resolved
 		return nil, fmt.Errorf("unsupported path namespace: %s", p.Namespace())
 	}
 
-	var dataFetcher fetcher.Factory
+	var resolver ipfspathresolver.Resolver
 	if ipath.Segments()[0] == "ipld" {
-		dataFetcher = api.ipldFetcherFactory
+		resolver = api.ipldPathResolver
 	} else {
-		dataFetcher = api.unixFSFetcherFactory
+		resolver = api.unixFSPathResolver
 	}
-	resolver := ipfspathresolver.NewBasicResolver(dataFetcher)
 
 	node, rest, err := resolver.ResolveToLastNode(ctx, ipath)
 	if err != nil {

--- a/core/node/core.go
+++ b/core/node/core.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/ipfs/boxo/ipld/unixfs"
 	"github.com/ipfs/boxo/mfs"
+	pathresolver "github.com/ipfs/boxo/path/resolver"
 	pin "github.com/ipfs/boxo/pinning/pinner"
 	"github.com/ipfs/boxo/pinning/pinner/dspinner"
 	"github.com/ipfs/go-cid"
@@ -83,14 +84,22 @@ func (s *syncDagService) Session(ctx context.Context) format.NodeGetter {
 	return merkledag.NewSession(ctx, s.DAGService)
 }
 
-type fetchersOut struct {
+// FetchersOut allows injection of fetchers.
+type FetchersOut struct {
 	fx.Out
 	IPLDFetcher   fetcher.Factory `name:"ipldFetcher"`
 	UnixfsFetcher fetcher.Factory `name:"unixfsFetcher"`
 }
 
+// FetchersIn allows using fetchers for other dependencies.
+type FetchersIn struct {
+	fx.In
+	IPLDFetcher   fetcher.Factory `name:"ipldFetcher"`
+	UnixfsFetcher fetcher.Factory `name:"unixfsFetcher"`
+}
+
 // FetcherConfig returns a fetcher config that can build new fetcher instances
-func FetcherConfig(bs blockservice.BlockService) fetchersOut {
+func FetcherConfig(bs blockservice.BlockService) FetchersOut {
 	ipldFetcher := bsfetcher.NewFetcherConfig(bs)
 	ipldFetcher.PrototypeChooser = dagpb.AddSupportToChooser(func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
 		if tlnkNd, ok := lnkCtx.LinkNode.(schema.TypedLinkNode); ok {
@@ -100,7 +109,22 @@ func FetcherConfig(bs blockservice.BlockService) fetchersOut {
 	})
 
 	unixFSFetcher := ipldFetcher.WithReifier(unixfsnode.Reify)
-	return fetchersOut{IPLDFetcher: ipldFetcher, UnixfsFetcher: unixFSFetcher}
+	return FetchersOut{IPLDFetcher: ipldFetcher, UnixfsFetcher: unixFSFetcher}
+}
+
+// PathResolversOut allows injection of path resolvers
+type PathResolversOut struct {
+	fx.Out
+	IPLDPathResolver   pathresolver.Resolver `name:"ipldPathResolver"`
+	UnixFSPathResolver pathresolver.Resolver `name:"unixFSPathResolver"`
+}
+
+// PathResolverConfig creates path resolvers with the given fetchers.
+func PathResolverConfig(fetchers FetchersIn) PathResolversOut {
+	return PathResolversOut{
+		IPLDPathResolver:   pathresolver.NewBasicResolver(fetchers.IPLDFetcher),
+		UnixFSPathResolver: pathresolver.NewBasicResolver(fetchers.UnixfsFetcher),
+	}
 }
 
 // Dag creates new DAGService

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -334,6 +334,7 @@ var Core = fx.Options(
 	fx.Provide(BlockService),
 	fx.Provide(Dag),
 	fx.Provide(FetcherConfig),
+	fx.Provide(PathResolverConfig),
 	fx.Provide(Pinning),
 	fx.Provide(Files),
 )

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -17,7 +17,6 @@ import (
 	ft "github.com/ipfs/boxo/ipld/unixfs"
 	uio "github.com/ipfs/boxo/ipld/unixfs/io"
 	path "github.com/ipfs/boxo/path"
-	"github.com/ipfs/boxo/path/resolver"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
@@ -69,7 +68,7 @@ func (s *Root) Lookup(ctx context.Context, name string) (fs.Node, error) {
 		return nil, fuse.ENOENT
 	}
 
-	nd, ndLnk, err := resolver.NewBasicResolver(s.Ipfs.UnixFSFetcherFactory).ResolvePath(ctx, p)
+	nd, ndLnk, err := s.Ipfs.UnixFSPathResolver.ResolvePath(ctx, p)
 	if err != nil {
 		// todo: make this error more versatile.
 		return nil, fuse.ENOENT


### PR DESCRIPTION
In order to make it possible to easily-overwrite the path Resolvers (i.e. via plugins), this creates resolvers as part of the Node rather than creating them ad-hoc.