### PR TITLE
ci: stop caching go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: make build
       - uses: actions/upload-artifact@v3
         with:
@@ -136,9 +133,6 @@ jobs:
             sleep 1
           done
         timeout-minutes: 5
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: go test -count=1 -v ./...
         working-directory: go-ipfs-api
       - run: cmd/ipfs/ipfs shutdown

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -32,9 +32,6 @@ jobs:
         with:
           go-version: 1.19.x
       - uses: actions/checkout@v3
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: make cmd/ipfs-try-build
         env:
           TEST_FUSE: 1

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -33,7 +33,4 @@ jobs:
         with:
           go-version: 1.19.x
       - uses: actions/checkout@v3
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: make -O test_go_lint

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -35,10 +35,6 @@ jobs:
           go-version: 1.19.x
       - name: Check out Kubo
         uses: actions/checkout@v3
-      - name: Restore Go cache
-        uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - name: 👉️ If this step failed, go to «Summary» (top left) → inspect the «Failures/Errors» table
         env:
           # increasing parallelism beyond 2 doesn't speed up the tests much

--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -32,10 +32,6 @@ jobs:
           path: kubo
       - name: Install missing tools
         run: sudo apt update && sudo apt install -y socat net-tools fish libxml2-utils
-      - name: Restore Go Cache
-        uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - uses: actions/cache@v3
         with:
           path: test/sharness/lib/dependencies


### PR DESCRIPTION
Go compiles fast and it does not seems to properly recognise the cached values given the build times are still in the 40s.

I think the extra 25s it takes to load and save the go cache is longer than what we gain.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
