### PR TITLE
fix: regression in 'ipfs dns'

### DIFF
--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	namesys "github.com/ipfs/boxo/namesys"
 	"github.com/ipfs/boxo/path"
@@ -19,7 +20,7 @@ const (
 var DNSCmd = &cmds.Command{
 	Status: cmds.Deprecated, // https://github.com/ipfs/kubo/issues/8607
 	Helptext: cmds.HelpText{
-		Tagline: "Resolve DNSLink records.",
+		Tagline: "Resolve DNSLink records. Deprecated: Use 'ipfs resolve /ipns/domain-name' instead.",
 		ShortDescription: `
 This command can only recursively resolve DNSLink TXT records.
 It will fail to recursively resolve through IPNS keys etc.
@@ -50,6 +51,10 @@ It will work across multiple DNSLinks and IPNS keys.
 		var routing []namesys.ResolveOption
 		if !recursive {
 			routing = append(routing, namesys.ResolveWithDepth(1))
+		}
+
+		if !strings.HasPrefix(name, "/ipns/") {
+			name = "/ipns/" + name
 		}
 
 		p, err := path.NewPath(name)


### PR DESCRIPTION
Seems we've introduced regression to the deprecated  `dns` command, it now requires `/ipns/` path, which breaks every software which used it for DNSLink lookups.

It was already deprecated, so no need for patch release, but let's fix it and improve helptext that is displayed at https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-dns  when the next release ships.

## before 

```consome
$ ipfs dns dist.ipfs.tech
Error: invalid path "dist.ipfs.tech": path does not have enough components
```

## expected behavior (this fix)

```consome
$ ipfs dns dist.ipfs.tech
/ipfs/QmXZX3Jiw2p1DKyShCKCbfNBCEL7eYW57B1asPr8FKPPmm
```


<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
