### PR TITLE
feat(rpc): Opt-in HTTP RPC API Authorization

### DIFF
--- a/client/rpc/auth/auth.go
+++ b/client/rpc/auth/auth.go
@@ -12,13 +12,13 @@ type AuthorizedRoundTripper struct {
 // NewAuthorizedRoundTripper creates a new [http.RoundTripper] that will set the
 // Authorization HTTP header with the value of [secret]. The given [roundTripper] is
 // the base [http.RoundTripper]. If it is nil, [http.DefaultTransport] is used.
-func NewAuthorizedRoundTripper(secret string, roundTripper http.RoundTripper) http.RoundTripper {
+func NewAuthorizedRoundTripper(authorization string, roundTripper http.RoundTripper) http.RoundTripper {
 	if roundTripper == nil {
 		roundTripper = http.DefaultTransport
 	}
 
 	return &AuthorizedRoundTripper{
-		authorization: secret,
+		authorization: authorization,
 		roundTripper:  roundTripper,
 	}
 }

--- a/client/rpc/auth/auth.go
+++ b/client/rpc/auth/auth.go
@@ -10,7 +10,7 @@ type AuthorizedRoundTripper struct {
 }
 
 // NewAuthorizedRoundTripper creates a new [http.RoundTripper] that will set the
-// Authorization HTTP header with the value of [secret]. The given [roundTripper] is
+// Authorization HTTP header with the value of [authorization]. The given [roundTripper] is
 // the base [http.RoundTripper]. If it is nil, [http.DefaultTransport] is used.
 func NewAuthorizedRoundTripper(authorization string, roundTripper http.RoundTripper) http.RoundTripper {
 	if roundTripper == nil {

--- a/client/rpc/auth/auth.go
+++ b/client/rpc/auth/auth.go
@@ -1,0 +1,29 @@
+package auth
+
+import "net/http"
+
+var _ http.RoundTripper = &AuthorizedRoundTripper{}
+
+type AuthorizedRoundTripper struct {
+	authorization string
+	roundTripper  http.RoundTripper
+}
+
+// NewAuthorizedRoundTripper creates a new [http.RoundTripper] that will set the
+// Authorization HTTP header with the value of [secret]. The given [roundTripper] is
+// the base [http.RoundTripper]. If it is nil, [http.DefaultTransport] is used.
+func NewAuthorizedRoundTripper(secret string, roundTripper http.RoundTripper) http.RoundTripper {
+	if roundTripper == nil {
+		roundTripper = http.DefaultTransport
+	}
+
+	return &AuthorizedRoundTripper{
+		authorization: secret,
+		roundTripper:  roundTripper,
+	}
+}
+
+func (tp *AuthorizedRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", tp.authorization)
+	return tp.roundTripper.RoundTrip(r)
+}

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -676,6 +676,10 @@ func serveHTTPApi(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, error
 		listeners = append(listeners, apiLis)
 	}
 
+	if len(cfg.API.Authorizations) > 0 && len(listeners) > 0 {
+		fmt.Printf("RPC API access is limited by the rules defined in API.Authorizations\n")
+	}
+
 	for _, listener := range listeners {
 		// we might have listened to /tcp/0 - let's see what we are listing on
 		fmt.Printf("RPC API server listening on %s\n", listener.Multiaddr())

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ipfs/kubo/client/rpc/auth"
 	"github.com/ipfs/kubo/cmd/ipfs/util"
 	oldcmds "github.com/ipfs/kubo/commands"
+	config "github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core"
 	corecmds "github.com/ipfs/kubo/core/commands"
 	"github.com/ipfs/kubo/core/corehttp"
@@ -326,9 +327,10 @@ func makeExecutor(req *cmds.Request, env interface{}) (cmds.Executor, error) {
 		return nil, fmt.Errorf("unsupported API address: %s", apiAddr)
 	}
 
-	apiSecret, specified := req.Options[corecmds.ApiSecretOption].(string)
+	apiAuth, specified := req.Options[corecmds.ApiAuthOption].(string)
 	if specified {
-		tpt = auth.NewAuthorizedRoundTripper(apiSecret, tpt)
+		authorization := config.ConvertAuthSecret(apiAuth)
+		tpt = auth.NewAuthorizedRoundTripper(authorization, tpt)
 	}
 
 	httpClient := &http.Client{

--- a/config/api.go
+++ b/config/api.go
@@ -1,15 +1,20 @@
 package config
 
+import (
+	"encoding/base64"
+	"strings"
+)
+
 const (
 	APITag           = "API"
 	AuthorizationTag = "Authorizations"
 )
 
 type RPCAuthScope struct {
-	// HTTPAuthSecret is the secret that will be compared to the HTTP "Authorization".
-	// A secret is in the format "type:value". Check the documentation for
+	// AuthSecret is the secret that will be compared to the HTTP "Authorization".
+	// header. A secret is in the format "type:value". Check the documentation for
 	// supported types.
-	HTTPAuthSecret string
+	AuthSecret string
 
 	// AllowedPaths is an explicit list of RPC path prefixes to allow.
 	// By default, none are allowed. ["/api/v0"] exposes all RPCs.
@@ -24,4 +29,35 @@ type API struct {
 	// If the map is empty, then the RPC API is exposed to everyone. Check the
 	// documentation for more details.
 	Authorizations map[string]*RPCAuthScope `json:",omitempty"`
+}
+
+// ConvertAuthSecret converts the given secret in the format "type:value" into an
+// HTTP Authorization header value. It can handle 'bearer' and 'basic' as type.
+// If type exists and is not known, an empty string is returned. If type does not
+// exist, 'bearer' type is assumed.
+func ConvertAuthSecret(secret string) string {
+	if secret == "" {
+		return secret
+	}
+
+	split := strings.SplitN(secret, ":", 2)
+	if len(split) < 2 {
+		// No prefix: assume bearer token.
+		return "Bearer " + secret
+	}
+
+	if strings.HasPrefix(secret, "basic:") {
+		if strings.Contains(split[1], ":") {
+			// Assume basic:user:password
+			return "Basic " + base64.StdEncoding.EncodeToString([]byte(split[1]))
+		} else {
+			// Assume already base64 encoded.
+			return "Basic " + split[1]
+		}
+	} else if strings.HasPrefix(secret, "bearer:") {
+		return "Bearer " + split[1]
+	}
+
+	// Unknown. Type is present, but we can't handle it.
+	return ""
 }

--- a/config/api.go
+++ b/config/api.go
@@ -1,16 +1,27 @@
 package config
 
 const (
-	ApiTag             = "API"
-	HTTPAuthSecretsTag = "HTTPAuthSecrets"
+	APITag           = "API"
+	AuthorizationTag = "Authorizations"
 )
+
+type RPCAuthScope struct {
+	// HTTPAuthSecret is the secret that will be compared to the HTTP "Authorization".
+	// A secret is in the format "type:value". Check the documentation for
+	// supported types.
+	HTTPAuthSecret string
+
+	// AllowedPaths is an explicit list of RPC path prefixes to allow.
+	// By default, none are allowed. ["/api/v0"] exposes all RPCs.
+	AllowedPaths []string
+}
 
 type API struct {
 	// HTTPHeaders are the HTTP headers to return with the API.
 	HTTPHeaders map[string][]string
 
-	// HTTPAuthSecrets are the secrets used to authenticate in the API.
-	// A secret is in the format "type:value". Check the documentation for
-	// supported types.
-	HTTPAuthSecrets map[string]string `json:",omitempty"`
+	// Authorization is a map of authorizations used to authenticate in the API.
+	// If the map is empty, then the RPC API is exposed to everyone. Check the
+	// documentation for more details.
+	Authorizations map[string]*RPCAuthScope `json:",omitempty"`
 }

--- a/config/api.go
+++ b/config/api.go
@@ -1,5 +1,16 @@
 package config
 
+const (
+	ApiTag             = "API"
+	HTTPAuthSecretsTag = "HTTPAuthSecrets"
+)
+
 type API struct {
-	HTTPHeaders map[string][]string // HTTP headers to return with the API.
+	// HTTPHeaders are the HTTP headers to return with the API.
+	HTTPHeaders map[string][]string
+
+	// HTTPAuthSecrets are the secrets used to authenticate in the API.
+	// A secret is in the format "type:value". Check the documentation for
+	// supported types.
+	HTTPAuthSecrets map[string]string `json:",omitempty"`
 }

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertAuthSecret(t *testing.T) {
+	for _, testCase := range []struct {
+		input  string
+		output string
+	}{
+		{"", ""},
+		{"someToken", "Bearer someToken"},
+		{"bearer:someToken", "Bearer someToken"},
+		{"basic:user:pass", "Basic dXNlcjpwYXNz"},
+		{"basic:dXNlcjpwYXNz", "Basic dXNlcjpwYXNz"},
+	} {
+		assert.Equal(t, testCase.output, ConvertAuthSecret(testCase.input))
+	}
+}

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -208,6 +208,11 @@ NOTE: For security reasons, this command will omit your private key and remote s
 			return err
 		}
 
+		cfg, err = scrubValue(cfg, []string{config.ApiTag, config.HTTPAuthSecretsTag})
+		if err != nil {
+			return err
+		}
+
 		cfg, err = scrubOptionalValue(cfg, config.PinningConcealSelector)
 		if err != nil {
 			return err

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -208,7 +208,7 @@ NOTE: For security reasons, this command will omit your private key and remote s
 			return err
 		}
 
-		cfg, err = scrubValue(cfg, []string{config.ApiTag, config.HTTPAuthSecretsTag})
+		cfg, err = scrubValue(cfg, []string{config.APITag, config.AuthorizationTag})
 		if err != nil {
 			return err
 		}

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -28,7 +28,8 @@ const (
 	DebugOption      = "debug"
 	LocalOption      = "local" // DEPRECATED: use OfflineOption
 	OfflineOption    = "offline"
-	ApiOption        = "api" //nolint
+	ApiOption        = "api"        //nolint
+	ApiSecretOption  = "api-secret" //nolint
 )
 
 var Root = &cmds.Command{
@@ -110,6 +111,7 @@ The CLI will exit with one of the following values:
 		cmds.BoolOption(LocalOption, "L", "Run the command locally, instead of using the daemon. DEPRECATED: use --offline."),
 		cmds.BoolOption(OfflineOption, "Run the command offline."),
 		cmds.StringOption(ApiOption, "Use a specific API instance (defaults to /ip4/127.0.0.1/tcp/5001)"),
+		cmds.StringOption(ApiSecretOption, "An HTTP Authorization header to send with the requests to the API"),
 
 		// global options, added to every command
 		cmdenv.OptionCidBase,

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -28,8 +28,8 @@ const (
 	DebugOption      = "debug"
 	LocalOption      = "local" // DEPRECATED: use OfflineOption
 	OfflineOption    = "offline"
-	ApiOption        = "api"        //nolint
-	ApiSecretOption  = "api-secret" //nolint
+	ApiOption        = "api"      //nolint
+	ApiAuthOption    = "api-auth" //nolint
 )
 
 var Root = &cmds.Command{
@@ -111,7 +111,7 @@ The CLI will exit with one of the following values:
 		cmds.BoolOption(LocalOption, "L", "Run the command locally, instead of using the daemon. DEPRECATED: use --offline."),
 		cmds.BoolOption(OfflineOption, "Run the command offline."),
 		cmds.StringOption(ApiOption, "Use a specific API instance (defaults to /ip4/127.0.0.1/tcp/5001)"),
-		cmds.StringOption(ApiSecretOption, "An HTTP Authorization header to send with the requests to the API"),
+		cmds.StringOption(ApiAuthOption, "Optional RPC API authorization secret (defined as AuthSecret in API.Authorizations config)"),
 
 		// global options, added to every command
 		cmdenv.OptionCidBase,

--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -210,6 +210,11 @@ func convertAuthorizationsMap(authScopes map[string]*config.RPCAuthScope) (map[s
 
 func withAuthSecrets(authorizations map[string]rpcAuthScopeWithUser, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v0/version" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		authorizationHeader := r.Header.Get("Authorization")
 		auth, ok := authorizations[authorizationHeader]
 

--- a/docs/changelogs/v0.25.md
+++ b/docs/changelogs/v0.25.md
@@ -6,6 +6,7 @@
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
+  - [Opt-in HTTP RPC API Authorization](#opt-in-http-rpc-api-authorization)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 

--- a/docs/changelogs/v0.25.md
+++ b/docs/changelogs/v0.25.md
@@ -13,6 +13,15 @@
 
 ### 🔦 Highlights
 
+#### Opt-in HTTP RPC API Authorization
+
+Kubo now supports HTTP RPC API authorization. It can be set in the field
+`API.Authorizations` in the configuration. Each user has its own unique
+authentication secret, as well as custom allowed paths. Therefore, you can
+give each user custom access to the RPC API.
+
+By default, all stays the same. For more information, check the [documentation](../../docs/config.md).
+
 ### 📝 Changelog
 
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/changelogs/v0.25.md
+++ b/docs/changelogs/v0.25.md
@@ -6,7 +6,7 @@
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
-  - [Opt-in HTTP RPC API Authorization](#opt-in-http-rpc-api-authorization)
+  - [RPC `API.Authorizations`](#rpc-apiauthorizations)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -14,14 +14,18 @@
 
 ### 🔦 Highlights
 
-#### Opt-in HTTP RPC API Authorization
+#### RPC `API.Authorizations`
 
-Kubo now supports HTTP RPC API authorization. It can be set in the field
-`API.Authorizations` in the configuration. Each user has its own unique
-authentication secret, as well as custom allowed paths. Therefore, you can
-give each user custom access to the RPC API.
+Kubo RPC API now supports optional HTTP Authorization.
 
-By default, all stays the same. For more information, check the [documentation](../../docs/config.md).
+Granular control over user access to the RPC can be defined in the
+[`API.Authorizations`](https://github.com/ipfs/kubo/blob/master/docs/config.md#apiauthorizations)
+map in the configuration file, allowing different users or apps to have unique
+access secrets and allowed paths.
+
+This feature is opt-in. By default, no authorization is set up.
+For configuration instructions,
+refer to the [documentation](https://github.com/ipfs/kubo/blob/master/docs/config.md#apiauthorizations).
 
 ### 📝 Changelog
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,10 @@ config file at runtime.
     - [`Addresses.NoAnnounce`](#addressesnoannounce)
   - [`API`](#api)
     - [`API.HTTPHeaders`](#apihttpheaders)
+    - [`API.HTTPHeaders`](#apihttpheaders)
+    - [`API.Authorizations`](#apiauthorizations)
+      - [`API.Authorizations: AuthSecret`](#apiauthorizations-authsecret)
+      - [`API.Authorizations: AllowedPaths`](#apiauthorizations-allowedpaths)
   - [`AutoNAT`](#autonat)
     - [`AutoNAT.ServiceMode`](#autonatservicemode)
     - [`AutoNAT.Throttle`](#autonatthrottle)
@@ -437,6 +441,49 @@ Example:
 Default: `null`
 
 Type: `object[string -> array[string]]` (header names -> array of header values)
+
+### `API.Authorizations`
+
+Map of Authorizations to protect the RPC API. By default, the RPC API is exposed
+without any protection on `127.0.0.1`. By setting this option, only the allowed
+users will be able to access it.
+
+Default: `null`
+
+Type: `object[string -> object]` (user name -> authorization object, see bellow)
+
+#### `API.Authorizations: AuthSecret`
+
+The secret that the user can use to authenticate. It has the format `type:value`.
+The following type are supported:
+
+- `basic` for Basic Auth. Can be one of the two:
+  - `basic:user:pass`
+  - `basic:encodedBasicAuth`
+- `bearer` for Bearer tokens, set as `bearer:token`.
+
+If no `type` is present, `bearer` is assumed. Unknown types will not be processed.
+
+You can use this secret also to log in via the command line: `ipfs id --api-auth basic:user:pass`.
+
+Default: `` (empty string)
+
+Type: `string`
+
+#### `API.Authorizations: AllowedPaths`
+
+An array of strings with the allowed path prefixes. The given user will only be
+able to access the paths prefixed by the given prefixes. For example, if you
+set `AllowedPaths` to `["/api/v0"]`, then the user will have access to the full
+RPC API. But if you set it to `["/api/v0/id", "/api/v0/files"]`, the user will 
+only have access to the `id` command, as well as all commands under `files`.
+
+Note that `/api/v0/version` is always permitted access. The command line tool uses
+this endpoint to check the remote node version to ensure compatibility.
+
+Default: `null`
+
+Type: `array[string]`
 
 ## `AutoNAT`
 

--- a/test/cli/auth_test.go
+++ b/test/cli/auth_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/ipfs/kubo/client/rpc/auth"
+	"github.com/ipfs/kubo/config"
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuth(t *testing.T) {
+	t.Parallel()
+
+	makeAndStartProtectedNode := func(t *testing.T, authorizations map[string]*config.RPCAuthScope) *harness.Node {
+		authorizations["test-node-starter"] = &config.RPCAuthScope{
+			HTTPAuthSecret: "bearer:test-node-starter",
+			AllowedPaths:   []string{"/api/v0"},
+		}
+
+		node := harness.NewT(t).NewNode().Init()
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.API.Authorizations = authorizations
+		})
+		node.StartDaemonWithAuthorization("Bearer test-node-starter")
+		return node
+	}
+
+	t.Run("Follows Allowed Paths", func(t *testing.T) {
+		t.Parallel()
+
+		node := makeAndStartProtectedNode(t, map[string]*config.RPCAuthScope{
+			"userA": {
+				HTTPAuthSecret: "bearer:userAToken",
+				AllowedPaths:   []string{"/api/v0/id"},
+			},
+		})
+
+		apiClient := node.APIClient()
+		apiClient.Client.Transport = auth.NewAuthorizedRoundTripper("Bearer userAToken", apiClient.Client.Transport)
+
+		// Can access ID.
+		resp := apiClient.Post("/api/v0/id", nil)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		// But not Ping.
+		resp = apiClient.Post("/api/v0/ping", nil)
+		assert.Equal(t, 403, resp.StatusCode)
+
+		node.StopDaemon()
+	})
+
+	t.Run("Generic Allowed Path Gives Full Access", func(t *testing.T) {
+		t.Parallel()
+
+		node := makeAndStartProtectedNode(t, map[string]*config.RPCAuthScope{
+			"userA": {
+				HTTPAuthSecret: "bearer:userAToken",
+				AllowedPaths:   []string{"/api/v0"},
+			},
+		})
+
+		apiClient := node.APIClient()
+		apiClient.Client.Transport = auth.NewAuthorizedRoundTripper("Bearer userAToken", apiClient.Client.Transport)
+
+		resp := apiClient.Post("/api/v0/id", nil)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		node.StopDaemon()
+	})
+}

--- a/test/cli/auth_test.go
+++ b/test/cli/auth_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const rpcDeniedMsg = "Kubo RPC Access Denied: Please provide a valid authorization token as defined in the API.Authorizations configuration."
+
 func TestAuth(t *testing.T) {
 	t.Parallel()
 
@@ -75,7 +77,7 @@ func TestAuth(t *testing.T) {
 			// But not 'ipfs config show'
 			resp = node.RunIPFS("config", "show", "--api-auth", authSecret)
 			require.Error(t, resp.Err)
-			require.Contains(t, resp.Stderr.String(), "Forbidden")
+			require.Contains(t, resp.Stderr.String(), rpcDeniedMsg)
 
 			node.StopDaemon()
 		}


### PR DESCRIPTION
Closes #10187 ← see design requirements and purpose there. 

I tried not to touch [`go-ipfs-cmds`](https://github.com/ipfs/go-ipfs-cmds). However, what I did in Kubo could've been done there too.

Closes #1532
Closes #2389
CC https://github.com/ipfs/ipfs-webui/issues/1586 https://github.com/ipfs/go-ipfs-api/issues/172 


--- 

### Feature Summary

This PR provides Kubo users with a basic HTTP Auth primitives for locking the RPC API down, and exposing only a subset of commands per access token defined in `API.Authorization` map. 


Future work, such as UCANs mentioned [here](https://github.com/ipfs/kubo/issues/1532#issuecomment-976425630), or sandboxing MSF, keys, IPNS names per user hinted [here](https://github.com/ipfs/kubo/issues/10187#issue-1968824281), could be built on top of this at a later time.