### PR TITLE
Align systemd unit file with the default IPFS installation path

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -17,7 +17,7 @@ Description=IPFS daemon
 
 [Service]
 # Environment="IPFS_PATH=/data/ipfs"  # optional path to ipfs init directory if not default ($HOME/.ipfs)
-ExecStart=/usr/bin/ipfs daemon
+ExecStart=/usr/local/bin/ipfs daemon
 Restart=on-failure
 
 [Install]

--- a/misc/systemd/ipfs-hardened.service
+++ b/misc/systemd/ipfs-hardened.service
@@ -8,7 +8,7 @@
 # To overwrite a variable, like ExecStart you have to specify it once
 # blank and a second time with a new value, like:
 # ExecStart=
-# ExecStart=/usr/bin/ipfs daemon --flag1 --flag2
+# ExecStart=/usr/local/bin/ipfs daemon --flag1 --flag2
 #
 # For more info about custom unit files see systemd.unit(5).
 
@@ -70,7 +70,7 @@ User=ipfs
 Group=ipfs
 StateDirectory=ipfs
 Environment=IPFS_PATH="${HOME}"
-ExecStart=/usr/bin/ipfs daemon --init --migrate
+ExecStart=/usr/local/bin/ipfs daemon --init --migrate
 Restart=on-failure
 KillSignal=SIGINT
 

--- a/misc/systemd/ipfs.service
+++ b/misc/systemd/ipfs.service
@@ -8,7 +8,7 @@
 # To overwrite a variable, like ExecStart you have to specify it once
 # blank and a second time with a new value, like:
 # ExecStart=
-# ExecStart=/usr/bin/ipfs daemon --flag1 --flag2
+# ExecStart=/usr/local/bin/ipfs daemon --flag1 --flag2
 #
 # For more info about custom unit files see systemd.unit(5).
 
@@ -41,7 +41,7 @@ User=ipfs
 Group=ipfs
 StateDirectory=ipfs
 Environment=IPFS_PATH="${HOME}"
-ExecStart=/usr/bin/ipfs daemon --init --migrate
+ExecStart=/usr/local/bin/ipfs daemon --init --migrate
 Restart=on-failure
 KillSignal=SIGINT
 


### PR DESCRIPTION
The current documentation (cmd/ipfs/dist/README.md), installation scripts, and Docker files all indicate that the default installation path for the IPFS binary is **/usr/local/bin/ipfs**. Moreover, following the official installation guide [here](https://docs.ipfs.tech/install/command-line/#install-official-binary-distributions) also places the binary in **/usr/local/bin/.**

However, the systemd service files reference a different path **(/usr/bin/ipfs**), which can lead to inconsistencies and potential operational issues.

This PR adjusts the systemd unit files to align with the predominant and documented installation path, ensuring consistency and reliability for users following the official guidelines.