### PR TITLE
docs(changelog): link to relevant IPIP-428

### DIFF
--- a/docs/changelogs/v0.22.md
+++ b/docs/changelogs/v0.22.md
@@ -46,7 +46,8 @@ by passing `--v1compat=false`. By default, we still create V1+V2 records, such
 that there is the highest chance of backwards compatibility. The goal is to move
 to V2 only in the future.
 
-**TODO**: add links to IPIP https://github.com/ipfs/specs/issues/376
+For more details, see [IPIP-428](https://specs.ipfs.tech/ipips/ipip-0428/)
+and the updated [IPNS Record Verification](https://specs.ipfs.tech/ipns/ipns-record/#record-verification) logic.
 
 #### IPNS name resolution has been fixed
 


### PR DESCRIPTION
The IPIP got merged, this updates changelog for 0.22 with link to latest validation spec.