### PR TITLE
docs: Gateway.HTTPHeaders

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -663,20 +663,7 @@ Type: `flag`
 
 Headers to set on gateway responses.
 
-Default:
-```json
-{
-	"Access-Control-Allow-Headers": [
-		"X-Requested-With"
-	],
-	"Access-Control-Allow-Methods": [
-		"GET"
-	],
-	"Access-Control-Allow-Origin": [
-		"*"
-	]
-}
-```
+Default: `{}` + implicit CORS headers from `boxo/gateway#AddAccessControlHeaders` and [ipfs/specs#423](https://github.com/ipfs/specs/issues/423)
 
 Type: `object[string -> array[string]]`
 


### PR DESCRIPTION
 https://github.com/ipfs/kubo/pull/9994 made these defaults implicit  (defined in boxo if missing from user config) + these values in docs were out of date anyway.  This PR reflects the current state of things.