### PR TITLE
core/bootstrap: fix panic without backup bootstrap peer functions

### DIFF
--- a/core/bootstrap/bootstrap.go
+++ b/core/bootstrap/bootstrap.go
@@ -96,7 +96,7 @@ func WithBackupPeers(load func(context.Context) []peer.AddrInfo, save func(conte
 	}
 }
 
-// BackupPeers returns the load and save  backup peers functions.
+// BackupPeers returns the load and save backup peers functions.
 func (cfg *BootstrapConfig) BackupPeers() (func(context.Context) []peer.AddrInfo, func(context.Context, []peer.AddrInfo)) {
 	return cfg.loadBackupBootstrapPeers, cfg.saveBackupBootstrapPeers
 }

--- a/core/bootstrap/bootstrap.go
+++ b/core/bootstrap/bootstrap.go
@@ -59,8 +59,8 @@ type BootstrapConfig struct {
 	// as backup bootstrap peers.
 	MaxBackupBootstrapSize int
 
-	SaveBackupBootstrapPeers func(context.Context, []peer.AddrInfo)
-	LoadBackupBootstrapPeers func(context.Context) []peer.AddrInfo
+	saveBackupBootstrapPeers func(context.Context, []peer.AddrInfo)
+	loadBackupBootstrapPeers func(context.Context) []peer.AddrInfo
 }
 
 // DefaultBootstrapConfig specifies default sane parameters for bootstrapping.
@@ -91,9 +91,20 @@ func WithBackupPeers(load func(context.Context) []peer.AddrInfo, save func(conte
 		panic("both load and save backup bootstrap peers functions must be defined")
 	}
 	return func(cfg *BootstrapConfig) {
-		cfg.LoadBackupBootstrapPeers = load
-		cfg.SaveBackupBootstrapPeers = save
+		cfg.loadBackupBootstrapPeers = load
+		cfg.saveBackupBootstrapPeers = save
 	}
+}
+
+// BackupPeers returns the load and save  backup peers functions.
+func (cfg *BootstrapConfig) BackupPeers() (func(context.Context) []peer.AddrInfo, func(context.Context, []peer.AddrInfo)) {
+	return cfg.loadBackupBootstrapPeers, cfg.saveBackupBootstrapPeers
+}
+
+// SetBackupPeers sets the load and save backup peers functions.
+func (cfg *BootstrapConfig) SetBackupPeers(load func(context.Context) []peer.AddrInfo, save func(context.Context, []peer.AddrInfo)) {
+	opt := WithBackupPeers(load, save)
+	opt(cfg)
 }
 
 // Bootstrap kicks off IpfsNode bootstrapping. This function will periodically
@@ -140,9 +151,9 @@ func Bootstrap(id peer.ID, host host.Host, rt routing.Routing, cfg BootstrapConf
 	doneWithRound <- struct{}{}
 	close(doneWithRound) // it no longer blocks periodic
 
-	// If LoadBackupBootstrapPeers is not nil then SaveBackupBootstrapPeers
+	// If loadBackupBootstrapPeers is not nil then saveBackupBootstrapPeers
 	// must also not be nil.
-	if cfg.LoadBackupBootstrapPeers != nil {
+	if cfg.loadBackupBootstrapPeers != nil {
 		startSavePeersAsTemporaryBootstrapProc(cfg, host, proc)
 	}
 
@@ -205,7 +216,7 @@ func saveConnectedPeersAsTemporaryBootstrap(ctx context.Context, host host.Host,
 
 	// If we didn't reach the target number use previously stored connected peers.
 	if len(backupPeers) < cfg.MaxBackupBootstrapSize {
-		oldSavedPeers := cfg.LoadBackupBootstrapPeers(ctx)
+		oldSavedPeers := cfg.loadBackupBootstrapPeers(ctx)
 		log.Debugf("missing %d peers to reach backup bootstrap target of %d, trying from previous list of %d saved peers",
 			cfg.MaxBackupBootstrapSize-len(backupPeers), cfg.MaxBackupBootstrapSize, len(oldSavedPeers))
 
@@ -229,7 +240,7 @@ func saveConnectedPeersAsTemporaryBootstrap(ctx context.Context, host host.Host,
 		}
 	}
 
-	cfg.SaveBackupBootstrapPeers(ctx, backupPeers)
+	cfg.saveBackupBootstrapPeers(ctx, backupPeers)
 	log.Debugf("saved %d peers (of %d target) as bootstrap backup in the config", len(backupPeers), cfg.MaxBackupBootstrapSize)
 	return nil
 }
@@ -261,14 +272,14 @@ func bootstrapRound(ctx context.Context, host host.Host, cfg BootstrapConfig) er
 		}
 	}
 
-	if cfg.LoadBackupBootstrapPeers == nil {
+	if cfg.loadBackupBootstrapPeers == nil {
 		log.Debugf("not enough bootstrap peers to fill the remaining target of %d connections", numToDial)
 		return ErrNotEnoughBootstrapPeers
 	}
 
 	log.Debugf("not enough bootstrap peers to fill the remaining target of %d connections, trying backup list", numToDial)
 
-	tempBootstrapPeers := cfg.LoadBackupBootstrapPeers(ctx)
+	tempBootstrapPeers := cfg.loadBackupBootstrapPeers(ctx)
 	if len(tempBootstrapPeers) > 0 {
 		numToDial -= int(peersConnect(ctx, host, tempBootstrapPeers, numToDial, false))
 		if numToDial <= 0 {

--- a/core/bootstrap/bootstrap.go
+++ b/core/bootstrap/bootstrap.go
@@ -124,7 +124,9 @@ func Bootstrap(id peer.ID, host host.Host, rt routing.Routing, cfg BootstrapConf
 	doneWithRound <- struct{}{}
 	close(doneWithRound) // it no longer blocks periodic
 
-	startSavePeersAsTemporaryBootstrapProc(cfg, host, proc)
+	if cfg.LoadBackupBootstrapPeers != nil && cfg.SaveBackupBootstrapPeers != nil {
+		startSavePeersAsTemporaryBootstrapProc(cfg, host, proc)
+	}
 
 	return proc, nil
 }
@@ -239,6 +241,11 @@ func bootstrapRound(ctx context.Context, host host.Host, cfg BootstrapConfig) er
 		if numToDial <= 0 {
 			return nil
 		}
+	}
+
+	if cfg.LoadBackupBootstrapPeers == nil {
+		log.Debugf("not enough bootstrap peers to fill the remaining target of %d connections", numToDial)
+		return ErrNotEnoughBootstrapPeers
 	}
 
 	log.Debugf("not enough bootstrap peers to fill the remaining target of %d connections, trying backup list", numToDial)

--- a/core/bootstrap/bootstrap.go
+++ b/core/bootstrap/bootstrap.go
@@ -88,7 +88,7 @@ func BootstrapConfigWithPeers(pis []peer.AddrInfo, options ...func(*BootstrapCon
 // WithBackupPeers configures functions to load and save backup bootstrap peers.
 func WithBackupPeers(load func(context.Context) []peer.AddrInfo, save func(context.Context, []peer.AddrInfo)) func(*BootstrapConfig) {
 	if save == nil && load != nil || save != nil && load == nil {
-		panic("both save an load backup bootstrap peers functions must be defined")
+		panic("both load and save backup bootstrap peers functions must be defined")
 	}
 	return func(cfg *BootstrapConfig) {
 		cfg.LoadBackupBootstrapPeers = load

--- a/core/bootstrap/bootstrap_test.go
+++ b/core/bootstrap/bootstrap_test.go
@@ -1,8 +1,12 @@
 package bootstrap
 
 import (
+	"crypto/rand"
 	"testing"
+	"time"
 
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/test"
 )
@@ -22,4 +26,32 @@ func TestRandomizeAddressList(t *testing.T) {
 	if len(out) != len(ps) {
 		t.Fail()
 	}
+}
+
+func TestNoTempPeersLoadAndSave(t *testing.T) {
+	period := 500 * time.Millisecond
+	bootCfg := BootstrapConfigWithPeers(nil)
+	bootCfg.MinPeerThreshold = 2
+	bootCfg.Period = period
+
+	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerID, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2pHost, err := libp2p.New(libp2p.Identity(priv))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bootstrapper, err := Bootstrap(peerID, p2pHost, nil, bootCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(4 * period)
+	bootstrapper.Close()
 }

--- a/core/core.go
+++ b/core/core.go
@@ -168,17 +168,15 @@ func (n *IpfsNode) Bootstrap(cfg bootstrap.BootstrapConfig) error {
 			return ps
 		}
 	}
-	if cfg.SaveBackupBootstrapPeers == nil {
-		cfg.SaveBackupBootstrapPeers = func(ctx context.Context, peerList []peer.AddrInfo) {
+	if load, save := cfg.BackupPeers(); load == nil {
+		save = func(ctx context.Context, peerList []peer.AddrInfo) {
 			err := n.saveTempBootstrapPeers(ctx, peerList)
 			if err != nil {
 				log.Warnf("saveTempBootstrapPeers failed: %s", err)
 				return
 			}
 		}
-	}
-	if cfg.LoadBackupBootstrapPeers == nil {
-		cfg.LoadBackupBootstrapPeers = func(ctx context.Context) []peer.AddrInfo {
+		load = func(ctx context.Context) []peer.AddrInfo {
 			peerList, err := n.loadTempBootstrapPeers(ctx)
 			if err != nil {
 				log.Warnf("loadTempBootstrapPeers failed: %s", err)
@@ -186,6 +184,7 @@ func (n *IpfsNode) Bootstrap(cfg bootstrap.BootstrapConfig) error {
 			}
 			return peerList
 		}
+		cfg.SetBackupPeers(load, save)
 	}
 
 	repoConf, err := n.Repo.Config()

--- a/core/core.go
+++ b/core/core.go
@@ -168,8 +168,8 @@ func (n *IpfsNode) Bootstrap(cfg bootstrap.BootstrapConfig) error {
 			return ps
 		}
 	}
-	if load, save := cfg.BackupPeers(); load == nil {
-		save = func(ctx context.Context, peerList []peer.AddrInfo) {
+	if load, _ := cfg.BackupPeers(); load == nil {
+		save := func(ctx context.Context, peerList []peer.AddrInfo) {
 			err := n.saveTempBootstrapPeers(ctx, peerList)
 			if err != nil {
 				log.Warnf("saveTempBootstrapPeers failed: %s", err)


### PR DESCRIPTION
A panic occurs when the first bootstrap round runs is these functions are not assigned in the configuration:
- `LoadBackupBootstrapPeers`
- `SaveBackupBootstrapPeers`

This fix assumes that it is acceptable for these functions to be `nil`, as it may be desirable to disable the backup peer load and save functionality.
