### PR TITLE
refactor: if statement [skip changelog]

### DIFF
--- a/cmd/ipfs/runmain_test.go
+++ b/cmd/ipfs/runmain_test.go
@@ -24,7 +24,7 @@ func TestRunMain(t *testing.T) {
 	}
 
 	// close outputs so go testing doesn't print anything
-	null, _ := os.OpenFile(os.DevNull, os.O_RDWR, 0755)
+	null, _ := os.OpenFile(os.DevNull, os.O_RDWR, 0o755)
 	os.Stderr = null
 	os.Stdout = null
 }

--- a/core/commands/cmdenv/cidbase.go
+++ b/core/commands/cmdenv/cidbase.go
@@ -84,9 +84,10 @@ func CidEncoderFromPath(p string) (cidenc.Encoder, error) {
 	} else if len(components) < 3 {
 		// Not enough components to include a CID.
 		return cidenc.Encoder{}, fmt.Errorf("no cid in path: %s", p)
-	} else {
-		maybeCid = components[2]
 	}
+
+	maybeCid = components[2]
+
 	c, err := cid.Decode(maybeCid)
 	if err != nil {
 		// Ok, not a CID-like thing. Keep the current encoder.

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -234,9 +234,9 @@ Specification of CAR formats: https://ipld.io/specs/transport/car/
 
 			if event.Root.PinErrorMsg != "" {
 				return fmt.Errorf("pinning root %q FAILED: %s", enc.Encode(event.Root.Cid), event.Root.PinErrorMsg)
-			} else {
-				event.Root.PinErrorMsg = "success"
 			}
+
+			event.Root.PinErrorMsg = "success"
 
 			_, err = fmt.Fprintf(
 				w,

--- a/core/corehttp/option_test.go
+++ b/core/corehttp/option_test.go
@@ -51,10 +51,9 @@ func TestCheckVersionOption(t *testing.T) {
 			called = true
 			if !tc.shouldHandle {
 				t.Error("handler was called even though version didn't match")
-			} else {
-				if _, err := io.WriteString(w, "check!"); err != nil {
-					t.Error(err)
-				}
+			}
+			if _, err := io.WriteString(w, "check!"); err != nil {
+				t.Error(err)
 			}
 		})
 

--- a/core/corehttp/routing.go
+++ b/core/corehttp/routing.go
@@ -100,10 +100,9 @@ func (it *peerChanIter) Next() bool {
 	if ok {
 		it.next = &addr
 		return true
-	} else {
-		it.next = nil
-		return false
 	}
+	it.next = nil
+	return false
 }
 
 func (it *peerChanIter) Val() types.Record {

--- a/core/node/libp2p/smux.go
+++ b/core/node/libp2p/smux.go
@@ -38,17 +38,16 @@ func makeSmuxTransportOption(tptConfig config.Transports) (libp2p.Option, error)
 			}
 		}
 		return libp2p.ChainOptions(opts...), nil
-	} else {
-		return prioritizeOptions([]priorityOption{{
-			priority:        tptConfig.Multiplexers.Yamux,
-			defaultPriority: 100,
-			opt:             libp2p.Muxer(yamux.ID, yamux.DefaultTransport),
-		}, {
-			priority:        tptConfig.Multiplexers.Mplex,
-			defaultPriority: config.Disabled,
-			opt:             libp2p.Muxer(mplex.ID, mplex.DefaultTransport),
-		}}), nil
 	}
+	return prioritizeOptions([]priorityOption{{
+		priority:        tptConfig.Multiplexers.Yamux,
+		defaultPriority: 100,
+		opt:             libp2p.Muxer(yamux.ID, yamux.DefaultTransport),
+	}, {
+		priority:        tptConfig.Multiplexers.Mplex,
+		defaultPriority: config.Disabled,
+		opt:             libp2p.Muxer(mplex.ID, mplex.DefaultTransport),
+	}}), nil
 }
 
 func SmuxTransport(tptConfig config.Transports) func() (opts Libp2pOpts, err error) {

--- a/fuse/node/mount_darwin.go
+++ b/fuse/node/mount_darwin.go
@@ -141,9 +141,8 @@ func darwinFuseCheckVersion(node *core.IpfsNode) error {
 			return err
 		} else if skip {
 			return nil // user told us not to check version... ok....
-		} else {
-			return errGFV
 		}
+		return errGFV
 	}
 
 	log.Debug("mount: osxfuse version:", ov)


### PR DESCRIPTION
when the `if` statement ends with `return` or `panic` we can remove the `else`.