### PR TITLE
fix(cmd): useful errors in dag import

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -237,7 +237,7 @@ Specification of CAR formats: https://ipld.io/specs/transport/car/
 			}
 
 			if event.Root.PinErrorMsg != "" {
-				event.Root.PinErrorMsg = fmt.Sprintf("FAILED: %s", event.Root.PinErrorMsg)
+				return fmt.Errorf("pinning root %q FAILED: %s", enc.Encode(event.Root.Cid), event.Root.PinErrorMsg)
 			} else {
 				event.Root.PinErrorMsg = "success"
 			}


### PR DESCRIPTION
This PR aims to improve UX  of importing broken (truncated)  CARs.

Most of the time, the error during `ipfs dag import` is caused by either a bitflip in one of the blocks, or a truncation of the car stream. This PR improves returned error with context that allows the user to understand what happened, and at which place in the car stream, making debug more humane:

```console
$ ipfs dag import ./truncated.car
Error: import failed after block "bafkreieyn4jhc5ht6qmhhqklqi2xvq3mjgn6z5r5mi4ri4hyvpaq3ojvde": unexpected EOF
```


Also, improved pin error on partial CAR import:

```console
$ curl -v 'http://127.0.0.1:8080/ipns/docs.ipfs.tech?format=car&dag-scope=entity' > ./partial-entity.car # Kubo 0.21.0-rc1 with IPIP-402
```

Before: 

```console
$ ipfs dag import --stats --pin-roots=true ./partial-entity.car
Pinned root	QmPDC11yLAbVw3dX5jMeEuSdk4BiVjSd9X87zaYRdVjzW3	FAILED: block was not found locally (offline): ipld: could not find QmPDvrDAz2aHeLjPVQ4uh1neyknUmDpf1GsBzAbpFhS8ro
Imported 1 blocks (1618 bytes)
[exit code 0] # fake success
```

After: 

```console
$ ipfs dag import --stats --pin-roots=true ./partial-entity.car
Error: pinning root "QmPDC11yLAbVw3dX5jMeEuSdk4BiVjSd9X87zaYRdVjzW3" FAILED: block was not found locally (offline): ipld: could not find QmXZhZq4k5MoZst3YJL8Er8r4qhSjaj2qUGp9Svn9rYb3N
[exit code 1]
```