### PR TITLE
fix: routing findprovs hangs with no records

### DIFF
--- a/core/commands/routing.go
+++ b/core/commands/routing.go
@@ -80,10 +80,9 @@ var findProvidersRoutingCmd = &cmds.Command{
 		ctx, cancel := context.WithCancel(req.Context)
 		ctx, events := routing.RegisterForQueryEvents(ctx)
 
-		pchan := n.Routing.FindProvidersAsync(ctx, c, numProviders)
-
 		go func() {
 			defer cancel()
+			pchan := n.Routing.FindProvidersAsync(ctx, c, numProviders)
 			for p := range pchan {
 				np := p
 				routing.PublishQueryEvent(ctx, &routing.QueryEvent{


### PR DESCRIPTION
The IPNS name resolution fix in kubo v0.22.0 (coming from go-libp2p-routing-helpers) resulted in changing the semantics of `Routing.FindProvidersAsync` such that it no longer returns a channel before the first result comes back. This is not great, functions that return with channels should generally do so quickly. Here it is particularly bad because the event channel used in DHT queries ends up getting clogged which effectively leads to a deadlock until the context is cancelled.

While this should be fixed in go-libp2p-routing-helpers, this should help for now and seems safe.