### PR TITLE
Preserve hostname specified with --api in http request headers

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -290,8 +290,8 @@ func makeExecutor(req *cmds.Request, env interface{}) (cmds.Executor, error) {
 		return exe, nil
 	}
 
-	// Resolve the API addr.
-	apiAddr, err = resolveAddr(req.Context, apiAddr)
+	// Check that the API addr is resolvable.
+	_, err = resolveAddr(req.Context, apiAddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
System resolves hostname to ip address which is no use for a reverse proxy (or kubernetes ingress) which may want to route the request to a service using the hostname.

Update still checks api addr is resolvable, but doesn't resolve it, thus enabling the cli to use a remote api behind a reverse proxy.