### PR TITLE
commands/add: return an error when using --only-hash and --to-files

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -194,7 +194,7 @@ See 'dag export' and 'dag import' for more information.
 		progress, _ := req.Options[progressOptionName].(bool)
 		trickle, _ := req.Options[trickleOptionName].(bool)
 		wrap, _ := req.Options[wrapOptionName].(bool)
-		hash, _ := req.Options[onlyHashOptionName].(bool)
+		onlyHash, _ := req.Options[onlyHashOptionName].(bool)
 		silent, _ := req.Options[silentOptionName].(bool)
 		chunker, _ := req.Options[chunkerOptionName].(string)
 		dopin, _ := req.Options[pinOptionName].(bool)
@@ -206,6 +206,10 @@ See 'dag export' and 'dag import' for more information.
 		inline, _ := req.Options[inlineOptionName].(bool)
 		inlineLimit, _ := req.Options[inlineLimitOptionName].(int)
 		toFilesStr, toFilesSet := req.Options[toFilesOptionName].(string)
+
+		if onlyHash && toFilesSet {
+			return fmt.Errorf("%s and %s options are not compatible", onlyHashOptionName, toFilesOptionName)
+		}
 
 		hashFunCode, ok := mh.Names[strings.ToLower(hashFunStr)]
 		if !ok {
@@ -233,7 +237,7 @@ See 'dag export' and 'dag import' for more information.
 			options.Unixfs.Chunker(chunker),
 
 			options.Unixfs.Pin(dopin),
-			options.Unixfs.HashOnly(hash),
+			options.Unixfs.HashOnly(onlyHash),
 			options.Unixfs.FsCache(fscache),
 			options.Unixfs.Nocopy(nocopy),
 


### PR DESCRIPTION
In that situation, the data is not written to permanent storage, so a reference in MFS would be to p2p blocks at best.

The /add command in that situation is also likely to hang as it reads immediately the root node without being able to get it (it falls back to bitswap).

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
