### PR TITLE
fix: 'ipfs routing findpeer' explicitly fails when searching for self

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -17,6 +17,7 @@ import (
 var log = logging.Logger("core/commands")
 
 var ErrNotOnline = errors.New("this command must be run in online mode. Try running 'ipfs daemon' first")
+var ErrSelfUnsupported = errors.New("finding your own node in the DHT is currently not supported")
 
 const (
 	RepoDirOption    = "repo-dir"

--- a/core/commands/routing.go
+++ b/core/commands/routing.go
@@ -301,6 +301,10 @@ var findPeerRoutingCmd = &cmds.Command{
 			return err
 		}
 
+		if pid == nd.Identity {
+			return ErrSelfUnsupported
+		}
+
 		ctx, cancel := context.WithCancel(req.Context)
 		ctx, events := routing.RegisterForQueryEvents(ctx)
 

--- a/test/cli/routing_dht_test.go
+++ b/test/cli/routing_dht_test.go
@@ -117,7 +117,23 @@ func testRoutingDHT(t *testing.T, enablePubsub bool) {
 	})
 }
 
+func testSelfFindDHT(t *testing.T) {
+	t.Run("ipfs routing findpeer fails for self", func(t *testing.T) {
+		t.Parallel()
+		nodes := harness.NewT(t).NewNodes(1).Init()
+		nodes.ForEachPar(func(node *harness.Node) {
+			node.IPFS("config", "Routing.Type", "dht")
+		})
+
+		nodes.StartDaemons()
+
+		res := nodes[0].RunIPFS("dht", "findpeer", nodes[0].PeerID().String())
+		assert.Equal(t, 1, res.ExitCode())
+	})
+}
+
 func TestRoutingDHT(t *testing.T) {
 	testRoutingDHT(t, false)
 	testRoutingDHT(t, true)
+	testSelfFindDHT(t)
 }


### PR DESCRIPTION
Closes #9898