### PR TITLE
fix(ci): speed up docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Get tags
         id: tags
         run: |
@@ -53,3 +61,12 @@ jobs:
           push: true
           file: ./Dockerfile
           tags: "${{ steps.tags.outputs.value }}"
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache to limit growth
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
Building [docker images in this repo](https://github.com/ipfs/kubo/actions/workflows/docker-image.yml) takes ~1h:

>  ![2023-04-06_14-28](https://user-images.githubusercontent.com/157609/230378816-f919c981-c6dd-449b-91d2-df87a1e97eab.png)

This PR is doing two things (iiuc -- please verify my assumptions :pray: ):
- speed up arm builds by allowing cross-comp from go instead of slow QEMU
- take a stab at caching buildx layers, without infinite growth
- works with both `docker buildx build` and the regular `docker build`

This fix was already applied in https://github.com/ipfs/bifrost-gateway/commit/14cfa48bed514fb8b865d41df3cecb5f827e54ab and seems to reduce [docker build times there](https://github.com/ipfs/bifrost-gateway/actions/workflows/docker-image.yml) from **20m** to **3m** :heavy_heart_exclamation: :

> ![2023-04-06_14-23](https://user-images.githubusercontent.com/157609/230377782-fca60234-d208-4f5a-ab77-bc32d12b7afb.png)


cc @galargh @laurentsenta @guseggert 