### PR TITLE
fix: remove IPNS multihash subdomain redirect tests

### DIFF
--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.8.0-rc3
+	github.com/ipfs/boxo v0.8.0-rc3.0.20230330140444-55d12581e5f6
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.26.4
 	github.com/multiformats/go-multiaddr v0.8.0

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -337,8 +337,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.0-rc3 h1:rttpGdhLE0zeTec8f2/e5YDgCYzEQf7dI4eRglu2ktc=
-github.com/ipfs/boxo v0.8.0-rc3/go.mod h1:RIsi4CnTyQ7AUsNn5gXljJYZlQrHBMnJp94p73liFiA=
+github.com/ipfs/boxo v0.8.0-rc3.0.20230330140444-55d12581e5f6 h1:ng8G4Mwcm/47CDTcB7/3eTKwJHubm/ATZ84UNed6VMo=
+github.com/ipfs/boxo v0.8.0-rc3.0.20230330140444-55d12581e5f6/go.mod h1:RIsi4CnTyQ7AUsNn5gXljJYZlQrHBMnJp94p73liFiA=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.8.0-rc3
+	github.com/ipfs/boxo v0.8.0-rc3.0.20230330140444-55d12581e5f6
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.0
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.0-rc3 h1:rttpGdhLE0zeTec8f2/e5YDgCYzEQf7dI4eRglu2ktc=
-github.com/ipfs/boxo v0.8.0-rc3/go.mod h1:RIsi4CnTyQ7AUsNn5gXljJYZlQrHBMnJp94p73liFiA=
+github.com/ipfs/boxo v0.8.0-rc3.0.20230330140444-55d12581e5f6 h1:ng8G4Mwcm/47CDTcB7/3eTKwJHubm/ATZ84UNed6VMo=
+github.com/ipfs/boxo v0.8.0-rc3.0.20230330140444-55d12581e5f6/go.mod h1:RIsi4CnTyQ7AUsNn5gXljJYZlQrHBMnJp94p73liFiA=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/test/sharness/t0114-gateway-subdomains.sh
+++ b/test/sharness/t0114-gateway-subdomains.sh
@@ -187,18 +187,6 @@ test_localhost_gateway_response_should_contain \
   "http://localhost:$GWAY_PORT/ipfs/$CIDv0" \
   "Location: http://${CIDv0to1}.ipfs.localhost:$GWAY_PORT/"
 
-# /ipns/<libp2p-key>
-
-test_localhost_gateway_response_should_contain \
-  "request for localhost/ipns/{CIDv0} redirects to CIDv1 with libp2p-key multicodec in subdomain" \
-  "http://localhost:$GWAY_PORT/ipns/$RSA_IPNS_IDv0" \
-  "Location: http://${RSA_IPNS_IDv1}.ipns.localhost:$GWAY_PORT/"
-
-test_localhost_gateway_response_should_contain \
-  "request for localhost/ipns/{CIDv0} redirects to CIDv1 with libp2p-key multicodec in subdomain" \
-  "http://localhost:$GWAY_PORT/ipns/$ED25519_IPNS_IDv0" \
-  "Location: http://${ED25519_IPNS_IDv1}.ipns.localhost:$GWAY_PORT/"
-
 # /ipns/<dnslink-fqdn>
 
 test_localhost_gateway_response_should_contain \
@@ -403,20 +391,6 @@ test_hostname_gateway_response_should_contain \
   "http://127.0.0.1:$GWAY_PORT/ipfs/?uri=ipfs%3A%2F%2FQmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco%2Fwiki%2FDiego_Maradona.html" \
   "Location: /ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Diego_Maradona.html"
 
-# example.com/ipns/<libp2p-key>
-
-test_hostname_gateway_response_should_contain \
-  "request for example.com/ipns/{CIDv0} redirects to CIDv1 with libp2p-key multicodec in subdomain" \
-  "example.com" \
-  "http://127.0.0.1:$GWAY_PORT/ipns/$RSA_IPNS_IDv0" \
-  "Location: http://${RSA_IPNS_IDv1}.ipns.example.com/"
-
-test_hostname_gateway_response_should_contain \
-  "request for example.com/ipns/{CIDv0} redirects to CIDv1 with libp2p-key multicodec in subdomain" \
-  "example.com" \
-  "http://127.0.0.1:$GWAY_PORT/ipns/$ED25519_IPNS_IDv0" \
-  "Location: http://${ED25519_IPNS_IDv1}.ipns.example.com/"
-
 # example.com/ipns/<dnslink-fqdn>
 
 test_hostname_gateway_response_should_contain \
@@ -590,14 +564,9 @@ test_expect_success \
 
 # ed25519 fits under 63 char limit when represented in base36
 IPNS_KEY="test_key_ed25519"
-IPNS_ED25519_B58MH=$(ipfs key list -l --ipns-base b58mh | grep $IPNS_KEY | cut -d" " -f1 | tr -d "\n")
 IPNS_ED25519_B36CID=$(ipfs key list -l --ipns-base base36 | grep $IPNS_KEY | cut -d" " -f1 | tr -d "\n")
 
 # local: *.localhost
-test_localhost_gateway_response_should_contain \
-  "request for a ED25519 libp2p-key at localhost/ipns/{b58mh} returns Location HTTP header for DNS-safe subdomain redirect in browsers" \
-  "http://localhost:$GWAY_PORT/ipns/$IPNS_ED25519_B58MH" \
-  "Location: http://${IPNS_ED25519_B36CID}.ipns.localhost:$GWAY_PORT/"
 
 # router should not redirect to hostnames that could fail due to DNS limits
 test_localhost_gateway_response_should_contain \
@@ -617,12 +586,6 @@ test_localhost_gateway_response_should_contain \
   "400 Bad Request"
 
 # public subdomain gateway: *.example.com
-
-test_hostname_gateway_response_should_contain \
-  "request for a ED25519 libp2p-key at example.com/ipns/{b58mh} returns Location HTTP header for DNS-safe subdomain redirect in browsers" \
-  "example.com" \
-  "http://127.0.0.1:$GWAY_PORT/ipns/$IPNS_ED25519_B58MH" \
-  "Location: http://${IPNS_ED25519_B36CID}.ipns.example.com"
 
 test_hostname_gateway_response_should_contain \
   "request for a too long CID at example.com/ipfs/{CIDv1} returns human readable error" \


### PR DESCRIPTION
Pair PR of https://github.com/ipfs/boxo/pull/236. **Might not be needed.**