### PR TITLE
docs: fix accelerated-dht-client

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -663,3 +663,7 @@ ipfs config --json Experimental.GatewayOverLibp2p true
 - [ ] Needs UX work for exposing non-recursive "HTTP transport" (NoFetch) over both libp2p and plain TCP (and sharing the configuration)
 - [ ] Needs a mechanism for HTTP handler to signal supported features ([IPIP-425](https://github.com/ipfs/specs/pull/425))
 - [ ] Needs an option for Kubo to detect peers that have it enabled and prefer HTTP transport before falling back to bitswap (and use CAR if peer supports dag-scope=entity from [IPIP-402](https://github.com/ipfs/specs/pull/402))
+
+## Accelerated DHT Client
+
+This feature now lives at [`Routing.AcceleratedDHTClient`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingaccelerateddhtclient).


### PR DESCRIPTION
This ensures https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#accelerated-dht-client still works and points people at new config option.