### PR TITLE
fix: correctly handle migration of configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,7 @@ func Path(configroot, extension string) (string, error) {
 //   - If the user-provided configuration file path is only a file name, use the
 //     configuration root directory, otherwise use only the user-provided path
 //     and ignore the configuration root.
-func Filename(configroot string, userConfigFile string) (string, error) {
+func Filename(configroot, userConfigFile string) (string, error) {
 	if userConfigFile == "" {
 		return Path(configroot, DefaultConfigFile)
 	}

--- a/config/types.go
+++ b/config/types.go
@@ -415,9 +415,9 @@ func (p OptionalString) String() string {
 var _ json.Unmarshaler = (*OptionalInteger)(nil)
 var _ json.Marshaler = (*OptionalInteger)(nil)
 
-type swarmLimits struct{}
+type swarmLimits doNotUse
 
-var _ json.Unmarshaler = swarmLimits{}
+var _ json.Unmarshaler = swarmLimits(false)
 
 func (swarmLimits) UnmarshalJSON(b []byte) error {
 	d := json.NewDecoder(bytes.NewReader(b))
@@ -439,9 +439,9 @@ func (swarmLimits) UnmarshalJSON(b []byte) error {
 	}
 }
 
-type experimentalAcceleratedDHTClient struct{}
+type experimentalAcceleratedDHTClient doNotUse
 
-var _ json.Unmarshaler = experimentalAcceleratedDHTClient{}
+var _ json.Unmarshaler = experimentalAcceleratedDHTClient(false)
 
 func (experimentalAcceleratedDHTClient) UnmarshalJSON(b []byte) error {
 	d := json.NewDecoder(bytes.NewReader(b))
@@ -462,3 +462,8 @@ func (experimentalAcceleratedDHTClient) UnmarshalJSON(b []byte) error {
 		}
 	}
 }
+
+// doNotUse is a type you must not use, it should be struct{} but encoding/json
+// does not support omitempty on structs and I can't be bothered to write custom
+// marshalers on all structs that have a doNotUse field.
+type doNotUse bool


### PR DESCRIPTION
readPluginsConfig was copied from ReadMigrationConfig and switched  erroring fields to a bool so it can be omitemptied.