### PR TITLE
fix(gateway): include CORS on subdomain redirects

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -67,12 +67,8 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			RootRedirect: "",
 			NoFetch:      false,
 			PathPrefixes: []string{},
-			HTTPHeaders: map[string][]string{
-				"Access-Control-Allow-Origin":  {"*"},
-				"Access-Control-Allow-Methods": {"GET"},
-				"Access-Control-Allow-Headers": {"X-Requested-With", "Range", "User-Agent"},
-			},
-			APICommands: []string{},
+			HTTPHeaders:  map[string][]string{},
+			APICommands:  []string{},
 		},
 		Reprovider: Reprovider{
 			Interval: nil,

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233
+	github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.27.7
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff
+	github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.27.7
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -320,8 +320,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233 h1:eWyELpyY+KdlAuwlpGfTRb1YEIO02orbHkYtZkGwqrI=
-github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
+github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9 h1:n66pkk54aXcGOrK2qJm+krxLQJWzo88skyefbuFqU44=
+github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -320,8 +320,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff h1:QnYD2h1e55nX9lSl5k8YVij1VIOICR7lPJlhbKOQjNM=
-github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
+github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233 h1:eWyELpyY+KdlAuwlpGfTRb1YEIO02orbHkYtZkGwqrI=
+github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff
+	github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233
+	github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233 h1:eWyELpyY+KdlAuwlpGfTRb1YEIO02orbHkYtZkGwqrI=
-github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
+github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9 h1:n66pkk54aXcGOrK2qJm+krxLQJWzo88skyefbuFqU44=
+github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff h1:QnYD2h1e55nX9lSl5k8YVij1VIOICR7lPJlhbKOQjNM=
-github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
+github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233 h1:eWyELpyY+KdlAuwlpGfTRb1YEIO02orbHkYtZkGwqrI=
+github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -7,7 +7,7 @@ replace github.com/ipfs/kubo => ../../
 require (
 	github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd
 	github.com/golangci/golangci-lint v1.49.0
-	github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff
+	github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0
 	github.com/ipfs/go-datastore v0.6.0

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -7,7 +7,7 @@ replace github.com/ipfs/kubo => ../../
 require (
 	github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd
 	github.com/golangci/golangci-lint v1.49.0
-	github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233
+	github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0
 	github.com/ipfs/go-datastore v0.6.0

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -413,8 +413,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff h1:QnYD2h1e55nX9lSl5k8YVij1VIOICR7lPJlhbKOQjNM=
-github.com/ipfs/boxo v0.10.2-0.20230620120822-417c5f7d61ff/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
+github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233 h1:eWyELpyY+KdlAuwlpGfTRb1YEIO02orbHkYtZkGwqrI=
+github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.1.2 h1:GAjkfhVx1f4YTODS6Esrj1wt2HhrtwTnhEr+DyPUaJo=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -413,8 +413,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233 h1:eWyELpyY+KdlAuwlpGfTRb1YEIO02orbHkYtZkGwqrI=
-github.com/ipfs/boxo v0.10.2-0.20230626222127-473506271233/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
+github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9 h1:n66pkk54aXcGOrK2qJm+krxLQJWzo88skyefbuFqU44=
+github.com/ipfs/boxo v0.10.2-0.20230627105028-a87f9ed0b2a9/go.mod h1:OGMmq97krQBiKx8LRGyf5DgWHeu+PDdIHNN2YnQlWjs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.1.2 h1:GAjkfhVx1f4YTODS6Esrj1wt2HhrtwTnhEr+DyPUaJo=

--- a/test/sharness/t0112-gateway-cors.sh
+++ b/test/sharness/t0112-gateway-cors.sh
@@ -7,21 +7,9 @@ test_description="Test CORS behavior on Gateway port"
 test_init_ipfs
 
 # Default config
-test_expect_success "Default Gateway.HTTPHeaders config match expected values" '
+test_expect_success "Default Gateway.HTTPHeaders is empty (implicit CORS values from boxo/gateway)" '
 cat <<EOF > expected
-{
-  "Access-Control-Allow-Headers": [
-    "X-Requested-With",
-    "Range",
-    "User-Agent"
-  ],
-  "Access-Control-Allow-Methods": [
-    "GET"
-  ],
-  "Access-Control-Allow-Origin": [
-    "*"
-  ]
-}
+{}
 EOF
     ipfs config --json Gateway.HTTPHeaders > actual &&
     test_cmp expected actual
@@ -43,13 +31,19 @@ test_expect_success "GET to Gateway succeeds" '
 test_expect_success "GET response for Gateway resource looks good" '
   test_should_contain "< Access-Control-Allow-Origin: \*" curl_output &&
   test_should_contain "< Access-Control-Allow-Methods: GET" curl_output &&
+  test_should_contain "< Access-Control-Allow-Methods: HEAD" curl_output &&
+  test_should_contain "< Access-Control-Allow-Methods: OPTIONS" curl_output &&
+  test_should_contain "< Access-Control-Allow-Headers: Content-Type" curl_output &&
   test_should_contain "< Access-Control-Allow-Headers: Range" curl_output &&
+  test_should_contain "< Access-Control-Allow-Headers: User-Agent" curl_output &&
+  test_should_contain "< Access-Control-Allow-Headers: X-Requested-With" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: Content-Range" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: Content-Length" curl_output &&
+  test_should_contain "< Access-Control-Expose-Headers: X-Chunked-Output" curl_output &&
+  test_should_contain "< Access-Control-Expose-Headers: X-Stream-Output" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output
 '
-
 # HTTP OPTIONS Request
 test_expect_success "OPTIONS to Gateway succeeds" '
   curl -svX OPTIONS -H "Origin: https://example.com" "http://127.0.0.1:$GWAY_PORT/ipfs/$thash" 2>curl_output &&
@@ -60,11 +54,32 @@ test_expect_success "OPTIONS to Gateway succeeds" '
 test_expect_success "OPTIONS response for Gateway resource looks good" '
   test_should_contain "< Access-Control-Allow-Origin: \*" curl_output &&
   test_should_contain "< Access-Control-Allow-Methods: GET" curl_output &&
+  test_should_contain "< Access-Control-Allow-Methods: HEAD" curl_output &&
+  test_should_contain "< Access-Control-Allow-Methods: OPTIONS" curl_output &&
+  test_should_contain "< Access-Control-Allow-Headers: Content-Type" curl_output &&
   test_should_contain "< Access-Control-Allow-Headers: Range" curl_output &&
+  test_should_contain "< Access-Control-Allow-Headers: User-Agent" curl_output &&
+  test_should_contain "< Access-Control-Allow-Headers: X-Requested-With" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: Content-Range" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: Content-Length" curl_output &&
+  test_should_contain "< Access-Control-Expose-Headers: X-Chunked-Output" curl_output &&
+  test_should_contain "< Access-Control-Expose-Headers: X-Stream-Output" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output
+'
+
+# HTTP OPTIONS Request on path → subdomain HTTP 301 redirect
+# (regression test for https://github.com/ipfs/kubo/issues/9983#issuecomment-1599673976)
+test_expect_success "OPTIONS to Gateway succeeds" '
+  curl -svX OPTIONS -H "Origin: https://example.com" "http://localhost:$GWAY_PORT/ipfs/$thash" 2>curl_output &&
+  cat curl_output
+'
+# OPTION Response from Gateway should contain CORS headers
+test_expect_success "OPTIONS response for subdomain redirect looks good" '
+  test_should_contain "HTTP/1.1 301 Moved Permanently" curl_output &&
+  test_should_contain "Location" curl_output &&
+  test_should_contain "< Access-Control-Allow-Origin: \*" curl_output &&
+  test_should_contain "< Access-Control-Allow-Methods: GET" curl_output
 '
 
 test_kill_ipfs_daemon


### PR DESCRIPTION
This PR closes #9983 which is regression since 0.20.
We should include this fix  in Kubo 0.21 (https://github.com/ipfs/kubo/issues/9814).

Depends on https://github.com/ipfs/boxo/pull/395