### PR TITLE
refactor: stop using go-libp2p deprecated peer.ID.Pretty

### DIFF
--- a/client/rpc/dht.go
+++ b/client/rpc/dht.go
@@ -17,7 +17,7 @@ func (api *DhtAPI) FindPeer(ctx context.Context, p peer.ID) (peer.AddrInfo, erro
 		Type      routing.QueryEventType
 		Responses []peer.AddrInfo
 	}
-	resp, err := api.core().Request("dht/findpeer", p.Pretty()).Send(ctx)
+	resp, err := api.core().Request("dht/findpeer", p.String()).Send(ctx)
 	if err != nil {
 		return peer.AddrInfo{}, err
 	}

--- a/client/rpc/swarm.go
+++ b/client/rpc/swarm.go
@@ -14,7 +14,7 @@ import (
 type SwarmAPI HttpApi
 
 func (api *SwarmAPI) Connect(ctx context.Context, pi peer.AddrInfo) error {
-	pidma, err := multiaddr.NewComponent("p2p", pi.ID.Pretty())
+	pidma, err := multiaddr.NewComponent("p2p", pi.ID.String())
 	if err != nil {
 		return err
 	}

--- a/config/init.go
+++ b/config/init.go
@@ -237,7 +237,7 @@ func CreateIdentity(out io.Writer, opts []options.KeyGenerateOption) (Identity, 
 	if err != nil {
 		return ident, err
 	}
-	ident.PeerID = id.Pretty()
+	ident.PeerID = id.String()
 	fmt.Fprintf(out, "peer identity: %s\n", ident.PeerID)
 	return ident, nil
 }

--- a/core/commands/dht_test.go
+++ b/core/commands/dht_test.go
@@ -14,12 +14,12 @@ func TestKeyTranslation(t *testing.T) {
 	pkname := namesys.PkKeyForID(pid)
 	ipnsname := ipns.NameFromPeer(pid).RoutingKey()
 
-	pkk, err := escapeDhtKey("/pk/" + pid.Pretty())
+	pkk, err := escapeDhtKey("/pk/" + pid.String())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ipnsk, err := escapeDhtKey("/ipns/" + pid.Pretty())
+	ipnsk, err := escapeDhtKey("/ipns/" + pid.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/commands/name/ipns.go
+++ b/core/commands/name/ipns.go
@@ -93,7 +93,7 @@ Resolve the value of a dnslink:
 			if err != nil {
 				return err
 			}
-			name = self.ID().Pretty()
+			name = self.ID().String()
 		} else {
 			name = req.Arguments[0]
 		}

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -79,7 +79,7 @@ trip latency information.
 		if len(n.Peerstore.Addrs(pid)) == 0 {
 			// Make sure we can find the node in question
 			if err := res.Emit(&PingResult{
-				Text:    fmt.Sprintf("Looking up peer %s", pid.Pretty()),
+				Text:    fmt.Sprintf("Looking up peer %s", pid),
 				Success: true,
 			}); err != nil {
 				return err
@@ -95,7 +95,7 @@ trip latency information.
 		}
 
 		if err := res.Emit(&PingResult{
-			Text:    fmt.Sprintf("PING %s.", pid.Pretty()),
+			Text:    fmt.Sprintf("PING %s.", pid),
 			Success: true,
 		}); err != nil {
 			return err

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -110,7 +110,7 @@ TOPIC AND DATA ENCODING
 			encoder, _ := mbase.EncoderByName("base64url")
 			psm := pubsubMessage{
 				Data:  encoder.Encode(msg.Data()),
-				From:  msg.From().Pretty(),
+				From:  msg.From().String(),
 				Seqno: encoder.Encode(msg.Seq()),
 			}
 			for _, topic := range msg.Topics() {
@@ -323,7 +323,7 @@ TOPIC AND DATA ENCODING
 		list := &stringList{make([]string, 0, len(peers))}
 
 		for _, peer := range peers {
-			list.Strings = append(list.Strings, peer.Pretty())
+			list.Strings = append(list.Strings, peer.String())
 		}
 		sort.Strings(list.Strings)
 		return cmds.EmitOnce(res, list)

--- a/core/commands/routing.go
+++ b/core/commands/routing.go
@@ -114,7 +114,7 @@ var findProvidersRoutingCmd = &cmds.Command{
 					if verbose {
 						fmt.Fprintf(out, "provider: ")
 					}
-					fmt.Fprintf(out, "%s\n", prov.ID.Pretty())
+					fmt.Fprintf(out, "%s\n", prov.ID)
 					if verbose {
 						for _, a := range prov.Addrs {
 							fmt.Fprintf(out, "\t%s\n", a)
@@ -479,7 +479,7 @@ identified by QmFoo.
 					return nil
 				},
 				routing.Value: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
-					fmt.Fprintf(out, "%s\n", obj.ID.Pretty())
+					fmt.Fprintf(out, "%s\n", obj.ID)
 					return nil
 				},
 			}

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -262,7 +262,7 @@ var swarmPeersCmd = &cmds.Command{
 		for _, c := range conns {
 			ci := connInfo{
 				Addr: c.Address().String(),
-				Peer: c.ID().Pretty(),
+				Peer: c.ID().String(),
 			}
 
 			if verbose || direction {
@@ -536,7 +536,7 @@ var swarmAddrsCmd = &cmds.Command{
 
 		out := make(map[string][]string)
 		for p, paddrs := range addrs {
-			s := p.Pretty()
+			s := p.String()
 			for _, a := range paddrs {
 				out[s] = append(out[s], a.String())
 			}
@@ -599,7 +599,7 @@ var swarmAddrsLocalCmd = &cmds.Command{
 		for _, addr := range maddrs {
 			saddr := addr.String()
 			if showid {
-				saddr = path.Join(saddr, p2pProtocolName, self.ID().Pretty())
+				saddr = path.Join(saddr, p2pProtocolName, self.ID().String())
 			}
 			addrs = append(addrs, saddr)
 		}
@@ -680,7 +680,7 @@ ipfs swarm connect /ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N
 
 		output := make([]string, len(pis))
 		for i, pi := range pis {
-			output[i] = "connect " + pi.ID.Pretty()
+			output[i] = "connect " + pi.ID.String()
 
 			err := api.Swarm().Connect(req.Context, pi)
 			if err != nil {
@@ -745,7 +745,7 @@ it will reconnect.
 			// a good backwards compat solution. Right now, I'm just
 			// preserving the current behavior.
 			for _, addr := range maddrs {
-				msg := "disconnect " + ainfo.ID.Pretty()
+				msg := "disconnect " + ainfo.ID.String()
 				if err := api.Swarm().Disconnect(req.Context, addr); err != nil {
 					msg += " failure: " + err.Error()
 				} else {

--- a/core/coreapi/test/api_test.go
+++ b/core/coreapi/test/api_test.go
@@ -56,7 +56,7 @@ func (NodeProvider) MakeAPISwarm(t *testing.T, ctx context.Context, fullIdentity
 			}
 
 			ident = config.Identity{
-				PeerID:  id.Pretty(),
+				PeerID:  id.String(),
 				PrivKey: base64.StdEncoding.EncodeToString(kbytes),
 			}
 		} else {

--- a/core/node/builder.go
+++ b/core/node/builder.go
@@ -141,7 +141,7 @@ func defaultRepo(dstore repo.Datastore) (repo.Repo, error) {
 
 	c.Bootstrap = cfg.DefaultBootstrapAddresses
 	c.Addresses.Swarm = []string{"/ip4/0.0.0.0/tcp/4001", "/ip4/0.0.0.0/udp/4001/quic-v1"}
-	c.Identity.PeerID = pid.Pretty()
+	c.Identity.PeerID = pid.String()
 	c.Identity.PrivKey = base64.StdEncoding.EncodeToString(privkeyb)
 
 	return &repo.Mock{

--- a/core/node/libp2p/hostopt.go
+++ b/core/node/libp2p/hostopt.go
@@ -17,7 +17,7 @@ var DefaultHostOption HostOption = constructPeerHost
 func constructPeerHost(id peer.ID, ps peerstore.Peerstore, options ...libp2p.Option) (host.Host, error) {
 	pkey := ps.PrivKey(id)
 	if pkey == nil {
-		return nil, fmt.Errorf("missing private key for node ID: %s", id.Pretty())
+		return nil, fmt.Errorf("missing private key for node ID: %s", id)
 	}
 	options = append([]libp2p.Option{libp2p.Identity(pkey), libp2p.Peerstore(ps)}, options...)
 	return libp2p.New(options...)

--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -360,7 +360,7 @@ func LimitConfigsToInfo(stats LimitsConfigAndUsage) ResourceInfos {
 
 	for i, p := range stats.Peers {
 		result = append(result, resourceLimitsAndUsageToResourceInfo(
-			config.ResourceMgrPeerScopePrefix+i.Pretty(),
+			config.ResourceMgrPeerScopePrefix+i.String(),
 			p,
 		)...)
 	}

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -151,7 +151,7 @@ func TestIpnsLocalLink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if linksto != nd.Identity.Pretty() {
+	if linksto != nd.Identity.String() {
 		t.Fatal("Link invalid")
 	}
 }
@@ -176,7 +176,7 @@ func TestIpnsBasicIO(t *testing.T) {
 		t.Fatal("Incorrect Read!")
 	}
 
-	fname2 := mnt.Dir + "/" + nd.Identity.Pretty() + "/testfile"
+	fname2 := mnt.Dir + "/" + nd.Identity.String() + "/testfile"
 	rbuf, err = os.ReadFile(fname2)
 	if err != nil {
 		t.Fatal(err)

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -220,7 +220,7 @@ func (r *Root) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 	listing := make([]fuse.Dirent, 0, len(r.Keys)*2)
 	for alias, k := range r.Keys {
 		ent := fuse.Dirent{
-			Name: k.ID().Pretty(),
+			Name: k.ID().String(),
 			Type: fuse.DT_Dir,
 		}
 		link := fuse.Dirent{

--- a/p2p/local.go
+++ b/p2p/local.go
@@ -76,7 +76,7 @@ func (l *localListener) setupStream(local manet.Conn) {
 	remote, err := l.dial(l.ctx)
 	if err != nil {
 		local.Close()
-		log.Warnf("failed to dial to remote %s/%s", l.peer.Pretty(), l.proto)
+		log.Warnf("failed to dial to remote %s/%s", l.peer, l.proto)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (l *localListener) ListenAddress() ma.Multiaddr {
 }
 
 func (l *localListener) TargetAddress() ma.Multiaddr {
-	addr, err := ma.NewMultiaddr(maPrefix + l.peer.Pretty())
+	addr, err := ma.NewMultiaddr(maPrefix + l.peer.String())
 	if err != nil {
 		panic(err)
 	}

--- a/p2p/remote.go
+++ b/p2p/remote.go
@@ -55,13 +55,13 @@ func (l *remoteListener) handleStream(remote net.Stream) {
 	peer := remote.Conn().RemotePeer()
 
 	if l.reportRemote {
-		if _, err := fmt.Fprintf(local, "%s\n", peer.Pretty()); err != nil {
+		if _, err := fmt.Fprintf(local, "%s\n", peer); err != nil {
 			_ = remote.Reset()
 			return
 		}
 	}
 
-	peerMa, err := ma.NewMultiaddr(maPrefix + peer.Pretty())
+	peerMa, err := ma.NewMultiaddr(maPrefix + peer.String())
 	if err != nil {
 		_ = remote.Reset()
 		return
@@ -88,7 +88,7 @@ func (l *remoteListener) Protocol() protocol.ID {
 }
 
 func (l *remoteListener) ListenAddress() ma.Multiaddr {
-	addr, err := ma.NewMultiaddr(maPrefix + l.p2p.identity.Pretty())
+	addr, err := ma.NewMultiaddr(maPrefix + l.p2p.identity.String())
 	if err != nil {
 		panic(err)
 	}

--- a/plugin/plugins/peerlog/peerlog.go
+++ b/plugin/plugins/peerlog/peerlog.go
@@ -148,7 +148,7 @@ func (pl *peerLogPlugin) collectEvents(node *core.IpfsNode) {
 		case e = <-pl.events:
 		}
 
-		peerID := zap.String("peer", e.peer.Pretty())
+		peerID := zap.String("peer", e.peer.String())
 
 		switch e.kind {
 		case eventConnect:


### PR DESCRIPTION
The `go-libp2p` peerID Pretty method is already deprecated, switch it to call String method.

Signed-off-by: Icarus9913 [icaruswu66@qq.com](mailto:icaruswu66@qq.com)