### PR TITLE
fix(migrations): use dweb.link instead of ipfs.io

### DIFF
--- a/repo/fsrepo/migrations/httpfetcher.go
+++ b/repo/fsrepo/migrations/httpfetcher.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	defaultGatewayURL = "https://ipfs.io"
+	// default is different name than ipfs.io which is being blocked by some ISPs
+	defaultGatewayURL = "https://dweb.link"
 	// Default maximum download size.
 	defaultFetchLimit = 1024 * 1024 * 512
 )

--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -153,7 +153,7 @@ func ReadMigrationConfig(repoRoot string, userConfigFile string) (*config.Migrat
 // GetMigrationFetcher creates one or more fetchers according to
 // downloadSources,.
 func GetMigrationFetcher(downloadSources []string, distPath string, newIpfsFetcher func(string) Fetcher) (Fetcher, error) {
-	const httpUserAgent = "go-ipfs"
+	const httpUserAgent = "kubo/migration"
 	const numTriesPerHTTP = 3
 
 	var fetchers []Fetcher


### PR DESCRIPTION
This is a quick fix which replaces `ipfs.io` with `dweb.link` to allow users who's ISP is blocking ipfs.io gateway ([like COX.NET here](https://github.com/ipfs/ipfs-desktop/issues/2572#issuecomment-1725932197)) to still benefit from HTTPS mirror.

I've confirmed this works (v0.18.0→v0.22.0), because golang's http client follows redirect to subdomain gateway:

```console
Run migrations now? [y/N] y
[...]
Downloading migration: fs-repo-13-to-14...
Fetching with HTTP: "https://dweb.link/ipfs/QmYerugGRCZWA8yQMKDsd9daEVXUR3C5nuw3VXuX1mggHa/fs-repo-13-to-14/versions"
Fetching with HTTP: "https://dweb.link/ipfs/QmYerugGRCZWA8yQMKDsd9daEVXUR3C5nuw3VXuX1mggHa/fs-repo-13-to-14/v1.0.0/fs-repo-13-to-14_v1.0.0_linux-amd64.tar.gz"
Downloaded and unpacked migration: /tmp/migrations2100767190/fs-repo-13-to-14 (v1.0.0)
```


(Long term we want to have multiple names once https://github.com/ipfs/kubo/issues/9159 is implemented, but for now this is an easy 1-line fix)


cc https://github.com/protocol/bifrost-infra/issues/2765 (internal ipfs.io notes)