### PR TITLE
fix: mark all routers DoNotWaitForSearchValue

### DIFF
--- a/core/node/libp2p/routing.go
+++ b/core/node/libp2p/routing.go
@@ -31,8 +31,7 @@ import (
 type Router struct {
 	routing.Routing
 
-	Priority         int // less = more important
-	DoNotWaitForIPNS bool
+	Priority int // less = more important
 }
 
 type p2pRouterOut struct {
@@ -127,7 +126,7 @@ func BaseRouting(cfg *config.Config) interface{} {
 				return out, err
 			}
 			routers := []*routinghelpers.ParallelRouter{
-				{Router: fullRTClient},
+				{Router: fullRTClient, DoNotWaitForSearchValue: true},
 			}
 			routers = append(routers, httpRouters...)
 			router := routinghelpers.NewComposableParallel(routers)
@@ -199,7 +198,7 @@ func Routing(in p2pOnlineRoutingIn) irouting.ProvideManyRouter {
 	for _, v := range routers {
 		cRouters = append(cRouters, &routinghelpers.ParallelRouter{
 			IgnoreError:             true,
-			DoNotWaitForSearchValue: v.DoNotWaitForIPNS,
+			DoNotWaitForSearchValue: true,
 			Router:                  v.Routing,
 		})
 	}
@@ -246,8 +245,7 @@ func PubsubRouter(mctx helpers.MetricsCtx, lc fx.Lifecycle, in p2pPSRoutingIn) (
 					Namespaces: []string{"ipns"},
 				},
 			},
-			Priority:         100,
-			DoNotWaitForIPNS: true,
+			Priority: 100,
 		},
 	}, psRouter, nil
 }

--- a/core/node/libp2p/routing.go
+++ b/core/node/libp2p/routing.go
@@ -31,7 +31,8 @@ import (
 type Router struct {
 	routing.Routing
 
-	Priority int // less = more important
+	Priority         int // less = more important
+	DoNotWaitForIPNS bool
 }
 
 type p2pRouterOut struct {
@@ -197,8 +198,9 @@ func Routing(in p2pOnlineRoutingIn) irouting.ProvideManyRouter {
 	var cRouters []*routinghelpers.ParallelRouter
 	for _, v := range routers {
 		cRouters = append(cRouters, &routinghelpers.ParallelRouter{
-			IgnoreError: true,
-			Router:      v.Routing,
+			IgnoreError:             true,
+			DoNotWaitForSearchValue: v.DoNotWaitForIPNS,
+			Router:                  v.Routing,
 		})
 	}
 
@@ -244,7 +246,8 @@ func PubsubRouter(mctx helpers.MetricsCtx, lc fx.Lifecycle, in p2pPSRoutingIn) (
 					Namespaces: []string{"ipns"},
 				},
 			},
-			Priority: 100,
+			Priority:         100,
+			DoNotWaitForIPNS: true,
 		},
 	}, psRouter, nil
 }

--- a/core/node/libp2p/routingopt.go
+++ b/core/node/libp2p/routingopt.go
@@ -61,10 +61,11 @@ func constructDefaultHTTPRouters(cfg *config.Config) ([]*routinghelpers.Parallel
 		}
 
 		routers = append(routers, &routinghelpers.ParallelRouter{
-			Router:       r,
-			IgnoreError:  true,             // https://github.com/ipfs/kubo/pull/9475#discussion_r1042507387
-			Timeout:      15 * time.Second, // 5x server value from https://github.com/ipfs/kubo/pull/9475#discussion_r1042428529
-			ExecuteAfter: 0,
+			Router:                  r,
+			IgnoreError:             true,             // https://github.com/ipfs/kubo/pull/9475#discussion_r1042507387
+			Timeout:                 15 * time.Second, // 5x server value from https://github.com/ipfs/kubo/pull/9475#discussion_r1042428529
+			DoNotWaitForSearchValue: true,
+			ExecuteAfter:            0,
 		})
 	}
 	return routers, nil
@@ -82,9 +83,10 @@ func ConstructDefaultRouting(cfg *config.Config, routingOpt RoutingOption) Routi
 			return nil, err
 		}
 		routers = append(routers, &routinghelpers.ParallelRouter{
-			Router:       dhtRouting,
-			IgnoreError:  false,
-			ExecuteAfter: 0,
+			Router:                  dhtRouting,
+			IgnoreError:             false,
+			DoNotWaitForSearchValue: true,
+			ExecuteAfter:            0,
 		})
 
 		httpRouters, err := constructDefaultHTTPRouters(cfg)

--- a/docs/changelogs/v0.22.md
+++ b/docs/changelogs/v0.22.md
@@ -26,10 +26,9 @@ to V2 only in the future.
 
 #### IPNS name resolution has been fixed
 
-IPNS name resolution used to always take 1 minute if the record was not yet cached.
-Even tho the DHT query most often finish in three digits miliseconds to single digits seconds.
+IPNS name resolution had a regression where if IPNS over PubSub was enabled, but the name was not also available via IPNS over PubSub it would take 1 minute to for the lookup to complete (if the record was not yet cached).
 
-This has been fixed, it now takes as long as the DHT will take.
+This has been fixed and as before will give the best record from either the DHT subsystem or IPNS over PubSub, whichever comes back first.
 
 For details see [#9927](https://github.com/ipfs/kubo/issues/9927) and [#10020](https://github.com/ipfs/kubo/pull/10020).
 

--- a/docs/changelogs/v0.22.md
+++ b/docs/changelogs/v0.22.md
@@ -7,6 +7,7 @@
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [`ipfs name publish` now supports V2 only IPNS records](#ipfs-name-publish-now-supports-v2-only-ipns-records)
+  - [IPNS name resolution has been fixed](#ipns-name-resolution-has-been-fixed)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -22,6 +23,15 @@ that there is the highest chance of backwards compatibility. The goal is to move
 to V2 only in the future.
 
 **TODO**: add links to IPIP https://github.com/ipfs/specs/issues/376
+
+#### IPNS name resolution has been fixed
+
+IPNS name resolution used to always take 1 minute if the record was not yet cached.
+Even tho the DHT query most often finish in three digits miliseconds to single digits seconds.
+
+This has been fixed, it now takes as long as the DHT will take.
+
+For details see [#9927](https://github.com/ipfs/kubo/issues/9927) and [#10020](https://github.com/ipfs/kubo/pull/10020).
 
 ### 📝 Changelog
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc // indirect
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
+	github.com/Jorropo/jsync v1.0.1 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
@@ -106,7 +107,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3 // indirect
 	github.com/libp2p/go-libp2p-pubsub-router v0.6.0 // indirect
 	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
-	github.com/libp2p/go-libp2p-routing-helpers v0.7.0 // indirect
+	github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2 // indirect
 	github.com/libp2p/go-libp2p-xor v0.1.0 // indirect
 	github.com/libp2p/go-mplex v0.7.0 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3 // indirect
 	github.com/libp2p/go-libp2p-pubsub-router v0.6.0 // indirect
 	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
-	github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2 // indirect
+	github.com/libp2p/go-libp2p-routing-helpers v0.7.1 // indirect
 	github.com/libp2p/go-libp2p-xor v0.1.0 // indirect
 	github.com/libp2p/go-mplex v0.7.0 // indirect
 	github.com/libp2p/go-msgio v0.3.0 // indirect

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -45,6 +45,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIo
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Jorropo/jsync v1.0.1 h1:6HgRolFZnsdfzRUj+ImB9og1JYOxQoReSywkHOGSaUU=
+github.com/Jorropo/jsync v1.0.1/go.mod h1:jCOZj3vrBCri3bSU3ErUYvevKlnbssrXeCivybS5ABQ=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
@@ -502,8 +504,8 @@ github.com/libp2p/go-libp2p-pubsub-router v0.6.0 h1:D30iKdlqDt5ZmLEYhHELCMRj8b4s
 github.com/libp2p/go-libp2p-pubsub-router v0.6.0/go.mod h1:FY/q0/RBTKsLA7l4vqC2cbRbOvyDotg8PJQ7j8FDudE=
 github.com/libp2p/go-libp2p-record v0.2.0 h1:oiNUOCWno2BFuxt3my4i1frNrt7PerzB3queqa1NkQ0=
 github.com/libp2p/go-libp2p-record v0.2.0/go.mod h1:I+3zMkvvg5m2OcSdoL0KPljyJyvNDFGKX7QdlpYUcwk=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.0 h1:sirOYVD0wGWjkDwHZvinunIpaqPLBXkcnXApVHwZFGA=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.0/go.mod h1:R289GUxUMzRXIbWGSuUUTPrlVJZ3Y/pPz495+qgXJX8=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2 h1:vrpRNp4Op39bYYqPQjfwTU341Kckpmbp4QIvKitw37I=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2/go.mod h1:cHStPSRC/wgbfpb5jYdMP7zaSmc2wWcb1mkzNr6AR8o=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-xor v0.1.0 h1:hhQwT4uGrBcuAkUGXADuPltalOdpf9aag9kaYNT2tLA=
 github.com/libp2p/go-libp2p-xor v0.1.0/go.mod h1:LSTM5yRnjGZbWNTA/hRwq2gGFrvRIbQJscoIL/u6InY=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -504,8 +504,8 @@ github.com/libp2p/go-libp2p-pubsub-router v0.6.0 h1:D30iKdlqDt5ZmLEYhHELCMRj8b4s
 github.com/libp2p/go-libp2p-pubsub-router v0.6.0/go.mod h1:FY/q0/RBTKsLA7l4vqC2cbRbOvyDotg8PJQ7j8FDudE=
 github.com/libp2p/go-libp2p-record v0.2.0 h1:oiNUOCWno2BFuxt3my4i1frNrt7PerzB3queqa1NkQ0=
 github.com/libp2p/go-libp2p-record v0.2.0/go.mod h1:I+3zMkvvg5m2OcSdoL0KPljyJyvNDFGKX7QdlpYUcwk=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2 h1:vrpRNp4Op39bYYqPQjfwTU341Kckpmbp4QIvKitw37I=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2/go.mod h1:cHStPSRC/wgbfpb5jYdMP7zaSmc2wWcb1mkzNr6AR8o=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1 h1:kc0kWCZecbBPAiFEHhxfGJZPqjg1g9zV+X+ovR4Tmnc=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1/go.mod h1:cHStPSRC/wgbfpb5jYdMP7zaSmc2wWcb1mkzNr6AR8o=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-xor v0.1.0 h1:hhQwT4uGrBcuAkUGXADuPltalOdpf9aag9kaYNT2tLA=
 github.com/libp2p/go-libp2p-xor v0.1.0/go.mod h1:LSTM5yRnjGZbWNTA/hRwq2gGFrvRIbQJscoIL/u6InY=

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/libp2p/go-libp2p-pubsub-router v0.6.0
 	github.com/libp2p/go-libp2p-record v0.2.0
-	github.com/libp2p/go-libp2p-routing-helpers v0.7.0
+	github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2
 	github.com/libp2p/go-libp2p-testing v0.12.0
 	github.com/libp2p/go-socket-activation v0.1.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -91,6 +91,7 @@ require (
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
+	github.com/Jorropo/jsync v1.0.1 // indirect
 	github.com/Kubuxu/go-os-helper v0.0.1 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/libp2p/go-libp2p-pubsub-router v0.6.0
 	github.com/libp2p/go-libp2p-record v0.2.0
-	github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2
+	github.com/libp2p/go-libp2p-routing-helpers v0.7.1
 	github.com/libp2p/go-libp2p-testing v0.12.0
 	github.com/libp2p/go-socket-activation v0.1.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -565,8 +565,8 @@ github.com/libp2p/go-libp2p-pubsub-router v0.6.0 h1:D30iKdlqDt5ZmLEYhHELCMRj8b4s
 github.com/libp2p/go-libp2p-pubsub-router v0.6.0/go.mod h1:FY/q0/RBTKsLA7l4vqC2cbRbOvyDotg8PJQ7j8FDudE=
 github.com/libp2p/go-libp2p-record v0.2.0 h1:oiNUOCWno2BFuxt3my4i1frNrt7PerzB3queqa1NkQ0=
 github.com/libp2p/go-libp2p-record v0.2.0/go.mod h1:I+3zMkvvg5m2OcSdoL0KPljyJyvNDFGKX7QdlpYUcwk=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2 h1:vrpRNp4Op39bYYqPQjfwTU341Kckpmbp4QIvKitw37I=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2/go.mod h1:cHStPSRC/wgbfpb5jYdMP7zaSmc2wWcb1mkzNr6AR8o=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1 h1:kc0kWCZecbBPAiFEHhxfGJZPqjg1g9zV+X+ovR4Tmnc=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1/go.mod h1:cHStPSRC/wgbfpb5jYdMP7zaSmc2wWcb1mkzNr6AR8o=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-libp2p-xor v0.1.0 h1:hhQwT4uGrBcuAkUGXADuPltalOdpf9aag9kaYNT2tLA=

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIo
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Jorropo/jsync v1.0.1 h1:6HgRolFZnsdfzRUj+ImB9og1JYOxQoReSywkHOGSaUU=
+github.com/Jorropo/jsync v1.0.1/go.mod h1:jCOZj3vrBCri3bSU3ErUYvevKlnbssrXeCivybS5ABQ=
 github.com/Kubuxu/go-os-helper v0.0.1 h1:EJiD2VUQyh5A9hWJLmc6iWg6yIcJ7jpBcwC8GMGXfDk=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -563,8 +565,8 @@ github.com/libp2p/go-libp2p-pubsub-router v0.6.0 h1:D30iKdlqDt5ZmLEYhHELCMRj8b4s
 github.com/libp2p/go-libp2p-pubsub-router v0.6.0/go.mod h1:FY/q0/RBTKsLA7l4vqC2cbRbOvyDotg8PJQ7j8FDudE=
 github.com/libp2p/go-libp2p-record v0.2.0 h1:oiNUOCWno2BFuxt3my4i1frNrt7PerzB3queqa1NkQ0=
 github.com/libp2p/go-libp2p-record v0.2.0/go.mod h1:I+3zMkvvg5m2OcSdoL0KPljyJyvNDFGKX7QdlpYUcwk=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.0 h1:sirOYVD0wGWjkDwHZvinunIpaqPLBXkcnXApVHwZFGA=
-github.com/libp2p/go-libp2p-routing-helpers v0.7.0/go.mod h1:R289GUxUMzRXIbWGSuUUTPrlVJZ3Y/pPz495+qgXJX8=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2 h1:vrpRNp4Op39bYYqPQjfwTU341Kckpmbp4QIvKitw37I=
+github.com/libp2p/go-libp2p-routing-helpers v0.7.1-0.20230724133210-850d18ac98d2/go.mod h1:cHStPSRC/wgbfpb5jYdMP7zaSmc2wWcb1mkzNr6AR8o=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
 github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-libp2p-xor v0.1.0 h1:hhQwT4uGrBcuAkUGXADuPltalOdpf9aag9kaYNT2tLA=

--- a/routing/delegated.go
+++ b/routing/delegated.go
@@ -105,10 +105,11 @@ func parse(visited map[string]bool,
 			}
 
 			pr = append(pr, &routinghelpers.ParallelRouter{
-				Router:       ri,
-				IgnoreError:  cr.IgnoreErrors,
-				Timeout:      cr.Timeout.Duration,
-				ExecuteAfter: cr.ExecuteAfter.WithDefault(0),
+				Router:                         ri,
+				IgnoreError:                    cr.IgnoreErrors,
+				DoNotWaitForStreamingResponses: cr.DoNotWaitForStreamingResponses,
+				Timeout:                        cr.Timeout.Duration,
+				ExecuteAfter:                   cr.ExecuteAfter.WithDefault(0),
 			})
 
 		}

--- a/routing/delegated.go
+++ b/routing/delegated.go
@@ -105,11 +105,11 @@ func parse(visited map[string]bool,
 			}
 
 			pr = append(pr, &routinghelpers.ParallelRouter{
-				Router:                         ri,
-				IgnoreError:                    cr.IgnoreErrors,
-				DoNotWaitForStreamingResponses: cr.DoNotWaitForStreamingResponses,
-				Timeout:                        cr.Timeout.Duration,
-				ExecuteAfter:                   cr.ExecuteAfter.WithDefault(0),
+				Router:                  ri,
+				IgnoreError:             cr.IgnoreErrors,
+				DoNotWaitForSearchValue: true,
+				Timeout:                 cr.Timeout.Duration,
+				ExecuteAfter:            cr.ExecuteAfter.WithDefault(0),
 			})
 
 		}


### PR DESCRIPTION
That means if the DHT has finished searching and no one responded over pubsub *yet*, we will not spend 1 minute searching for no reason.

This also include other error handling bug fixes inside `go-libp2p-routing-helpers`.

Fixes: #9927

![Screenshot 2023-07-19 at 04-55-48 Jaeger UI](https://github.com/ipfs/kubo/assets/24391983/fc475516-ac30-48a2-8eee-3582b64a78b5)

Depends on https://github.com/libp2p/go-libp2p-routing-helpers/pull/75