### PR TITLE
docs: remove link to deleted #accelerated-dht-client [skip changelog]

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -26,7 +26,6 @@ the above issue.
 - [Strategic Providing](#strategic-providing)
 - [Graphsync](#graphsync)
 - [Noise](#noise)
-- [Accelerated DHT Client](#accelerated-dht-client)
 - [Optimistic Provide](#optimistic-provide)
 
 ---


### PR DESCRIPTION
"Accelerated DHT Client" is no longer an experimental feature and the link I'm suggesting to remove is currently pointing nowhere.

This is a minor change but I think it will avoid confusion.
