### PR TITLE
chore: bump boxo for verifcid breaking changes

### DIFF
--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -377,7 +377,7 @@ var hashesCmd = &cmds.Command{
 		var res []CodeAndName
 		// use mhash.Codes in case at some point there are multiple names for a given code
 		for code, name := range mhash.Codes {
-			if !verifcid.IsGoodHash(code) {
+			if !verifcid.DefaultAllowlist.IsAllowed(code) {
 				continue
 			}
 			res = append(res, CodeAndName{int(code), name})

--- a/core/commands/pin/pin.go
+++ b/core/commands/pin/pin.go
@@ -688,7 +688,7 @@ func pinVerify(ctx context.Context, n *core.IpfsNode, opts pinVerifyOpts, enc ci
 			return status
 		}
 
-		if err := verifcid.ValidateCid(root); err != nil {
+		if err := verifcid.ValidateCid(verifcid.DefaultAllowlist, root); err != nil {
 			status := PinStatus{Ok: false}
 			if opts.explain {
 				status.BadNodes = []BadNode{{Cid: enc.Encode(key), Err: err.Error()}}

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.18
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.11.0
+	github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.29.2
 	github.com/multiformats/go-multiaddr v0.10.1

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -301,8 +301,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.11.0 h1:urMxhZ3xoF4HssJVD3+0ssGT9pptEfHfbL8DYdoWFlg=
-github.com/ipfs/boxo v0.11.0/go.mod h1:8IfDmp+FzFGcF4zjAgHMVPpwYw4AjN9ePEzDfkaYJ1w=
+github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f h1:sXqGLIATCsBdHse7S9n6e328NhORvVM64+4IRuFlpmI=
+github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f/go.mod h1:8IfDmp+FzFGcF4zjAgHMVPpwYw4AjN9ePEzDfkaYJ1w=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/gc/gc.go
+++ b/gc/gc.go
@@ -156,7 +156,7 @@ func GC(ctx context.Context, bs bstore.GCBlockstore, dstor dstore.Datastore, pn 
 // to walk the tree.
 func Descendants(ctx context.Context, getLinks dag.GetLinks, set *cid.Set, roots <-chan pin.StreamedCid) error {
 	verifyGetLinks := func(ctx context.Context, c cid.Cid) ([]*ipld.Link, error) {
-		err := verifcid.ValidateCid(c)
+		err := verifcid.ValidateCid(verifcid.DefaultAllowlist, c)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ipfs/boxo v0.11.0
+	github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.11.0 h1:urMxhZ3xoF4HssJVD3+0ssGT9pptEfHfbL8DYdoWFlg=
-github.com/ipfs/boxo v0.11.0/go.mod h1:8IfDmp+FzFGcF4zjAgHMVPpwYw4AjN9ePEzDfkaYJ1w=
+github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f h1:sXqGLIATCsBdHse7S9n6e328NhORvVM64+4IRuFlpmI=
+github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f/go.mod h1:8IfDmp+FzFGcF4zjAgHMVPpwYw4AjN9ePEzDfkaYJ1w=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -7,7 +7,7 @@ replace github.com/ipfs/kubo => ../../
 require (
 	github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd
 	github.com/golangci/golangci-lint v1.49.0
-	github.com/ipfs/boxo v0.11.0
+	github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0
 	github.com/ipfs/go-datastore v0.6.0

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -395,8 +395,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.11.0 h1:urMxhZ3xoF4HssJVD3+0ssGT9pptEfHfbL8DYdoWFlg=
-github.com/ipfs/boxo v0.11.0/go.mod h1:8IfDmp+FzFGcF4zjAgHMVPpwYw4AjN9ePEzDfkaYJ1w=
+github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f h1:sXqGLIATCsBdHse7S9n6e328NhORvVM64+4IRuFlpmI=
+github.com/ipfs/boxo v0.11.1-0.20230817061817-1d2f5e511e9f/go.mod h1:8IfDmp+FzFGcF4zjAgHMVPpwYw4AjN9ePEzDfkaYJ1w=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.1.2 h1:GAjkfhVx1f4YTODS6Esrj1wt2HhrtwTnhEr+DyPUaJo=

--- a/thirdparty/verifbs/verifbs.go
+++ b/thirdparty/verifbs/verifbs.go
@@ -14,7 +14,7 @@ type VerifBSGC struct {
 }
 
 func (bs *VerifBSGC) Put(ctx context.Context, b blocks.Block) error {
-	if err := verifcid.ValidateCid(b.Cid()); err != nil {
+	if err := verifcid.ValidateCid(verifcid.DefaultAllowlist, b.Cid()); err != nil {
 		return err
 	}
 	return bs.GCBlockstore.Put(ctx, b)
@@ -22,7 +22,7 @@ func (bs *VerifBSGC) Put(ctx context.Context, b blocks.Block) error {
 
 func (bs *VerifBSGC) PutMany(ctx context.Context, blks []blocks.Block) error {
 	for _, b := range blks {
-		if err := verifcid.ValidateCid(b.Cid()); err != nil {
+		if err := verifcid.ValidateCid(verifcid.DefaultAllowlist, b.Cid()); err != nil {
 			return err
 		}
 	}
@@ -30,7 +30,7 @@ func (bs *VerifBSGC) PutMany(ctx context.Context, blks []blocks.Block) error {
 }
 
 func (bs *VerifBSGC) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	if err := verifcid.ValidateCid(c); err != nil {
+	if err := verifcid.ValidateCid(verifcid.DefaultAllowlist, c); err != nil {
 		return nil, err
 	}
 	return bs.GCBlockstore.Get(ctx, c)
@@ -41,7 +41,7 @@ type VerifBS struct {
 }
 
 func (bs *VerifBS) Put(ctx context.Context, b blocks.Block) error {
-	if err := verifcid.ValidateCid(b.Cid()); err != nil {
+	if err := verifcid.ValidateCid(verifcid.DefaultAllowlist, b.Cid()); err != nil {
 		return err
 	}
 	return bs.Blockstore.Put(ctx, b)
@@ -49,7 +49,7 @@ func (bs *VerifBS) Put(ctx context.Context, b blocks.Block) error {
 
 func (bs *VerifBS) PutMany(ctx context.Context, blks []blocks.Block) error {
 	for _, b := range blks {
-		if err := verifcid.ValidateCid(b.Cid()); err != nil {
+		if err := verifcid.ValidateCid(verifcid.DefaultAllowlist, b.Cid()); err != nil {
 			return err
 		}
 	}
@@ -57,7 +57,7 @@ func (bs *VerifBS) PutMany(ctx context.Context, blks []blocks.Block) error {
 }
 
 func (bs *VerifBS) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	if err := verifcid.ValidateCid(c); err != nil {
+	if err := verifcid.ValidateCid(verifcid.DefaultAllowlist, c); err != nil {
 		return nil, err
 	}
 	return bs.Blockstore.Get(ctx, c)


### PR DESCRIPTION
This is a Q&D fix to get kubo building again, this is completely equivalent to what we used to have. I'll submit a patch that DI the verifcid.Allowlist interface with fx later but this is needed to unblock something else.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
