### PR TITLE
fix: print rcmgr to logger

### DIFF
--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ipfs/kubo/repo"
 )
 
+var rcmgrLogger = logging.Logger("rcmgr")
+
 const NetLimitTraceFilename = "rcmgr.json.gz"
 
 var ErrNoResourceMgr = fmt.Errorf("missing ResourceMgr: make sure the daemon is running with Swarm.ResourceMgr.Enabled")
@@ -56,14 +58,13 @@ func ResourceManager(cfg config.SwarmConfig, userResourceOverrides rcmgr.Partial
 			}
 
 			if !isPartialConfigEmpty(userResourceOverrides) {
-				fmt.Print(`
+				rcmgrLogger.Info(`
 libp2p-resource-limit-overrides.json has been loaded, "default" fields will be
-filled in with autocomputed defaults.
-`)
+filled in with autocomputed defaults.`)
 			}
 
 			// We want to see this message on startup, that's why we are using fmt instead of log.
-			fmt.Print(msg)
+			rcmgrLogger.Info(msg)
 
 			if err := ensureConnMgrMakeSenseVsResourceMgr(limitConfig, cfg); err != nil {
 				return nil, opts, err
@@ -109,7 +110,7 @@ filled in with autocomputed defaults.
 			lrm.start(helpers.LifecycleCtx(mctx, lc))
 			manager = lrm
 		} else {
-			fmt.Println("go-libp2p resource manager protection disabled")
+			rcmgrLogger.Info("go-libp2p resource manager protection disabled")
 			manager = &network.NullResourceManager{}
 		}
 

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -80,13 +80,6 @@ test_expect_success "ipfs daemon output looks good" '
   STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" &&
   echo "Initializing daemon..." >expected_daemon &&
   ipfs version --all >> expected_daemon &&
-  echo "" >>expected_daemon &&
-  echo "Computed default go-libp2p Resource Manager limits based on:" >>expected_daemon &&
-  echo "    - '"'"'Swarm.ResourceMgr.MaxMemory'"'"': \"4GB\"" >>expected_daemon &&
-  echo "    - '"'"'Swarm.ResourceMgr.MaxFileDescriptors'"'"': 1024" >>expected_daemon &&
-  echo "" >>expected_daemon &&
-  echo "Theses can be inspected with '"'"'ipfs swarm resources'"'"'." >>expected_daemon &&
-  echo "" >>expected_daemon &&
   sed "s/^/Swarm listening on /" listen_addrs >>expected_daemon &&
   sed "s/^/Swarm announcing /" local_addrs >>expected_daemon &&
   echo "RPC API server listening on '$API_MADDR'" >>expected_daemon &&


### PR DESCRIPTION
This was proposed by @lidel as an easy alternative to #9826.
It helps by trimming down the wall of text:
```console
$ ipfs daemon
Initializing daemon...
Kubo version: 0.21.0-dev
Repo version: 14
System version: amd64/linux
Golang version: go1.19.10
Swarm listening on /ip4/127.0.0.1/tcp/4001
Swarm listening on /ip4/127.0.0.1/udp/4001/quic
Swarm listening on /ip4/127.0.0.1/udp/4001/quic-v1
Swarm listening on /ip4/127.0.0.1/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm listening on /ip4/172.17.0.1/tcp/4001
Swarm listening on /ip4/172.17.0.1/udp/4001/quic
Swarm listening on /ip4/172.17.0.1/udp/4001/quic-v1
Swarm listening on /ip4/172.17.0.1/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm listening on /ip4/192.168.1.31/tcp/4001
Swarm listening on /ip4/192.168.1.31/udp/4001/quic
Swarm listening on /ip4/192.168.1.31/udp/4001/quic-v1
Swarm listening on /ip4/192.168.1.31/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm listening on /ip6/204:e3e5:ec57:9482:3f92:bf4d:74bf:cfed/tcp/4001
Swarm listening on /ip6/204:e3e5:ec57:9482:3f92:bf4d:74bf:cfed/udp/4001/quic
Swarm listening on /ip6/204:e3e5:ec57:9482:3f92:bf4d:74bf:cfed/udp/4001/quic-v1
Swarm listening on /ip6/204:e3e5:ec57:9482:3f92:bf4d:74bf:cfed/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm listening on /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/tcp/4001
Swarm listening on /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/udp/4001/quic
Swarm listening on /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/udp/4001/quic-v1
Swarm listening on /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm listening on /ip6/2a01:cb05:806e:900:5551:169f:7e3:5e59/tcp/4001
Swarm listening on /ip6/2a01:cb05:806e:900:5551:169f:7e3:5e59/udp/4001/quic
Swarm listening on /ip6/2a01:cb05:806e:900:5551:169f:7e3:5e59/udp/4001/quic-v1
Swarm listening on /ip6/2a01:cb05:806e:900:5551:169f:7e3:5e59/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm listening on /ip6/::1/tcp/4001
Swarm listening on /ip6/::1/udp/4001/quic
Swarm listening on /ip6/::1/udp/4001/quic-v1
Swarm listening on /ip6/::1/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm listening on /p2p-circuit
Swarm announcing /ip4/127.0.0.1/tcp/4001
Swarm announcing /ip4/127.0.0.1/udp/4001/quic
Swarm announcing /ip4/127.0.0.1/udp/4001/quic-v1
Swarm announcing /ip4/127.0.0.1/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm announcing /ip4/192.168.1.31/tcp/4001
Swarm announcing /ip4/192.168.1.31/udp/4001/quic
Swarm announcing /ip4/192.168.1.31/udp/4001/quic-v1
Swarm announcing /ip4/192.168.1.31/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm announcing /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/tcp/4001
Swarm announcing /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/udp/4001/quic
Swarm announcing /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/udp/4001/quic-v1
Swarm announcing /ip6/2a01:cb05:806e:900:50b0:74cc:c3cd:7105/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
Swarm announcing /ip6/::1/tcp/4001
Swarm announcing /ip6/::1/udp/4001/quic
Swarm announcing /ip6/::1/udp/4001/quic-v1
Swarm announcing /ip6/::1/udp/4001/quic-v1/webtransport/certhash/uEiBxxxS3-F4l3cdUMusi6JDe4me_I8_x0HwwCVC7dty6tw/certhash/uEiDoGHKF-YokgamslR4CqcVPFtVvKGVz1KoW26Xqeis9aw
RPC API server listening on /ip4/127.0.0.1/tcp/5001
WebUI: http://127.0.0.1:5001/webui
Gateway server listening on /ip4/127.0.0.1/tcp/8080
Daemon is ready
^C
Received interrupt signal, shutting down...
```