### PR TITLE
ci: fix tag checkout in the interop workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,10 @@ jobs:
           # https://github.com/ipfs/helia/pull/200
           # https://github.com/ipfs/helia-unixfs/pull/68
           # https://github.com/ipfs/helia-ipns/pull/72
-          export TAG="$(git describe --tags --abbrev=0)"
-          echo "Running tests against: $TAG"
-          git checkout "$TAG"
+          git fetch --tags
+          tag="$(git describe --tags --abbrev=0)"
+          echo "Running tests against: $tag"
+          git checkout "$tag"
         working-directory: interop
       - run: npm install
         working-directory: interop


### PR DESCRIPTION
IIRC we're going to have to fetch tags first for the latest tag checkout to work as expected. BTW, thank you for putting up https://github.com/ipfs/kubo/pull/10042 🙇 ❤️ 