### PR TITLE
docs/config: remove extra commas in PublicGateways example entries

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -761,7 +761,7 @@ between content roots.
             "PublicGateways": {
                 "dweb.link": {
                     "UseSubdomains": true,
-                    "Paths": ["/ipfs", "/ipns"],
+                    "Paths": ["/ipfs", "/ipns"]
                 }
             }
         }
@@ -776,7 +776,7 @@ between content roots.
         "PublicGateways": {
             "ipfs.io": {
                 "UseSubdomains": false,
-                "Paths": ["/ipfs", "/ipns", "/api"],
+                "Paths": ["/ipfs", "/ipns", "/api"]
             }
         }
     }


### PR DESCRIPTION
In the examples for the "PublicGateways" config setting, remove extra commas in the JSON so it will not throw syntax errors