### PR TITLE
test: fix autoclient flakiness

### DIFF
--- a/test/cli/dht_autoclient_test.go
+++ b/test/cli/dht_autoclient_test.go
@@ -20,6 +20,7 @@ func TestDHTAutoclient(t *testing.T) {
 	t.Run("file added on node in client mode is retrievable from node in client mode", func(t *testing.T) {
 		t.Parallel()
 		randomBytes := testutils.RandomBytes(1000)
+		randomBytes = append(randomBytes, '\r')
 		hash := nodes[8].IPFSAdd(bytes.NewReader(randomBytes))
 
 		res := nodes[9].IPFS("cat", hash)

--- a/test/cli/harness/buffer.go
+++ b/test/cli/harness/buffer.go
@@ -25,11 +25,19 @@ func (b *Buffer) String() string {
 	return b.b.String()
 }
 
-// Trimmed returns the bytes as a string, with leading and trailing whitespace removed.
+// Trimmed returns the bytes as a string, but with the trailing newline removed.
+// This only removes a single trailing newline, not all whitespace.
 func (b *Buffer) Trimmed() string {
 	b.m.Lock()
 	defer b.m.Unlock()
-	return strings.TrimSpace(b.b.String())
+	s := b.b.String()
+	if len(s) == 0 {
+		return s
+	}
+	if s[len(s)-1] == '\n' {
+		return s[:len(s)-1]
+	}
+	return s
 }
 
 func (b *Buffer) Bytes() []byte {


### PR DESCRIPTION
The test trims all whitespace bytes from the output of 'ipfs cat' but if the random bytes end in a whitespace char then it trims that too, resulting in random test failure.

Instead this updates the test harness to only trim a single trailing newline char, so that it doesn't end up chomping legitimate output.