### PR TITLE
API/Gateway listens on both IPv4 and IPv6 as well

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -128,8 +128,14 @@ func addressesConfig() Addresses {
 		Announce:       []string{},
 		AppendAnnounce: []string{},
 		NoAnnounce:     []string{},
-		API:            Strings{"/ip4/127.0.0.1/tcp/5001"},
-		Gateway:        Strings{"/ip4/127.0.0.1/tcp/8080"},
+		API: []string{
+			"/ip4/127.0.0.1/tcp/5001",
+			"/ip6/::/tcp/5001",
+		},
+		Gateway: []string{
+			"/ip4/127.0.0.1/tcp/8080",
+			"/ip6/::/tcp/8080",
+		},
 	}
 }
 


### PR DESCRIPTION
Node.JS 18 stopped reordering DNS to have IPv4 addresses be first(https://github.com/nodejs/node/pull/39987), and this causes some issues since Kubo isn't listening for API requests on [::1]. To fix this, we change the default config to listen on IPv6 and IPv4 for both api and gateway.  This PR will resolve https://github.com/ipfs/kubo/issues/9637. 