### PR TITLE
coreapi/unixfs: don't create an additional IpfsNode for --only-hash

### DIFF
--- a/core/node/builder.go
+++ b/core/node/builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 
 	"go.uber.org/fx"
 
@@ -34,9 +33,6 @@ type BuildCfg struct {
 	// DO NOT SET THIS UNLESS YOU'RE TESTING.
 	DisableEncryptedConnections bool
 
-	// If NilRepo is set, a Repo backed by a nil datastore will be constructed
-	NilRepo bool
-
 	Routing libp2p.RoutingOption
 	Host    libp2p.HostOption
 	Repo    repo.Repo
@@ -51,18 +47,8 @@ func (cfg *BuildCfg) getOpt(key string) bool {
 }
 
 func (cfg *BuildCfg) fillDefaults() error {
-	if cfg.Repo != nil && cfg.NilRepo {
-		return errors.New("cannot set a Repo and specify nilrepo at the same time")
-	}
-
 	if cfg.Repo == nil {
-		var d ds.Datastore
-		if cfg.NilRepo {
-			d = ds.NewNullDatastore()
-		} else {
-			d = ds.NewMapDatastore()
-		}
-		r, err := defaultRepo(dsync.MutexWrap(d))
+		r, err := defaultRepo(dsync.MutexWrap(ds.NewMapDatastore()))
 		if err != nil {
 			return err
 		}

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -178,7 +178,7 @@ func Storage(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 	return fx.Options(
 		fx.Provide(RepoConfig),
 		fx.Provide(Datastore),
-		fx.Provide(BaseBlockstoreCtor(cacheOpts, bcfg.NilRepo, cfg.Datastore.HashOnRead)),
+		fx.Provide(BaseBlockstoreCtor(cacheOpts, cfg.Datastore.HashOnRead)),
 		finalBstore,
 	)
 }

--- a/core/node/storage.go
+++ b/core/node/storage.go
@@ -27,17 +27,14 @@ func Datastore(repo repo.Repo) datastore.Datastore {
 type BaseBlocks blockstore.Blockstore
 
 // BaseBlockstoreCtor creates cached blockstore backed by the provided datastore
-func BaseBlockstoreCtor(cacheOpts blockstore.CacheOpts, nilRepo bool, hashOnRead bool) func(mctx helpers.MetricsCtx, repo repo.Repo, lc fx.Lifecycle) (bs BaseBlocks, err error) {
+func BaseBlockstoreCtor(cacheOpts blockstore.CacheOpts, hashOnRead bool) func(mctx helpers.MetricsCtx, repo repo.Repo, lc fx.Lifecycle) (bs BaseBlocks, err error) {
 	return func(mctx helpers.MetricsCtx, repo repo.Repo, lc fx.Lifecycle) (bs BaseBlocks, err error) {
 		// hash security
 		bs = blockstore.NewBlockstore(repo.Datastore())
 		bs = &verifbs.VerifBS{Blockstore: bs}
-
-		if !nilRepo {
-			bs, err = blockstore.CachedBlockstore(helpers.LifecycleCtx(mctx, lc), bs, cacheOpts)
-			if err != nil {
-				return nil, err
-			}
+		bs, err = blockstore.CachedBlockstore(helpers.LifecycleCtx(mctx, lc), bs, cacheOpts)
+		if err != nil {
+			return nil, err
 		}
 
 		bs = blockstore.NewIdStore(bs)


### PR DESCRIPTION
It looks to me that we don't need to create a full `IpfsNode` for `--only-hash`, we only need a null blockstore to simulate adding the data.

This also remove entirely the `NilRepo` option when creating `IpfsNode`, as it looked like a no longer necessary workaround to me.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
