### PR TITLE
fix: docker repository initialization race condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start_ipfs"]
 # Healthcheck for the container
 # QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn is the CID of empty folder
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD ipfs dag stat /ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn || exit 1
+  CMD ipfs --api=/ip4/127.0.0.1/tcp/5001 dag stat /ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn || exit 1
 
 # Execute the daemon subcommand by default
 CMD ["daemon", "--migrate=true", "--agent-version-suffix=docker"]


### PR DESCRIPTION
Fixes: #8725

When running the health check command without passing the `--api` command line flag and if the Kubo daemon is not active, executing `ipfs dag stat` will initialize the repository. It is common for the health check command to be run with root privileges. As a result, the repository will be owned by the root user. Then, if the Kubo daemon process attempts to access the repository later on, it will encounter a permission denied error because it runs as a non-privileged user by default.

Hence, this PR simply provides the `--api` flag to the `ipfs dag stat` command. Given that we are operating on a docker container, we can make some assumptions. I can't come up with a scenario where one would desire to assign a different port to the internal API rather than using the default 5001. Therefore, I have hard-coded the value accordingly.


Before I settled on this opinion, I had this script:

```shell
#!/bin/sh

set -e

# strip any potential trailing slashes and append the filename
API_PATH="${1%/}/api"

# If the file does not exist, we know the daemon
# is not running and the healthcheck failed
if [ ! -f "$API_PATH" ]; then
  exit 1
fi

# The CID of the empty directory
CID=QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn

# Do the actual health check
ipfs dag --api=$(cat "$API_PATH") stat /ipfs/$CID 2>&1 > /dev/null || exit 1
```
with

```Dockerfile
HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
  CMD /usr/local/bin/healthcheck "$IPFS_PATH"
```