### PR TITLE
fix: error when v -0 is present and custom -b is passed && upgrade CID to V1 when custom -b is present and -v is not specified

### DIFF
--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -87,7 +87,7 @@ The optional format string is a printf style format string:
 			if opts.newCodec != 0 && opts.newCodec != cid.DagProtobuf {
 				return fmt.Errorf("cannot convert to CIDv0 with any codec other than dag-pb")
 			}
-			if baseStr != "base58btc" {
+			if baseStr != "" && baseStr != "base58btc" {
 				return fmt.Errorf("cannot convert to CIDv0 with any multibase other than the implicit base58btc")
 			}
 			opts.verConv = toCidV0

--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -80,10 +80,15 @@ The optional format string is a printf style format string:
 
 		switch verStr {
 		case "":
-			// noop
+			if baseStr != "" {
+				opts.verConv = toCidV1
+			}
 		case "0":
 			if opts.newCodec != 0 && opts.newCodec != cid.DagProtobuf {
 				return fmt.Errorf("cannot convert to CIDv0 with any codec other than dag-pb")
+			}
+			if baseStr != "base58btc" {
+				return fmt.Errorf("cannot convert to CIDv0 with any multibase other than the implicit base58btc")
 			}
 			opts.verConv = toCidV0
 		case "1":

--- a/core/commands/cid_test.go
+++ b/core/commands/cid_test.go
@@ -4,30 +4,8 @@ import (
 	"testing"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
+	"github.com/multiformats/go-multibase"
 )
-
-var allMultibases = []string{
-	"identity",
-	"base2",
-	"base32upper",
-	"base32pad",
-	"base32padupper",
-	"base16",
-	"base16upper",
-	"base36",
-	"base36upper",
-	"base64",
-	"base64pad",
-	"base32hexpad",
-	"base32hexpadupper",
-	"base64url",
-	"base64urlpad",
-	"base32hex",
-	"base32hexupper",
-	"base58btc",
-	"base58flickr",
-	"base256emoji",
-}
 
 func TestCidFmtCmd(t *testing.T) {
 	t.Parallel()
@@ -43,7 +21,7 @@ func TestCidFmtCmd(t *testing.T) {
 
 		var testV0PresentAndCustomBaseCases []testV0PresentAndCustomBaseCase
 
-		for _, e := range allMultibases {
+		for _, e := range multibase.EncodingToStr {
 			var testCase testV0PresentAndCustomBaseCase
 
 			if e == "base58btc" {

--- a/core/commands/cid_test.go
+++ b/core/commands/cid_test.go
@@ -1,0 +1,133 @@
+package commands
+
+import (
+	"testing"
+
+	cmds "github.com/ipfs/go-ipfs-cmds"
+)
+
+var allMultibases = []string{
+	"identity",
+	"base2",
+	"base32upper",
+	"base32pad",
+	"base32padupper",
+	"base16",
+	"base16upper",
+	"base36",
+	"base36upper",
+	"base64",
+	"base64pad",
+	"base32hexpad",
+	"base32hexpadupper",
+	"base64url",
+	"base64urlpad",
+	"base32hex",
+	"base32hexupper",
+	"base58btc",
+	"base58flickr",
+	"base256emoji",
+}
+
+func TestCidFmtCmd(t *testing.T) {
+	t.Parallel()
+
+	// Test 'error when -v 0 is present and a custom -b is passed'
+	t.Run("ipfs cid format <cid> -b z -v 0", func(t *testing.T) {
+		t.Parallel()
+
+		type testV0PresentAndCustomBaseCase struct {
+			MultibaseName  string
+			ExpectedErrMsg string
+		}
+
+		var testV0PresentAndCustomBaseCases []testV0PresentAndCustomBaseCase
+
+		for _, e := range allMultibases {
+			var testCase testV0PresentAndCustomBaseCase
+
+			if e == "base58btc" {
+				testCase.MultibaseName = e
+				testCase.ExpectedErrMsg = ""
+				testV0PresentAndCustomBaseCases = append(testV0PresentAndCustomBaseCases, testCase)
+				continue
+			}
+			testCase.MultibaseName = e
+			testCase.ExpectedErrMsg = "cannot convert to CIDv0 with any multibase other than the implicit base58btc"
+			testV0PresentAndCustomBaseCases = append(testV0PresentAndCustomBaseCases, testCase)
+		}
+
+		for _, e := range testV0PresentAndCustomBaseCases {
+
+			// Mock request
+			req := &cmds.Request{
+				Options: map[string]interface{}{
+					cidVerisonOptionName:   "0",
+					cidMultibaseOptionName: e.MultibaseName,
+					cidFormatOptionName:    "%s",
+				},
+			}
+
+			// Response emitter
+			resp := cmds.ResponseEmitter(nil)
+
+			// Call the CidFmtCmd function with the mock request and response
+			err := cidFmtCmd.Run(req, resp, nil)
+			if err == nil && e.MultibaseName == "base58btc" {
+				continue
+			}
+
+			errMsg := err.Error()
+			if errMsg != e.ExpectedErrMsg {
+				t.Errorf("Expected %s, got %s instead", e.ExpectedErrMsg, errMsg)
+			}
+		}
+	})
+
+	// Test 'upgrade CID to v1 when passing a custom -b and no -v is specified'
+	t.Run("ipfs cid format <cid-version-0> -b z", func(t *testing.T) {
+		t.Parallel()
+
+		type testImplicitVersionAndCustomMultibaseCase struct {
+			Ver           string
+			CidV1         string
+			CidV0         string
+			MultibaseName string
+		}
+
+		var testCases = []testImplicitVersionAndCustomMultibaseCase{
+			{
+				Ver:           "",
+				CidV1:         "zdj7WWwMSWGoyxYkkT7mHgYvr6tV8CYd77aYxxqSbg9HsiMcE",
+				CidV0:         "QmPr755CxWUwt39C2Yiw4UGKrv16uZhSgeZJmoHUUS9TSJ",
+				MultibaseName: "z",
+			},
+			{
+				Ver:           "",
+				CidV1:         "CAFYBEIDI7ZABPGG3S63QW3AJG2XAZNE4NJQPN777WLWYRAIDG3TE5QFN3A======",
+				CidV0:         "QmVQVyEijmLb2cBQrowNQsaPbnUnJhfDK1sYe3wepm6ySf",
+				MultibaseName: "base32padupper",
+			},
+		}
+		for _, e := range testCases {
+			// Mock request
+			req := &cmds.Request{
+				Options: map[string]interface{}{
+					cidVerisonOptionName:   e.Ver,
+					cidMultibaseOptionName: e.MultibaseName,
+					cidFormatOptionName:    "%s",
+				},
+			}
+
+			// Response emitter
+			resp := cmds.ResponseEmitter(nil)
+
+			// Call the CidFmtCmd function with the mock request and response
+			err := cidFmtCmd.Run(req, resp, nil)
+
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This fixes #9556 
I'm some sort of beginner when it comes to contributing to open source. I think the tests could be better (I just don't know how), especially the second test since I couldn't read the response body to compare with the expected CID. So in the second test case the only test is really just asserting no error is returned.

I see in the pull request a message telling me to update "docs/changelogs", since I don't know what to update on it I won't touch it.