### PR TITLE
test: fix Docker tests in GH Actions

### DIFF
--- a/test/ipfs-test-lib.sh
+++ b/test/ipfs-test-lib.sh
@@ -50,19 +50,19 @@ test_path_cmp() {
 
 # Docker
 
-# This takes a Dockerfile, and a build context directory
+# This takes a Dockerfile, a tag name, and a build context directory
 docker_build() {
-    docker build --rm -f "$1" "$2" | ansi_strip
+    docker build --rm --tag "$1" --file "$2" "$3" | ansi_strip
 }
 
 # This takes an image as argument and writes a docker ID on stdout
 docker_run() {
-    docker run -d "$1"
+    docker run --detach "$1"
 }
 
 # This takes a docker ID and a command as arguments
 docker_exec() {
-    docker exec -t "$1" /bin/sh -c "$2"
+    docker exec --tty "$1" /bin/sh -c "$2"
 }
 
 # This takes a docker ID as argument
@@ -72,12 +72,12 @@ docker_stop() {
 
 # This takes a docker ID as argument
 docker_rm() {
-    docker rm -f -v "$1" > /dev/null
+    docker rm --force --volumes "$1" > /dev/null
 }
 
 # This takes a docker image name as argument
 docker_rmi() {
-    docker rmi -f "$1" > /dev/null
+    docker rmi --force "$1" > /dev/null
 }
 
 # Test whether all the expected lines are included in a file. The file

--- a/test/sharness/t0002-docker-image.sh
+++ b/test/sharness/t0002-docker-image.sh
@@ -27,18 +27,12 @@ TEST_TRASH_DIR=$(pwd)
 TEST_SCRIPTS_DIR=$(dirname "$TEST_TRASH_DIR")
 TEST_TESTS_DIR=$(dirname "$TEST_SCRIPTS_DIR")
 APP_ROOT_DIR=$(dirname "$TEST_TESTS_DIR")
+IMAGE_TAG=kubo_test
 
 test_expect_success "docker image build succeeds" '
-  docker_build "$TEST_TESTS_DIR/../Dockerfile" "$APP_ROOT_DIR" | tee build-actual ||
+  docker_build "$IMAGE_TAG" "$TEST_TESTS_DIR/../Dockerfile" "$APP_ROOT_DIR" ||
   test_fsh echo "TEST_TESTS_DIR: $TEST_TESTS_DIR" ||
-  test_fsh echo "APP_ROOT_DIR : $APP_ROOT_DIR" ||
-  test_fsh cat build-actual
-'
-
-test_expect_success "docker image build output looks good" '
-  SUCCESS_LINE=$(egrep "^Successfully built" build-actual) &&
-  IMAGE_ID=$(expr "$SUCCESS_LINE" : "^Successfully built \(.*\)") ||
-  test_fsh cat build-actual
+  test_fsh echo "APP_ROOT_DIR : $APP_ROOT_DIR"
 '
 
 test_expect_success "write init scripts" '
@@ -52,7 +46,7 @@ test_expect_success "docker image runs" '
                   -p 127.0.0.1:5001:5001 -p 127.0.0.1:8080:8080 \
                   -v "$PWD/001.sh":/container-init.d/001.sh \
                   -v "$PWD/002.sh":/container-init.d/002.sh \
-                  "$IMAGE_ID")
+                  "$IMAGE_TAG")
 '
 
 test_expect_success "docker container gateway is up" '
@@ -100,5 +94,5 @@ test_expect_success "stop docker container" '
 '
 
 docker_rm "$DOC_ID"
-docker_rmi "$IMAGE_ID"
+docker_rmi "$IMAGE_TAG"
 test_done

--- a/test/sharness/t0003-docker-migrate.sh
+++ b/test/sharness/t0003-docker-migrate.sh
@@ -24,10 +24,10 @@ TEST_TRASH_DIR=$(pwd)
 TEST_SCRIPTS_DIR=$(dirname "$TEST_TRASH_DIR")
 TEST_TESTS_DIR=$(dirname "$TEST_SCRIPTS_DIR")
 APP_ROOT_DIR=$(dirname "$TEST_TESTS_DIR")
+IMAGE_TAG=kubo_migrate
 
 test_expect_success "docker image build succeeds" '
-  docker_build "$TEST_TESTS_DIR/../Dockerfile" "$APP_ROOT_DIR" >actual &&
-  IMAGE_ID=$(tail -n1 actual | cut -d " " -f 3)
+  docker_build "$IMAGE_TAG" "$TEST_TESTS_DIR/../Dockerfile" "$APP_ROOT_DIR"
 '
 
 test_init_ipfs
@@ -53,7 +53,7 @@ test_expect_success "startup fake dists server" '
 '
 
 test_expect_success "docker image runs" '
-  DOC_ID=$(docker run -d -v "$IPFS_PATH":/data/ipfs --net=host "$IMAGE_ID")
+  DOC_ID=$(docker run -d -v "$IPFS_PATH":/data/ipfs --net=host "$IMAGE_TAG")
 '
 
 test_expect_success "docker container tries to pull migrations from netcat" '
@@ -78,6 +78,5 @@ test_expect_success "correct version was requested" '
 '
 
 docker_rm "$DOC_ID"
-docker_rmi "$IMAGE_ID"
+docker_rmi "$IMAGE_TAG"
 test_done
-


### PR DESCRIPTION
GH Actions recently changed their Docker build implementation and it has a different output than previously, causing the tests that parse its output to fail.

This switches the test to not parse Docker build output. The parsing was used to extract the image ID while still showing logs. A better way to show logs and still know the image ID is to tag it, which is what this now does.

This also renames the Docker tests so that they run earlier. This takes better advantage of the fact that the sharness tests are run in parallel. Since the Docker test are quite long, and are at the end of the list, the test runner is not running other tests in parallel while the Docker tests are running.
