### PR TITLE
ci: fix platform of the target docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN set -eux; \
   && chmod +x tini
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} busybox:1.31.1-glibc
+FROM busybox:1.31.1-glibc
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Get the ipfs binary, entrypoint script, and TLS CAs from the build container.


### PR DESCRIPTION
@lidel As per https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/, shouldn't the final image build skip the `--platform` arg so that the end image is built for the requested target platform?

closes #7541
closes #4584