### PR TITLE
test: use self hosted runner for go tests

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -12,9 +12,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  go-test:
+  go-test-runner:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    uses: ipfs/kubo/.github/workflows/runner.yml@master
+  go-test:
+    needs: [go-test-runner]
+    runs-on: ${{ fromJSON(needs.go-test-runner.outputs.config).labels }}
     timeout-minutes: 20
     env:
       TEST_NO_DOCKER: 1
@@ -39,7 +42,7 @@ jobs:
           name: ${{ github.job }}
       - name: 👉️ If this step failed, go to «Summary» (top left) → inspect the «Failures/Errors» table
         run: |
-          make -j 1 test/unit/gotest.junit.xml &&
+          make -j 2 test/unit/gotest.junit.xml &&
             [[ ! $(jq -s -c 'map(select(.Action == "fail")) | .[]' test/unit/gotest.json) ]]
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0


### PR DESCRIPTION
Compare this test run with https://github.com/ipfs/kubo/actions/runs/4610952102, test run time decreases from 7 min to 2 min.