### PR TITLE
feat: ipfs key sign|verify

### DIFF
--- a/client/rpc/key.go
+++ b/client/rpc/key.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 
@@ -9,6 +10,7 @@ import (
 	iface "github.com/ipfs/kubo/core/coreiface"
 	caopts "github.com/ipfs/kubo/core/coreiface/options"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multibase"
 )
 
 type KeyAPI HttpApi
@@ -140,4 +142,54 @@ func (api *KeyAPI) Remove(ctx context.Context, name string) (iface.Key, error) {
 
 func (api *KeyAPI) core() *HttpApi {
 	return (*HttpApi)(api)
+}
+
+func (api *KeyAPI) Sign(ctx context.Context, name string, data []byte) (iface.Key, []byte, error) {
+	var out struct {
+		Key       keyOutput
+		Signature string
+	}
+
+	err := api.core().Request("key/sign").
+		Option("key", name).
+		FileBody(bytes.NewReader(data)).
+		Exec(ctx, &out)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key, err := newKey(out.Key.Name, out.Key.Id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, signature, err := multibase.Decode(out.Signature)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return key, signature, nil
+}
+
+func (api *KeyAPI) Verify(ctx context.Context, keyOrName string, signature, data []byte) (iface.Key, bool, error) {
+	var out struct {
+		Key            keyOutput
+		SignatureValid bool
+	}
+
+	err := api.core().Request("key/verify").
+		Option("key", keyOrName).
+		Option("signature", toMultibase(signature)).
+		FileBody(bytes.NewReader(data)).
+		Exec(ctx, &out)
+	if err != nil {
+		return nil, false, err
+	}
+
+	key, err := newKey(out.Key.Name, out.Key.Id)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return key, out.SignatureValid, nil
 }

--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -164,6 +164,8 @@ func TestCommands(t *testing.T) {
 		"/key/rename",
 		"/key/rm",
 		"/key/rotate",
+		"/key/sign",
+		"/key/verify",
 		"/log",
 		"/log/level",
 		"/log/ls",

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -24,6 +24,7 @@ import (
 	migrations "github.com/ipfs/kubo/repo/fsrepo/migrations"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	peer "github.com/libp2p/go-libp2p/core/peer"
+	mbase "github.com/multiformats/go-multibase"
 )
 
 var KeyCmd = &cmds.Command{
@@ -51,6 +52,8 @@ publish'.
 		"rename": keyRenameCmd,
 		"rm":     keyRmCmd,
 		"rotate": keyRotateCmd,
+		"sign":   keySignCmd,
+		"verify": keyVerifyCmd,
 	},
 }
 
@@ -686,6 +689,163 @@ func keyOutputListEncoders() cmds.EncoderFunc {
 		tw.Flush()
 		return nil
 	})
+}
+
+type KeySignOutput struct {
+	Key       string // CIDv1-Libp2p-Key
+	Signature string
+}
+
+var keySignCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Generates a signature for the given data with a specified key.",
+	},
+	Options: []cmds.Option{
+		cmds.StringOption("key", "k", "The name of the key to use for signing."),
+	},
+	Arguments: []cmds.Argument{
+		cmds.FileArg("data", true, false, "The data to sign.").EnableStdin(),
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		sk, err := getKeyForSignVerify(req, env)
+		if err != nil {
+			return err
+		}
+
+		pid, err := peer.IDFromPrivateKey(sk)
+		if err != nil {
+			return err
+		}
+
+		// Read given data.
+		data, err := readDataForSignVerify(req)
+		if err != nil {
+			return err
+		}
+
+		// Sign it!
+		sig, err := sk.Sign(data)
+		if err != nil {
+			return err
+		}
+
+		encoder, err := mbase.EncoderByName("base64url")
+		if err != nil {
+			return err
+		}
+
+		return res.Emit(&KeySignOutput{
+			Key:       peer.ToCid(pid).String(),
+			Signature: encoder.Encode(sig),
+		})
+	},
+	Type: KeySignOutput{},
+}
+
+type KeyVerifyOutput struct {
+	Key            string // CIDv1-Libp2p-Key
+	SignatureValid bool
+}
+
+var keyVerifyCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Verify that the given data and signature match.",
+	},
+	Options: []cmds.Option{
+		cmds.StringOption("key", "k", "The name of the key to use for signing."),
+		cmds.StringOption("signature", "s", "Multibase-encoded signature to verify."),
+	},
+	Arguments: []cmds.Argument{
+		cmds.FileArg("data", true, false, "The data to verify against the given signature.").EnableStdin(),
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		var (
+			pk  crypto.PubKey
+			pid peer.ID
+		)
+
+		name, _ := req.Options["key"].(string)
+		if sk, err := getKeyForSignVerify(req, env); err == nil {
+			pk = sk.GetPublic()
+			pid, err = peer.IDFromPublicKey(pk)
+			if err != nil {
+				return err
+			}
+		} else if pid, err = peer.Decode(name); err == nil {
+			pk, err = pid.ExtractPublicKey()
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+
+		// Read signature
+		signatureString, _ := req.Options["signature"].(string)
+		_, signature, err := mbase.Decode(signatureString)
+		if err != nil {
+			return err
+		}
+
+		// Read given data.
+		data, err := readDataForSignVerify(req)
+		if err != nil {
+			return err
+		}
+
+		// Verify
+		valid, err := pk.Verify(data, signature)
+		if err != nil {
+			return err
+		}
+
+		return res.Emit(&KeyVerifyOutput{
+			Key:            peer.ToCid(pid).String(),
+			SignatureValid: valid,
+		})
+	},
+	Type: KeyVerifyOutput{},
+}
+
+func getKeyForSignVerify(req *cmds.Request, env cmds.Environment) (crypto.PrivKey, error) {
+	name, _ := req.Options["key"].(string)
+	if name == "" || name == "self" {
+		node, err := cmdenv.GetNode(env)
+		if err != nil {
+			return nil, err
+		}
+
+		return node.PrivateKey, nil
+	} else {
+		cfgRoot, err := cmdenv.GetConfigRoot(env)
+		if err != nil {
+			return nil, err
+		}
+
+		// Signing is read-only: safe to read key without acquiring repo lock
+		// (this makes sign work when ipfs daemon is already running)
+		ksp := filepath.Join(cfgRoot, "keystore")
+		ks, err := keystore.NewFSKeystore(ksp)
+		if err != nil {
+			return nil, err
+		}
+
+		return ks.Get(name)
+	}
+}
+
+func readDataForSignVerify(req *cmds.Request) ([]byte, error) {
+	file, err := cmdenv.GetFileArg(req.Files.Entries())
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte("libp2p-key signed message:"), data...), nil
 }
 
 // DaemonNotRunning checks to see if the ipfs repo is locked, indicating that

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -697,8 +697,14 @@ type KeySignOutput struct {
 }
 
 var keySignCmd = &cmds.Command{
+	Status: cmds.Experimental,
 	Helptext: cmds.HelpText{
-		Tagline: "Generates a signature for the given data with a specified key.",
+		Tagline: "Generates a signature for the given data with a specified key. Useful for proving the key ownership.",
+		LongDescription: `
+Sign arbitrary bytes, such as to prove ownership of a Peer ID or an IPNS Name.
+To avoid signature reuse, the signed payload is always prefixed with
+"libp2p-key signed message:".
+`,
 	},
 	Options: []cmds.Option{
 		cmds.StringOption("key", "k", "The name of the key to use for signing."),
@@ -757,8 +763,13 @@ type KeyVerifyOutput struct {
 }
 
 var keyVerifyCmd = &cmds.Command{
+	Status: cmds.Experimental,
 	Helptext: cmds.HelpText{
 		Tagline: "Verify that the given data and signature match.",
+		LongDescription: `
+Verify if the given data and signatures match. To avoid the signature reuse,
+the signed payload is always prefixed with "libp2p-key signed message:".
+`,
 	},
 	Options: []cmds.Option{
 		cmds.StringOption("key", "k", "The name of the key to use for signing."),

--- a/core/coreiface/key.go
+++ b/core/coreiface/key.go
@@ -40,4 +40,8 @@ type KeyAPI interface {
 
 	// Remove removes keys from keystore. Returns ipns path of the removed key
 	Remove(ctx context.Context, name string) (Key, error)
+
+	Sign(ctx context.Context, name string, data []byte) (Key, []byte, error)
+
+	Verify(ctx context.Context, keyOrName string, signature, data []byte) (Key, bool, error)
 }

--- a/core/coreiface/key.go
+++ b/core/coreiface/key.go
@@ -41,7 +41,11 @@ type KeyAPI interface {
 	// Remove removes keys from keystore. Returns ipns path of the removed key
 	Remove(ctx context.Context, name string) (Key, error)
 
+	// Sign signs the given data with the key named name. Returns the key used
+	// for signing, the signature, and an error.
 	Sign(ctx context.Context, name string, data []byte) (Key, []byte, error)
 
+	// Verify verifies if the given data and signatures match. Returns the key used
+	// for verification, whether signature and data match, and an error.
 	Verify(ctx context.Context, keyOrName string, signature, data []byte) (Key, bool, error)
 }

--- a/core/coreiface/tests/key.go
+++ b/core/coreiface/tests/key.go
@@ -10,6 +10,7 @@ import (
 	opt "github.com/ipfs/kubo/core/coreiface/options"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mbase "github.com/multiformats/go-multibase"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,145 +44,83 @@ func (tp *TestSuite) TestKey(t *testing.T) {
 func (tp *TestSuite) TestListSelf(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	self, err := api.Key().Self(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	keys, err := api.Key().List(ctx)
-	if err != nil {
-		t.Fatalf("failed to list keys: %s", err)
-		return
-	}
-
-	if len(keys) != 1 {
-		t.Fatalf("there should be 1 key (self), got %d", len(keys))
-		return
-	}
-
-	if keys[0].Name() != "self" {
-		t.Errorf("expected the key to be called 'self', got '%s'", keys[0].Name())
-	}
-
-	if keys[0].Path().String() != "/ipns/"+iface.FormatKeyID(self.ID()) {
-		t.Errorf("expected the key to have path '/ipns/%s', got '%s'", iface.FormatKeyID(self.ID()), keys[0].Path().String())
-	}
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "self", keys[0].Name())
+	assert.Equal(t, "/ipns/"+iface.FormatKeyID(self.ID()), keys[0].Path().String())
 }
 
 func (tp *TestSuite) TestRenameSelf(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, _, err = api.Key().Rename(ctx, "self", "foo")
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "cannot rename key with name 'self'") {
-			t.Fatalf("expected error 'cannot rename key with name 'self'', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "cannot rename key with name 'self'")
 
 	_, _, err = api.Key().Rename(ctx, "self", "foo", opt.Key.Force(true))
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "cannot rename key with name 'self'") {
-			t.Fatalf("expected error 'cannot rename key with name 'self'', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "cannot rename key with name 'self'")
 }
 
 func (tp *TestSuite) TestRemoveSelf(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Remove(ctx, "self")
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "cannot remove key with name 'self'") {
-			t.Fatalf("expected error 'cannot remove key with name 'self'', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "cannot remove key with name 'self'")
 }
 
 func (tp *TestSuite) TestGenerate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	k, err := api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if k.Name() != "foo" {
-		t.Errorf("expected the key to be called 'foo', got '%s'", k.Name())
-	}
+	require.NoError(t, err)
+	require.Equal(t, "foo", k.Name())
 
 	verifyIPNSPath(t, k.Path().String())
 }
 
-func verifyIPNSPath(t *testing.T, p string) bool {
+func verifyIPNSPath(t *testing.T, p string) {
 	t.Helper()
-	if !strings.HasPrefix(p, "/ipns/") {
-		t.Errorf("path %q does not look like an IPNS path", p)
-		return false
-	}
+
+	require.True(t, strings.HasPrefix(p, "/ipns/"))
+
 	k := p[len("/ipns/"):]
 	c, err := cid.Decode(k)
-	if err != nil {
-		t.Errorf("failed to decode IPNS key %q (%v)", k, err)
-		return false
-	}
+	require.NoError(t, err)
+
 	b36, err := c.StringOfBase(mbase.Base36)
-	if err != nil {
-		t.Fatalf("cid cannot format itself in b36")
-		return false
-	}
-	if b36 != k {
-		t.Errorf("IPNS key is not base36")
-	}
-	return true
+	require.NoError(t, err)
+	require.Equal(t, k, b36)
 }
 
 func (tp *TestSuite) TestGenerateSize(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	k, err := api.Key().Generate(ctx, "foo", opt.Key.Size(2048))
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if k.Name() != "foo" {
-		t.Errorf("expected the key to be called 'foo', got '%s'", k.Name())
-	}
+	require.NoError(t, err)
+	require.Equal(t, "foo", k.Name())
 
 	verifyIPNSPath(t, k.Path().String())
 }
@@ -193,93 +132,47 @@ func (tp *TestSuite) TestGenerateType(t *testing.T) {
 	defer cancel()
 
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	k, err := api.Key().Generate(ctx, "bar", opt.Key.Type(opt.Ed25519Key))
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if k.Name() != "bar" {
-		t.Errorf("expected the key to be called 'foo', got '%s'", k.Name())
-	}
-
+	require.NoError(t, err)
+	require.Equal(t, "bar", k.Name())
 	// Expected to be an inlined identity hash.
-	if !strings.HasPrefix(k.Path().String(), "/ipns/12") {
-		t.Errorf("expected the key to be prefixed with '/ipns/12', got '%s'", k.Path().String())
-	}
+	require.True(t, strings.HasPrefix(k.Path().String(), "/ipns/12"))
 }
 
 func (tp *TestSuite) TestGenerateExisting(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "key with name 'foo' already exists") {
-			t.Fatalf("expected error 'key with name 'foo' already exists', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "key with name 'foo' already exists")
 
 	_, err = api.Key().Generate(ctx, "self")
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "cannot create key with name 'self'") {
-			t.Fatalf("expected error 'cannot create key with name 'self'', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "cannot create key with name 'self'")
 }
 
 func (tp *TestSuite) TestList(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	l, err := api.Key().List(ctx)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if len(l) != 2 {
-		t.Fatalf("expected to get 2 keys, got %d", len(l))
-		return
-	}
-
-	if l[0].Name() != "self" {
-		t.Fatalf("expected key 0 to be called 'self', got '%s'", l[0].Name())
-		return
-	}
-
-	if l[1].Name() != "foo" {
-		t.Fatalf("expected key 1 to be called 'foo', got '%s'", l[1].Name())
-		return
-	}
+	require.NoError(t, err)
+	require.Len(t, l, 2)
+	require.Equal(t, "self", l[0].Name())
+	require.Equal(t, "foo", l[1].Name())
 
 	verifyIPNSPath(t, l[0].Path().String())
 	verifyIPNSPath(t, l[1].Path().String())
@@ -288,256 +181,138 @@ func (tp *TestSuite) TestList(t *testing.T) {
 func (tp *TestSuite) TestRename(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	k, overwrote, err := api.Key().Rename(ctx, "foo", "bar")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if overwrote {
-		t.Error("overwrote should be false")
-	}
-
-	if k.Name() != "bar" {
-		t.Errorf("returned key should be called 'bar', got '%s'", k.Name())
-	}
+	require.NoError(t, err)
+	assert.False(t, overwrote)
+	assert.Equal(t, "bar", k.Name())
 }
 
 func (tp *TestSuite) TestRenameToSelf(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, _, err = api.Key().Rename(ctx, "foo", "self")
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "cannot overwrite key with name 'self'") {
-			t.Fatalf("expected error 'cannot overwrite key with name 'self'', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "cannot overwrite key with name 'self'")
 }
 
 func (tp *TestSuite) TestRenameToSelfForce(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, _, err = api.Key().Rename(ctx, "foo", "self", opt.Key.Force(true))
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "cannot overwrite key with name 'self'") {
-			t.Fatalf("expected error 'cannot overwrite key with name 'self'', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "cannot overwrite key with name 'self'")
 }
 
 func (tp *TestSuite) TestRenameOverwriteNoForce(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "bar")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, _, err = api.Key().Rename(ctx, "foo", "bar")
-	if err == nil {
-		t.Error("expected error to not be nil")
-	} else {
-		if !strings.Contains(err.Error(), "key by that name already exists, refusing to overwrite") {
-			t.Fatalf("expected error 'key by that name already exists, refusing to overwrite', got '%s'", err.Error())
-		}
-	}
+	require.ErrorContains(t, err, "key by that name already exists, refusing to overwrite")
 }
 
 func (tp *TestSuite) TestRenameOverwrite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	kfoo, err := api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "bar")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	k, overwrote, err := api.Key().Rename(ctx, "foo", "bar", opt.Key.Force(true))
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if !overwrote {
-		t.Error("overwrote should be true")
-	}
-
-	if k.Name() != "bar" {
-		t.Errorf("returned key should be called 'bar', got '%s'", k.Name())
-	}
-
-	if k.Path().String() != kfoo.Path().String() {
-		t.Errorf("k and kfoo should have equal paths, '%s'!='%s'", k.Path().String(), kfoo.Path().String())
-	}
+	require.NoError(t, err)
+	require.True(t, overwrote)
+	assert.Equal(t, "bar", k.Name())
+	assert.Equal(t, kfoo.Path().String(), k.Path().String())
 }
 
 func (tp *TestSuite) TestRenameSameNameNoForce(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	k, overwrote, err := api.Key().Rename(ctx, "foo", "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if overwrote {
-		t.Error("overwrote should be false")
-	}
-
-	if k.Name() != "foo" {
-		t.Errorf("returned key should be called 'foo', got '%s'", k.Name())
-	}
+	require.NoError(t, err)
+	assert.False(t, overwrote)
+	assert.Equal(t, "foo", k.Name())
 }
 
 func (tp *TestSuite) TestRenameSameName(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	k, overwrote, err := api.Key().Rename(ctx, "foo", "foo", opt.Key.Force(true))
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if overwrote {
-		t.Error("overwrote should be false")
-	}
-
-	if k.Name() != "foo" {
-		t.Errorf("returned key should be called 'foo', got '%s'", k.Name())
-	}
+	require.NoError(t, err)
+	assert.False(t, overwrote)
+	assert.Equal(t, "foo", k.Name())
 }
 
 func (tp *TestSuite) TestRemove(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	api, err := tp.makeAPI(t, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	k, err := api.Key().Generate(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	l, err := api.Key().List(ctx)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if len(l) != 2 {
-		t.Fatalf("expected to get 2 keys, got %d", len(l))
-		return
-	}
+	require.NoError(t, err)
+	require.Len(t, l, 2)
 
 	p, err := api.Key().Remove(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if k.Path().String() != p.Path().String() {
-		t.Errorf("k and p should have equal paths, '%s'!='%s'", k.Path().String(), p.Path().String())
-	}
+	require.NoError(t, err)
+	assert.Equal(t, p.Path().String(), k.Path().String())
 
 	l, err = api.Key().List(ctx)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if len(l) != 1 {
-		t.Fatalf("expected to get 1 key, got %d", len(l))
-		return
-	}
-
-	if l[0].Name() != "self" {
-		t.Errorf("expected the key to be called 'self', got '%s'", l[0].Name())
-	}
+	require.NoError(t, err)
+	require.Len(t, l, 1)
+	assert.Equal(t, "self", l[0].Name())
 }
 
 func (tp *TestSuite) TestSign(t *testing.T) {

--- a/docs/changelogs/v0.25.md
+++ b/docs/changelogs/v0.25.md
@@ -58,12 +58,9 @@ For more information see https://github.com/ipfs/kubo/pull/9747.
 
 ##### Commands `ipfs key sign` and `ipfs key verify`
 
-The Kubo CLI `ipfs key` now includes two new subcommands: `sign` and `verify`.
-This allows the Kubo node to sign arbitrary cryptographic bytes. For security,
-these will always be prefixed with `libp2p-key signed message:`.
+This allows the Kubo node to sign arbitrary bytes to prove ownership of a PeerID or an IPNS Name. To avoid signature reuse, the signed payload is always prefixed with `libp2p-key signed message:`.
 
-These commands are also both available through the RPC client and implemented
-in `client/rpc`.
+These commands are also both available through the RPC client and implemented in `client/rpc`.
 
 For more information see https://github.com/ipfs/kubo/issues/10230.
 

--- a/docs/changelogs/v0.25.md
+++ b/docs/changelogs/v0.25.md
@@ -10,6 +10,7 @@
   - [RPC `API.Authorizations`](#rpc-apiauthorizations)
   - [MPLEX Removal](#mplex-removal)
   - [Graphsync Experiment Removal](#graphsync-experiment-removal)
+  - [Commands `ipfs key sign` and `ipfs key verify`](#commands-ipfs-key-sign-and-ipfs-key-verify)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -54,6 +55,17 @@ And we are left to have to maintain the go-graphsync implementation when trying
 to update Kubo because some dependency changed and it fails to build anymore.
 
 For more information see https://github.com/ipfs/kubo/pull/9747.
+
+##### Commands `ipfs key sign` and `ipfs key verify`
+
+The Kubo CLI `ipfs key` now includes two new subcommands: `sign` and `verify`.
+This allows the Kubo node to sign arbitrary cryptographic bytes. For security,
+these will always be prefixed with `libp2p-key signed message:`.
+
+These commands are also both available through the RPC client and implemented
+in `client/rpc`.
+
+For more information see https://github.com/ipfs/kubo/issues/10230.
 
 ### 📝 Changelog
 


### PR DESCRIPTION
Closes #10230 by adding `key sign|verify` commands that facilitate offline key ownership proofs.

Notes:

- Output response is a bit different than the suggested in #10230 in order to match the remaining `key/*` endpoints. Similarly, `Err` field is not included as there's already a common way for the API to error, and that is not by adding a field to the output.
- In `key/verify`, the signature URL param is base64url encoded. None of the other things have to be encoded. The rest of the binary data goes in the body, so it does not relate to the issues in #7939.
- `self` is used as a default key. Happy to change this.
- Paid some debt by changing the current key tests to `require.` and `assert.`
- ⚠️ Helia test failures tracked on [Slack](https://filecoinproject.slack.com/archives/C04M8232QRW/p1701251128568139).
