### PR TITLE
adding --auto-migrate flag to daemon.go

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -282,7 +282,11 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		fmt.Println("Found outdated fs-repo, migrations need to be run.")
 
 		if !found {
-			domigrate = YesNoPrompt("Run migrations now? [y/N]")
+			if os.Args[1] == "daemon" && os.Args[2] == "--auto-migrate" {
+				domigrate = true
+			} else {
+				domigrate = YesNoPrompt("Run migrations now? [y/N]")
+			}
 		}
 
 		if !domigrate {


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
adding an --auto-migrate flag so migration prompts will not block execution of the binary in auto deployment scenarios
