### PR TITLE
feat(rcmgrObs): Register the rcmgr metrics with the default registerer

### DIFF
--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -16,6 +16,7 @@ import (
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 	"github.com/multiformats/go-multiaddr"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 
 	"github.com/ipfs/kubo/config"
@@ -70,6 +71,7 @@ filled in with autocomputed defaults.`)
 				return nil, opts, err
 			}
 
+			rcmgrObs.MustRegisterWith(prometheus.DefaultRegisterer)
 			str, err := rcmgrObs.NewStatsTraceReporter()
 			if err != nil {
 				return nil, opts, err


### PR DESCRIPTION
<!--
PR Creation Checklist
- [ ] Update Changelog
-->

This lets the rcmgr metrcis show up in `http://localhost:5001/debug/metrics/prometheus`. It looks like you're using the default prometheus registerer here: https://github.com/ipfs/kubo/blob/master/core/corehttp/metrics.go#L62