### PR TITLE
docs(readme): header improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Kubo was the first IPFS implementation and is the most widely used one today. Im
 
 Featureset
 - Runs an IPFS-Node as a network service that is part of LAN and WAN DHT
-- [HTTP Gateway](https://specs.ipfs.tech/http-gateways/) functionality for content retrieval
+- [HTTP Gateway](https://specs.ipfs.tech/http-gateways/) (`/ipfs` and `/ipns`) functionality for trusted and [trustless](https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval) content retrieval
+- [HTTP Routing V1](https://specs.ipfs.tech/routing/http-routing-v1/) (`/routing/v1`) client and server implementation for [delegated routing](./docs/delegated-routing.md) lookups
 - [HTTP Kubo RPC API](https://docs.ipfs.tech/reference/kubo/rpc/) (`/api/v0`) to access and control the daemon
 - [Command Line Interface](https://docs.ipfs.tech/reference/kubo/cli/) based on (`/api/v0`) RPC API
 - [WebUI](https://github.com/ipfs/ipfs-webui/#readme) to manage the Kubo node

--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
 <h1 align="center">
-<img src="https://ipfs.io/ipfs/QmTtCH31LdGV4LjRm5FNmnw6hUwZq1Z1YXtjeNKHBeaRcQ/kubo-logo.png" alt="Kubo logo" title="Kubo logo" width="200">
-<br>
-Kubo: IPFS Implementation in GO
+  <br>
+  <a href="https://docs.ipfs.tech/how-to/command-line-quick-start/"><img src="https://user-images.githubusercontent.com/157609/250148884-d6d12db8-fdcf-4be3-8546-2550b69845d8.png" alt="Kubo logo" title="Kubo logo" width="200"></a>
+  <br>
+  Kubo: IPFS Implementation in GO
+  <br>
 </h1>
+
 <p align="center" style="font-size: 1.2rem;">The first implementation of IPFS.</p>
 
-<hr />
+<p align="center">
+  <a href="https://ipfs.tech"><img src="https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square" alt="Official Part of IPFS Project"></a>
+  <a href="https://discuss.ipfs.tech"><img alt="Discourse Forum" src="https://img.shields.io/discourse/posts?server=https%3A%2F%2Fdiscuss.ipfs.tech"></a>
+  <a href="https://matrix.to/#/#ipfs-space:ipfs.io"><img alt="Matrix" src="https://img.shields.io/matrix/ipfs-space%3Aipfs.io?server_fqdn=matrix.org"></a>
+  <a href="https://github.com/ipfs/kubo/actions"><img src="https://img.shields.io/github/actions/workflow/status/ipfs/kubo/build.yml?branch=master" alt="ci"></a>
+  <a href="https://github.com/ipfs/kubo/releases"><img alt="GitHub release" src="https://img.shields.io/github/v/release/ipfs/kubo?filter=!*rc*"></a>
+  <a href="https://godoc.org/github.com/ipfs/kubo"><img src="https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square" alt="godoc reference"></a>  
+</p>
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square&cacheSeconds=3600)](https://protocol.ai)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square&cacheSeconds=3600)](https://godoc.org/github.com/ipfs/kubo)
+<hr />
 
 ## What is Kubo?
 
 Kubo was the first IPFS implementation and is the most widely used one today. Implementing the *Interplanetary Filesystem* - the Web3 standard for content-addressing, interoperable with HTTP. Thus powered by IPLD's data models and the libp2p for network communication. Kubo is written in Go.
 
 Featureset
-- Runs an IPFS-Node as a network service
-- [Command Line Interface](https://docs.ipfs.tech/reference/kubo/cli/) to IPFS-Nodes
-- Local [Web2-to-Web3 HTTP Gateway functionality](https://github.com/ipfs/specs/tree/main/http-gateways#readme)
-- HTTP RPC API (`/api/v0`) to access and control the daemon
-- IPFS's internal Webgui can be used to manage the Kubo nodes
+- Runs an IPFS-Node as a network service that is part of LAN and WAN DHT
+- [HTTP Gateway](https://specs.ipfs.tech/http-gateways/) functionality for content retrieval
+- [HTTP Kubo RPC API](https://docs.ipfs.tech/reference/kubo/rpc/) (`/api/v0`) to access and control the daemon
+- [Command Line Interface](https://docs.ipfs.tech/reference/kubo/cli/) based on (`/api/v0`) RPC API
+- [WebUI](https://github.com/ipfs/ipfs-webui/#readme) to manage the Kubo node
 
 ### Other implementations
 


### PR DESCRIPTION
This cosmetic PR applies some improvements from https://github.com/ipfs/npm-kubo, links to community chat and forum, and improves "featureset" section.

Creates better first impression:

> ![Screenshot 2023-09-22 at 19-36-14 kubo_README md at 1f827543da8cba99fcda173d6edc13022de89c56 · ipfs_kubo](https://github.com/ipfs/kubo/assets/157609/6a31c3a3-3c39-42b5-86a5-3197280cc6bb)
