### PR TITLE
[skip changelog] improve error in fuse node failures

### DIFF
--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -104,7 +104,7 @@ func (s *Root) Lookup(ctx context.Context, name string) (fs.Node, error) {
 		return nil, syscall.Errno(syscall.ENOTSUP)
 	}
 	if err != nil {
-		log.Error("could not convert protobuf or raw node")
+		log.Errorf("could not convert protobuf or raw node: %s", err)
 		return nil, syscall.Errno(syscall.ENOENT)
 	}
 


### PR DESCRIPTION
the underlying error when a protobuf is not able to be converted as expected during a fuse read is not being lost but silently dropped