### PR TITLE
feat: switch Docker base image to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19.1-buster
-LABEL maintainer="Steven Allen <steven@stebalien.com>"
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19.1-alpine
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-# Install deps
-RUN apt-get update && apt-get install -y \
-  libssl-dev \
-  ca-certificates \
-  fuse
+RUN apk add make bash gcc musl-dev
 
 ENV SRC_DIR /kubo
 
@@ -27,55 +22,26 @@ ARG IPFS_PLUGINS
 
 # Build the thing.
 # Also: fix getting HEAD commit hash via git rev-parse.
-RUN cd $SRC_DIR \
-  && mkdir -p .git/objects \
-  && GOOS=$TARGETOS GOARCH=$TARGETARCH GOFLAGS=-buildvcs=false make build GOTAGS=openssl IPFS_PLUGINS=$IPFS_PLUGINS
-
-# Get su-exec, a very minimal tool for dropping privileges,
-# and tini, a very minimal init daemon for containers
-ENV SUEXEC_VERSION v0.2
-ENV TINI_VERSION v0.19.0
-RUN set -eux; \
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
-        "amd64" | "armhf" | "arm64") tiniArch="tini-static-$dpkgArch" ;;\
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-    esac; \
-  cd /tmp \
-  && git clone https://github.com/ncopa/su-exec.git \
-  && cd su-exec \
-  && git checkout -q $SUEXEC_VERSION \
-  && make su-exec-static \
-  && cd /tmp \
-  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/$tiniArch \
-  && chmod +x tini
+RUN cd $SRC_DIR && \
+	mkdir -p .git/objects && \
+	GOOS=$TARGETOS \
+	GOARCH=$TARGETARCH \
+	GOFLAGS=-buildvcs=false \
+	make build IPFS_PLUGINS=$IPFS_PLUGINS
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} busybox:1.31.1-glibc
-LABEL maintainer="Steven Allen <steven@stebalien.com>"
+FROM --platform=${BUILDPLATFORM:-linux/amd64} alpine
+
+RUN apk add --no-cache fuse ca-certificates su-exec tini
 
 # Get the ipfs binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /kubo
 COPY --from=0 $SRC_DIR/cmd/ipfs/ipfs /usr/local/bin/ipfs
 COPY --from=0 $SRC_DIR/bin/container_daemon /usr/local/bin/start_ipfs
 COPY --from=0 $SRC_DIR/bin/container_init_run /usr/local/bin/container_init_run
-COPY --from=0 /tmp/su-exec/su-exec-static /sbin/su-exec
-COPY --from=0 /tmp/tini /sbin/tini
-COPY --from=0 /bin/fusermount /usr/local/bin/fusermount
-COPY --from=0 /etc/ssl/certs /etc/ssl/certs
-
-# Add suid bit on fusermount so it will run properly
-RUN chmod 4755 /usr/local/bin/fusermount
 
 # Fix permissions on start_ipfs (ignore the build machine's permissions)
 RUN chmod 0755 /usr/local/bin/start_ipfs
-
-# This shared lib (part of glibc) doesn't seem to be included with busybox.
-COPY --from=0 /lib/*-linux-gnu*/libdl.so.2 /lib/
-
-# Copy over SSL libraries.
-COPY --from=0 /usr/lib/*-linux-gnu*/libssl.so* /usr/lib/
-COPY --from=0 /usr/lib/*-linux-gnu*/libcrypto.so* /usr/lib/
 
 # Swarm TCP; should be exposed to the public
 EXPOSE 4001

--- a/cmd/ipfs/Rules.mk
+++ b/cmd/ipfs/Rules.mk
@@ -13,7 +13,8 @@ PATH := $(realpath $(d)):$(PATH)
 # DEPS_OO_$(d) += merkledag/pb/merkledag.pb.go namesys/pb/namesys.pb.go
 # DEPS_OO_$(d) += pin/internal/pb/header.pb.go unixfs/pb/unixfs.pb.go
 
-$(d)_flags =-ldflags="-X "github.com/ipfs/kubo".CurrentCommit=$(git-hash)"
+LDFLAGS +=-X github.com/ipfs/kubo.CurrentCommit=$(git-hash)
+$(d)_flags =-ldflags "$(LDFLAGS)"
 
 $(d)-try-build $(IPFS_BIN_$(d)): GOFLAGS += $(cmd/ipfs_flags)
 


### PR DESCRIPTION
This switches to Alpine from Busybox. The motivation for me is to dramatically speed up Docker builds, but this has some other positive side effects too:

- Alpine has a package manager and  a shell, so you can exec into a running container and meaningfully interact with it

- We don't need to build su-exec and tini in Ubuntu and then copy stuff over to BusyBox, these are already in APK

- Alpine uses musl instead of glibc so this exercises a different libc implementation for Kubo

The size difference is negligible, particularly when compressed--the image size is dominated by the Kubo binary which is ~80 MiB.