### PR TITLE
test: cancel workflows on same branch when new commit is added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
 env:
   GO_VERSION: 1.19.1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   interop-prep:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,10 @@ permissions:
   contents: read  #  to fetch code (actions/checkout)
   security-events: write  #   (github/codeql-action/autobuild)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codeql:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker-build:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go-build-runner:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/golang-analysis.yml
+++ b/.github/workflows/golang-analysis.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read  #  to fetch code (actions/checkout)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go-check:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go-lint:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go-test:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sharness-runner:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
This is pretty common when working through PRs and ends up causing tons of in-flight GitHub Actions workflows running because they aren't currently canceled when a new commit is added. This will cancel previous runs if a new commit is added on a branch (which is the behavior we had on CircleCI).