### PR TITLE
ci: ignore js-js interop test cases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,8 @@ jobs:
           npm install kubo-rpc-client@^3.0.1
           npm install ipfs-interop@^10.0.1
         working-directory: interop
-      - run: npx ipfs-interop -- -t node
+      # Run the interop tests while ignoring the js-js interop test cases
+      - run: npx ipfs-interop -- -t node --grep '^(?!.*(js\d? -> js\d?|js-js-js))'
         env:
           LIBP2P_TCP_REUSEPORT: false
           LIBP2P_ALLOW_WEAK_RSA_KEYS: 1


### PR DESCRIPTION
This PR ignores some of the js-js interop test cases which were previously run by default by https://github.com/ipfs/interop

It does so by passing a `grep` argument which uses negative lookahead to exclude test case names that include:
- either `js(:number:)? -> js(:number)?`
- or `js-js-js`

###### Testing

- [x] CI - https://github.com/ipfs/kubo/actions/runs/4567262975/jobs/8061669798?pr=9781
