### PR TITLE
ci: remove obsolete protocol/cache-go-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v4
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: make build
       - uses: actions/upload-artifact@v3
         with:
@@ -136,9 +133,6 @@ jobs:
             sleep 1
           done
         timeout-minutes: 5
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: go test -count=1 -v ./...
         working-directory: go-ipfs-api
       - run: cmd/ipfs/ipfs shutdown

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -32,9 +32,6 @@ jobs:
         with:
           go-version: 1.20.x
       - uses: actions/checkout@v4
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: make cmd/ipfs-try-build
         env:
           TEST_FUSE: 1

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -33,7 +33,4 @@ jobs:
         with:
           go-version: 1.20.x
       - uses: actions/checkout@v4
-      - uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - run: make -O test_go_lint

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -37,10 +37,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install missing tools
         run: sudo apt update && sudo apt install -y zsh
-      - name: Restore Go cache
-        uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - name: 👉️ If this step failed, go to «Summary» (top left) → inspect the «Failures/Errors» table
         env:
           # increasing parallelism beyond 2 doesn't speed up the tests much

--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -32,10 +32,6 @@ jobs:
           path: kubo
       - name: Install missing tools
         run: sudo apt update && sudo apt install -y socat net-tools fish libxml2-utils
-      - name: Restore Go Cache
-        uses: protocol/cache-go-action@v1
-        with:
-          name: ${{ github.job }}
       - uses: actions/cache@v3
         with:
           path: test/sharness/lib/dependencies


### PR DESCRIPTION
https://github.com/ipfs/kubo/pull/9976 updated setup-go action to v4, which comes with cache enabled by default. We can now remove our custom go caching action.