### PR TITLE
docs(changelog): clarify webrtc in v0.24

### DIFF
--- a/docs/changelogs/v0.24.md
+++ b/docs/changelogs/v0.24.md
@@ -71,14 +71,20 @@ cached more efficiently and load faster in browser contexts.
 
 #### Experimental Transport: WebRTC Direct
 
-[WebRTC Direct](https://github.com/libp2p/go-libp2p/pull/2337) has now been introduced
-in [`go-libp2p`](https://github.com/libp2p/go-libp2p/releases/tag/v0.32.0) v0.32.0. This
-transport protocol allows browser nodes to connect to other nodes without special configuration,
-such as TLS certificates. This can be useful for browsers that do not yet support
-WebTransport, for example.
+This Kubo release includes the initial work towards WebRTC Direct
+introduced in [`go-libp2p`](https://github.com/libp2p/go-libp2p/releases/tag/v0.32.0) v0.32:
 
-Note that, at the moment, WebRTC Direct cannot be used to connect to a browser node to a
-node that is behind a NAT or firewall. This is being worked on [`go-libp2p#2009`](https://github.com/libp2p/go-libp2p/issues/2009).
+> [WebRTC Direct](https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md)
+> allows browser nodes to connect to go-libp2p nodes directly,
+> without any configuration (e.g. TLS certificates) needed on the go-libp2p
+> side. This is useful for browser nodes that aren’t able to use
+> [WebTransport](https://blog.libp2p.io/2022-12-19-libp2p-webtransport/).
+
+The `/webrtc-direct` transport is disabled by default in Kubo 0.24,
+and not ready for production use yet, but we plan to enable it in a future release.
+
+See [`Swarm.Transports.Network.WebRTCDirect`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmtransportsnetworkwebrtcdirect)
+to learn how to enable it manually, and what current limitations are.
 
 ### 📝 Changelog
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -2076,13 +2076,25 @@ Type: `flag`
 #### `Swarm.Transports.Network.WebRTCDirect`
 
 **Experimental:** the support for WebRTC Direct is currently experimental.
+This feature was introduced in [`go-libp2p@v0.32.0`](https://github.com/libp2p/go-libp2p/releases/tag/v0.32.0).
 
-A new feature of [`go-libp2p`](https://github.com/libp2p/go-libp2p/releases/tag/v0.32.0)
-is the [WebRTC Direct](https://github.com/libp2p/go-libp2p/pull/2337) transport.
+[WebRTC Direct](https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md)
+is a transport protocol that provides another way for browsers to
+connect to the rest of the libp2p network. WebRTC Direct allows for browser
+nodes to connect to other nodes without special configuration, such as TLS
+certificates. This can be useful for browser nodes that do not yet support
+[WebTransport](https://blog.libp2p.io/2022-12-19-libp2p-webtransport/).
 
-WebRTC Direct is a transport protocol that provides another way for browsers to connect to the rest of the libp2p network. WebRTC Direct allows for browser nodes to connect to other nodes without special configuration, such as TLS certificates. This can be useful for browser nodes that do not yet support WebTransport, for example.
+Enabling this transport allows Kubo node to act on `/udp/4001/webrtc-direct`
+listeners defined in `Addresses.Swarm`, `Addresses.Announce` or
+`Addresses.AppendAnnounce`.
 
-Note that, at the moment, WebRTC Direct cannot be used to connect to a browser node to a node that is behind a NAT or firewall. This is being worked on [`go-libp2p#2009`](https://github.com/libp2p/go-libp2p/issues/2009).
+**NOTE:** at the moment, WebRTC Direct cannot be used to connect to a browser
+node to a node that is behind a NAT or firewall.
+This requires using normal
+[WebRTC](https://github.com/libp2p/specs/blob/master/webrtc/webrtc.md),
+which is currently being worked on in
+[go-libp2p#2009](https://github.com/libp2p/go-libp2p/issues/2009).
 
 Default: Disabled
 


### PR DESCRIPTION
I missed the addition of WebRTC Direct and read about it in changelog and took me a moment to understand how to enable it :sweat_smile: 


This PR sets the expectations as "not production ready", but also gives users hint how to enable it via [`Swarm.Transports.Network.WebRTCDirect`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmtransportsnetworkwebrtcdirect) and by adding `/udp/4001/webrtc-direct` listener.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
