### PR TITLE
docs(config): clarify Reprovider.Strategy: roots

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1467,6 +1467,13 @@ Tells reprovider what should be announced. Valid strategies are:
 - `"all"` - announce all CIDs of stored blocks
 - `"pinned"` - only announce pinned CIDs recursively (both roots and child blocks)
 - `"roots"` - only announce the root block of explicitly pinned CIDs
+  - **⚠️  BE CAREFUL:** node with `roots` strategy will not announce child blocks.
+    It makes sense only for use cases where the entire DAG is fetched in full,
+    and a graceful resume does not have to be guaranteed: the lack of child
+    announcements means an interrupted retrieval won't be able to find
+    providers for the missing block in the middle of a file, unless the peer
+    happens to already be connected to a provider and ask for child CID over
+    bitswap.
 
 Default: `"all"`
 


### PR DESCRIPTION
This adds the disclaimer suggested by @AnnaArchivist in https://github.com/ipfs/kubo/issues/9416:

> [..]  what is the purpose of Reprovider.Strategy "roots" in the first place? Is it only useful if we know that other nodes will always fully recursively fetch all the "children" of a root node? If so, then that should be more clearly documented.


Once https://github.com/ipfs/kubo/issues/8676 and https://github.com/ipfs/kubo/issues/10251 are resolved, this disclaimer can be removed.
