### PR TITLE
test: skip flaky pubsub test

### DIFF
--- a/test/integration/pubsub_msg_seen_cache_test.go
+++ b/test/integration/pubsub_msg_seen_cache_test.go
@@ -20,16 +20,17 @@ import (
 	"github.com/ipfs/go-datastore"
 	syncds "github.com/ipfs/go-datastore/sync"
 
-	"github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p-pubsub/pb"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p-pubsub/timecache"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	mock "github.com/ipfs/kubo/core/mock"
-	"github.com/libp2p/go-libp2p/p2p/net/mock"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 )
 
 func TestMessageSeenCacheTTL(t *testing.T) {
+	t.Skip("skipping PubSub seen cache TTL test due to flakiness")
 	if err := RunMessageSeenCacheTTLTest(t, "10s"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This test flakes very often and we plan on removing this feature entirely, so disabling this test since its failures are pretty disruptive.