### PR TITLE
client/rpc: rename package name to match rpc and edit migration story

### DIFF
--- a/client/rpc/README.md
+++ b/client/rpc/README.md
@@ -1,4 +1,4 @@
-# `httpapi`
+# `coreiface.CoreAPI` over http `rpc`
 
 > IPFS CoreAPI implementation using HTTP API
 
@@ -19,13 +19,13 @@ import (
     "context"
     "fmt"
 
-    ipfsClient "github.com/ipfs/kubo/client/rpc"
+    "github.com/ipfs/kubo/client/rpc"
     path "github.com/ipfs/boxo/coreiface/path"
 )
 
 func main() {
     // "Connect" to local node
-    node, err := ipfsClient.NewLocalApi()
+    node, err := rpc.NewLocalApi()
     if err != nil {
         fmt.Printf(err)
         return

--- a/client/rpc/api.go
+++ b/client/rpc/api.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"errors"

--- a/client/rpc/api_test.go
+++ b/client/rpc/api_test.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/apifile.go
+++ b/client/rpc/apifile.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"bytes"

--- a/client/rpc/dag.go
+++ b/client/rpc/dag.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"bytes"

--- a/client/rpc/dht.go
+++ b/client/rpc/dht.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/errors.go
+++ b/client/rpc/errors.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"errors"

--- a/client/rpc/errors_test.go
+++ b/client/rpc/errors_test.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"errors"

--- a/client/rpc/key.go
+++ b/client/rpc/key.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/name.go
+++ b/client/rpc/name.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/object.go
+++ b/client/rpc/object.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"bytes"

--- a/client/rpc/path.go
+++ b/client/rpc/path.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/pin.go
+++ b/client/rpc/pin.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/pubsub.go
+++ b/client/rpc/pubsub.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"bytes"

--- a/client/rpc/request.go
+++ b/client/rpc/request.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/requestbuilder.go
+++ b/client/rpc/requestbuilder.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"bytes"

--- a/client/rpc/response.go
+++ b/client/rpc/response.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"encoding/json"

--- a/client/rpc/routing.go
+++ b/client/rpc/routing.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"bytes"

--- a/client/rpc/swarm.go
+++ b/client/rpc/swarm.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/client/rpc/unixfs.go
+++ b/client/rpc/unixfs.go
@@ -1,4 +1,4 @@
-package httpapi
+package rpc
 
 import (
 	"context"

--- a/docs/changelogs/v0.21.md
+++ b/docs/changelogs/v0.21.md
@@ -66,7 +66,8 @@ updated the CoreAPI with new Kubo features but forgot to port thoses to the
 http-client, making it impossible to use them together with the same coreapi
 version.
 
-**TODO(@Jorropo)**: add link to `boxo-migrate` once support for rewriting this import path has been added
+For smooth transition `v0.7.0` of `go-ipfs-http-client` provides updated stubs
+for Kubo `v0.21`.
 
 ### 📝 Changelog
 

--- a/docs/http-rpc-clients.md
+++ b/docs/http-rpc-clients.md
@@ -4,11 +4,11 @@ Kubo provides official HTTP RPC  (`/api/v0`) clients for selected languages:
 
 - [`js-kubo-rpc-client`](https://github.com/ipfs/js-kubo-rpc-client) - Official JS client for talking to Kubo RPC over HTTP
 - [`go-ipfs-api`](https://github.com/ipfs/go-ipfs-api) - The go interface to ipfs's HTTP RPC - Follow https://github.com/ipfs/kubo/issues/9124 for coming changes.
-- [`httpapi`](./client/rpc) (previously `go-ipfs-http-client`)) - IPFS CoreAPI implementation using HTTP RPC
+- [`httpapi`](./client/rpc) (previously `go-ipfs-http-client`) - [`coreiface.CoreAPI`](https://pkg.go.dev/github.com/ipfs/boxo/coreiface#CoreAPI) implementation using HTTP RPC
 
 ## Recommended clients
 
 | Language |     Package Name    | Github Repository                          |
 |:--------:|:-------------------:|--------------------------------------------|
 | JS       | kubo-rpc-client     | https://github.com/ipfs/js-kubo-rpc-client |
-| Go       | `httpapi`           | [`./client/rpc`](./client/rpc)             |
+| Go       | `rpc`               | [`./client/rpc`](./client/rpc)             |


### PR DESCRIPTION
Migration will happen with stub types pushed at: https://github.com/ipfs/go-ipfs-http-client/pull/180
this our last PR cycle with `go-ipfs-http-client` so I'll merge this here first and update kubo's version in `go-ipfs-http-client` once kubo v0.21.0 is released.