### PR TITLE
Fix/routing put cmd

### DIFF
--- a/core/commands/routing.go
+++ b/core/commands/routing.go
@@ -11,6 +11,7 @@ import (
 
 	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
 
+	iface "github.com/ipfs/boxo/coreiface"
 	"github.com/ipfs/boxo/coreiface/options"
 	dag "github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/ipfs/boxo/ipns"
@@ -458,6 +459,9 @@ identified by QmFoo.
 
 		err = api.Routing().Put(req.Context, req.Arguments[0], data, opts...)
 		if err != nil {
+			if err == iface.ErrOffline {
+				err = errAllowOffline
+			}
 			return err
 		}
 

--- a/core/commands/routing.go
+++ b/core/commands/routing.go
@@ -11,9 +11,9 @@ import (
 
 	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
 
-	iface "github.com/ipfs/boxo/coreiface"
 	"github.com/ipfs/boxo/coreiface/options"
 	dag "github.com/ipfs/boxo/ipld/merkledag"
+	"github.com/ipfs/boxo/ipns"
 	cid "github.com/ipfs/go-cid"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -451,22 +451,19 @@ identified by QmFoo.
 			options.Put.AllowOffline(allowOffline),
 		}
 
+		ipnsName, err := ipns.NameFromString(req.Arguments[0])
+		if err != nil {
+			return err
+		}
+
 		err = api.Routing().Put(req.Context, req.Arguments[0], data, opts...)
 		if err != nil {
 			return err
 		}
 
-		id, err := api.Key().Self(req.Context)
-		if err != nil {
-			if err == iface.ErrOffline {
-				err = errAllowOffline
-			}
-			return err
-		}
-
 		return res.Emit(routing.QueryEvent{
 			Type: routing.Value,
-			ID:   id.ID(),
+			ID:   ipnsName.Peer(),
 		})
 	},
 	Encoders: cmds.EncoderMap{

--- a/test/cli/dht_legacy_test.go
+++ b/test/cli/dht_legacy_test.go
@@ -131,7 +131,7 @@ func TestLegacyDHT(t *testing.T) {
 			node.WriteBytes("foo", []byte("foo"))
 			res := node.RunIPFS("dht", "put", "/ipns/"+node.PeerID().String(), "foo")
 			assert.Equal(t, 1, res.ExitCode())
-			assert.Contains(t, res.Stderr.String(), "this action must be run in online mode")
+			assert.Contains(t, res.Stderr.String(), "can't put while offline: pass `--allow-offline` to override")
 		})
 	})
 }

--- a/test/cli/routing_dht_test.go
+++ b/test/cli/routing_dht_test.go
@@ -111,7 +111,7 @@ func testRoutingDHT(t *testing.T, enablePubsub bool) {
 				node.WriteBytes("foo", []byte("foo"))
 				res := node.RunIPFS("routing", "put", "/ipns/"+node.PeerID().String(), "foo")
 				assert.Equal(t, 1, res.ExitCode())
-				assert.Contains(t, res.Stderr.String(), "this action must be run in online mode")
+				assert.Contains(t, res.Stderr.String(), "can't put while offline: pass `--allow-offline` to override")
 			})
 		})
 	})


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Fixed two oddities in the `routing put` command (noticed while setting up gateway conformance tests):
1. It always returned the host's peerID instead of the one for the record being put
2. There was some logic around hinting at offline mode but it wasn't used for `Routing().Put`

There's an implicitly breaking change here where `/pk` records used to work but won't anymore due to the check on a valid IPNS name, although `/pk` records are not mentioned in the help text at all. This is easily fixable, but before fixing seems like we should agree on if we should (and if so add a test)