### PR TITLE
fix: allow daemon to start correctly if the API is null

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -727,8 +727,11 @@ func serveHTTPApi(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, error
 		return nil, fmt.Errorf("serveHTTPApi: ConstructNode() failed: %s", err)
 	}
 
-	if err := node.Repo.SetAPIAddr(rewriteMaddrToUseLocalhostIfItsAny(listeners[0].Multiaddr())); err != nil {
-		return nil, fmt.Errorf("serveHTTPApi: SetAPIAddr() failed: %w", err)
+	if len(listeners) > 0 {
+		// Only add an api file if the API is running.
+		if err := node.Repo.SetAPIAddr(rewriteMaddrToUseLocalhostIfItsAny(listeners[0].Multiaddr())); err != nil {
+			return nil, fmt.Errorf("serveHTTPApi: SetAPIAddr() failed: %w", err)
+		}
 	}
 
 	errc := make(chan error)

--- a/test/cli/daemon_test.go
+++ b/test/cli/daemon_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/ipfs/kubo/test/cli/harness"
+)
+
+func TestDaemon(t *testing.T) {
+	t.Parallel()
+
+	t.Run("daemon starts if api is set to null", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init()
+		node.SetIPFSConfig("API", nil)
+		node.IPFS("daemon") // can't use .StartDaemon because it do a .WaitOnAPI
+	})
+}

--- a/test/cli/daemon_test.go
+++ b/test/cli/daemon_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/ipfs/kubo/test/cli/harness"
@@ -12,7 +13,13 @@ func TestDaemon(t *testing.T) {
 	t.Run("daemon starts if api is set to null", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init()
-		node.SetIPFSConfig("API", nil)
-		node.IPFS("daemon") // can't use .StartDaemon because it do a .WaitOnAPI
+		node.SetIPFSConfig("Addresses.API", nil)
+		node.Runner.MustRun(harness.RunRequest{
+			Path:    node.IPFSBin,
+			Args:    []string{"daemon"},
+			RunFunc: (*exec.Cmd).Start, // Start without waiting for completion.
+		})
+
+		node.StopDaemon()
 	})
 }

--- a/test/cli/harness/ipfs.go
+++ b/test/cli/harness/ipfs.go
@@ -38,9 +38,20 @@ func (n *Node) SetIPFSConfig(key string, val interface{}, flags ...string) {
 	n.IPFS(args...)
 
 	// validate the config was set correctly
-	var newVal string
-	n.GetIPFSConfig(key, &newVal)
-	if val != newVal {
+
+	// Create a new value which is a pointer to the same type as the source.
+	var newVal any
+	if val != nil {
+		// If it is not nil grab the type with reflect.
+		newVal = reflect.New(reflect.TypeOf(val)).Interface()
+	} else {
+		// else just set a pointer to an any.
+		var anything any
+		newVal = &anything
+	}
+	n.GetIPFSConfig(key, newVal)
+	// dereference newVal using reflect to load the resulting value
+	if !reflect.DeepEqual(val, reflect.ValueOf(newVal).Elem().Interface()) {
 		log.Panicf("key '%s' did not retain value '%s' after it was set, got '%s'", key, val, newVal)
 	}
 }


### PR DESCRIPTION
Fixes: #10056

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
