### PR TITLE
ci: add changelog update checker workflow [skip changelog]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 <!--
-PR Creation Checklist
-- [ ] Update Changelog
+Please update docs/changelogs/. If your change does not require a changelog entry, please do one of the following:
+- add `[skip changelog]` to the PR title
+- label the PR with `skip/changelog`
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-Please update docs/changelogs/. If your change does not require a changelog entry, please do one of the following:
+Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
 - add `[skip changelog]` to the PR title
 - label the PR with `skip/changelog`
 -->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           npm install ipfs-interop@^10.0.1
         working-directory: interop
       # Run the interop tests while ignoring the js-js interop test cases
-      - run: npx ipfs-interop -- -t node --grep '^(?!.*(js\d? -> js\d?|js-js-js))' --parallel
+      - run: npx ipfs-interop -- -t node --grep '^(?!.*(js\d? -> js\d?|js-js-js|js-rv\d?-js))' --parallel
         env:
           LIBP2P_TCP_REUSEPORT: false
           LIBP2P_ALLOW_WEAK_RSA_KEYS: 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,10 @@ on:
       - reopened
       - labeled
       - unlabeled
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
 
 jobs:
   changelog:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,35 @@
+name: Changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  changelog:
+    if: contains(github.event.pull_request.title, '[skip changelog]') == false &&
+        contains(github.event.pull_request.labels.*.name, 'skip/changelog') == false
+    runs-on: ubuntu-latest
+    name: Changelog
+    steps:
+      - id: changelog
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ENDPOINT: repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
+          SELECTOR: 'map(select(.filename | startswith("docs/changelogs/"))) | length'
+        run: gh api "$ENDPOINT" --jq "$SELECTOR" | xargs -I{} echo "modified={}" | tee -a $GITHUB_OUTPUT
+      - if: steps.changelog.outputs.modified == '0'
+        env:
+          MESSAGE: |
+            docs/changelogs/ was not modified in this PR. Please do one of the following:
+            - add a changelog entry
+            - add `[skip changelog]` to the PR title
+            - label the PR with `skip/changelog`
+        run: |
+          echo "::error::${MESSAGE//$'\n'/%0A}"
+          exit 1


### PR DESCRIPTION
Related to https://github.com/ipfs/boxo/pull/398

This PR adds a CI workflow which checks whether the PR contains docs/changelogs/ modifications. 

The check can be skipped by either adding `[skip changelog]` to the PR title or labelling the PR with `skip/changelog`. These instructions are included in the PR template and in the workflow failure message.

The check succeeds if docs/changelogs/ was modified and fails otherwise.

Tested in https://github.com/galargh/.github/pull/40

---

If we ever decide to use this beyond kubo/boxo, we should consider turning this into a reusable workflow. 