### PR TITLE
feat: reusable ipns verify

### DIFF
--- a/core/commands/name/name.go
+++ b/core/commands/name/name.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
-	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mbase "github.com/multiformats/go-multibase"
 )
@@ -216,33 +215,7 @@ Passing --verify will verify signature against provided public key.
 				PublicKey: id,
 			}
 
-			pub, err := id.ExtractPublicKey()
-			if err != nil {
-				// Make sure it works with all those RSA that cannot be embedded into the
-				// Peer ID.
-				if len(entry.PubKey) > 0 {
-					pub, err = ic.UnmarshalPublicKey(entry.PubKey)
-					if err != nil {
-						return err
-					}
-
-					// Verify the public key matches the name we are verifying.
-					entryID, err := peer.IDFromPublicKey(pub)
-
-					if err != nil {
-						return err
-					}
-
-					if id != entryID {
-						return fmt.Errorf("record public key does not match the verified name")
-					}
-				}
-			}
-			if err != nil {
-				return err
-			}
-
-			err = ipns.Validate(pub, &entry)
+			err = ipns.ValidateWithPeerID(id, &entry)
 			if err == nil {
 				result.Validation.Valid = true
 			} else {

--- a/core/commands/name/name.go
+++ b/core/commands/name/name.go
@@ -9,17 +9,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/ipfs/boxo/ipns"
-	ipns_pb "github.com/ipfs/boxo/ipns/pb"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
-	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/dagcbor"
-	"github.com/ipld/go-ipld-prime/codec/dagjson"
-	ic "github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-libp2p/core/peer"
-	mbase "github.com/multiformats/go-multibase"
 )
 
 type IpnsEntry struct {
@@ -84,29 +76,9 @@ Resolve the value of a dnslink:
 	},
 }
 
-type IpnsInspectValidation struct {
-	Valid     bool
-	Reason    string
-	PublicKey peer.ID
-}
-
-// IpnsInspectEntry contains the deserialized values from an IPNS Entry:
-// https://github.com/ipfs/specs/blob/main/ipns/IPNS.md#record-serialization-format
-type IpnsInspectEntry struct {
-	Value        string
-	ValidityType *ipns_pb.IpnsEntry_ValidityType
-	Validity     *time.Time
-	Sequence     uint64
-	TTL          *uint64
-	PublicKey    string
-	SignatureV1  string
-	SignatureV2  string
-	Data         interface{}
-}
-
 type IpnsInspectResult struct {
-	Entry      IpnsInspectEntry
-	Validation *IpnsInspectValidation
+	Entry      *ipns.IpnsInspectEntry
+	Validation *ipns.IpnsInspectValidation
 }
 
 var IpnsInspectCmd = &cmds.Command{
@@ -152,102 +124,28 @@ Passing --verify will verify signature against provided public key.
 			return err
 		}
 
-		var entry ipns_pb.IpnsEntry
-		err = proto.Unmarshal(b.Bytes(), &entry)
+		entry, err := ipns.UnmarshalIpnsEntry(b.Bytes())
 		if err != nil {
 			return err
 		}
 
-		encoder, err := mbase.EncoderByName("base64")
+		inspectEntry, err := ipns.InspectIpnsRecord(entry)
 		if err != nil {
 			return err
 		}
 
 		result := &IpnsInspectResult{
-			Entry: IpnsInspectEntry{
-				Value:        string(entry.Value),
-				ValidityType: entry.ValidityType,
-				Sequence:     *entry.Sequence,
-				TTL:          entry.Ttl,
-				PublicKey:    encoder.Encode(entry.PubKey),
-				SignatureV1:  encoder.Encode(entry.SignatureV1),
-				SignatureV2:  encoder.Encode(entry.SignatureV2),
-				Data:         nil,
-			},
-		}
-
-		if len(entry.Data) != 0 {
-			// This is hacky. The variable node (datamodel.Node) doesn't directly marshal
-			// to JSON. Therefore, we need to first decode from DAG-CBOR, then encode in
-			// DAG-JSON and finally unmarshal it from JSON. Since DAG-JSON is a subset
-			// of JSON, that should work. Then, we can store the final value in the
-			// result.Entry.Data for further inspection.
-			node, err := ipld.Decode(entry.Data, dagcbor.Decode)
-			if err != nil {
-				return err
-			}
-
-			var buf bytes.Buffer
-			err = dagjson.Encode(node, &buf)
-			if err != nil {
-				return err
-			}
-
-			err = json.Unmarshal(buf.Bytes(), &result.Entry.Data)
-			if err != nil {
-				return err
-			}
-		}
-
-		validity, err := ipns.GetEOL(&entry)
-		if err == nil {
-			result.Entry.Validity = &validity
+			Entry: inspectEntry,
 		}
 
 		verify, ok := req.Options["verify"].(string)
 		if ok {
 			key := strings.TrimPrefix(verify, "/ipns/")
-			id, err := peer.Decode(key)
+			validation, err := ipns.Verify(key, entry)
 			if err != nil {
 				return err
 			}
-
-			result.Validation = &IpnsInspectValidation{
-				PublicKey: id,
-			}
-
-			pub, err := id.ExtractPublicKey()
-			if err != nil {
-				// Make sure it works with all those RSA that cannot be embedded into the
-				// Peer ID.
-				if len(entry.PubKey) > 0 {
-					pub, err = ic.UnmarshalPublicKey(entry.PubKey)
-					if err != nil {
-						return err
-					}
-
-					// Verify the public key matches the name we are verifying.
-					entryID, err := peer.IDFromPublicKey(pub)
-
-					if err != nil {
-						return err
-					}
-
-					if id != entryID {
-						return fmt.Errorf("record public key does not match the verified name")
-					}
-				}
-			}
-			if err != nil {
-				return err
-			}
-
-			err = ipns.Validate(pub, &entry)
-			if err == nil {
-				result.Validation.Valid = true
-			} else {
-				result.Validation.Reason = err.Error()
-			}
+			result.Validation = validation
 		}
 
 		return cmds.EmitOnce(res, result)

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82
+	github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c
+	github.com/ipfs/boxo v0.8.2-0.20230510114019-33e3f0cd052b
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82
+	github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd
+	github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -321,8 +321,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd h1:kUXxjnVJYoxcsik7sqn7SPRxS+Yxv4broDJnrynq8+w=
-github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
+github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82 h1:WddjqbpZs6VHWQOpWoyj5N5DSy6o1oGsO41Wp9iQInE=
+github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82/go.mod h1:bORAHrH6hUtDZjbzTEaLrSpTdyhHKDIpjDRT+A14B7w=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -321,8 +321,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82 h1:WddjqbpZs6VHWQOpWoyj5N5DSy6o1oGsO41Wp9iQInE=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82/go.mod h1:bORAHrH6hUtDZjbzTEaLrSpTdyhHKDIpjDRT+A14B7w=
+github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c h1:itWTywGeZRLNP44o86gPUnzNNsRl2+2XMTI/JJCanik=
+github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -321,8 +321,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82 h1:WddjqbpZs6VHWQOpWoyj5N5DSy6o1oGsO41Wp9iQInE=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82/go.mod h1:bORAHrH6hUtDZjbzTEaLrSpTdyhHKDIpjDRT+A14B7w=
+github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd h1:kUXxjnVJYoxcsik7sqn7SPRxS+Yxv4broDJnrynq8+w=
+github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -321,8 +321,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c h1:itWTywGeZRLNP44o86gPUnzNNsRl2+2XMTI/JJCanik=
-github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
+github.com/ipfs/boxo v0.8.2-0.20230510114019-33e3f0cd052b h1:6EVpfwbBgwhfZOA19i55jOGokKOy+OaQAm1dg4RbXmc=
+github.com/ipfs/boxo v0.8.2-0.20230510114019-33e3f0cd052b/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c
+	github.com/ipfs/boxo v0.8.2-0.20230510114019-33e3f0cd052b
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82
+	github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,9 @@ require (
 	github.com/elgris/jsondiff v0.0.0-20160530203242-765b5c24c302
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82
+	github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0
@@ -115,6 +114,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,10 @@ require (
 	github.com/elgris/jsondiff v0.0.0-20160530203242-765b5c24c302
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5
 	github.com/fsnotify/fsnotify v1.6.0
+	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd
+	github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0
@@ -114,7 +115,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd h1:kUXxjnVJYoxcsik7sqn7SPRxS+Yxv4broDJnrynq8+w=
-github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
+github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82 h1:WddjqbpZs6VHWQOpWoyj5N5DSy6o1oGsO41Wp9iQInE=
+github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82/go.mod h1:bORAHrH6hUtDZjbzTEaLrSpTdyhHKDIpjDRT+A14B7w=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c h1:itWTywGeZRLNP44o86gPUnzNNsRl2+2XMTI/JJCanik=
-github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
+github.com/ipfs/boxo v0.8.2-0.20230510114019-33e3f0cd052b h1:6EVpfwbBgwhfZOA19i55jOGokKOy+OaQAm1dg4RbXmc=
+github.com/ipfs/boxo v0.8.2-0.20230510114019-33e3f0cd052b/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82 h1:WddjqbpZs6VHWQOpWoyj5N5DSy6o1oGsO41Wp9iQInE=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82/go.mod h1:bORAHrH6hUtDZjbzTEaLrSpTdyhHKDIpjDRT+A14B7w=
+github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd h1:kUXxjnVJYoxcsik7sqn7SPRxS+Yxv4broDJnrynq8+w=
+github.com/ipfs/boxo v0.8.2-0.20230510081958-236e39e7b6fd/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82 h1:WddjqbpZs6VHWQOpWoyj5N5DSy6o1oGsO41Wp9iQInE=
-github.com/ipfs/boxo v0.8.2-0.20230510071416-d7db1adc7e82/go.mod h1:bORAHrH6hUtDZjbzTEaLrSpTdyhHKDIpjDRT+A14B7w=
+github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c h1:itWTywGeZRLNP44o86gPUnzNNsRl2+2XMTI/JJCanik=
+github.com/ipfs/boxo v0.8.2-0.20230510103853-88ba464fd66c/go.mod h1:Ej2r08Z4VIaFKqY08UXMNhwcLf6VekHhK8c+KqA1B9Y=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=


### PR DESCRIPTION
Sister PR in boxo: https://github.com/ipfs/boxo/pull/294

Extracts the ipns verification code out of kubo to boxo. This makes the verification code reusable, for example, with gateway-conformance testing (https://github.com/ipfs/gateway-conformance/pull/37)

Relates to https://github.com/ipfs/specs/issues/376

- [x] ⚠️ update with the correct boxo commit when the sister PR is merged