### PR TITLE
Fix broken link in HTTP RPC client doc [skip changelog]

### DIFF
--- a/docs/http-rpc-clients.md
+++ b/docs/http-rpc-clients.md
@@ -5,4 +5,4 @@ Kubo provides official HTTP RPC  (`/api/v0`) clients for selected languages:
 | Language |     Package Name    | Github Repository                          |
 |:--------:|:-------------------:|--------------------------------------------|
 | JS       | kubo-rpc-client     | https://github.com/ipfs/js-kubo-rpc-client |
-| Go       | `rpc`               | [`./client/rpc`](./client/rpc)             |
+| Go       | `rpc`               | [`../client/rpc`](../client/rpc)           |


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

In the README under the "Getting Started" Section there is a link to HTTP RPC clients and examples.


<img width="854" alt="Screenshot 2023-12-20 at 4 49 45 PM" src="https://github.com/ipfs/kubo/assets/11562951/4f840d02-dd8b-4710-b045-93923a014e91">

When you click on "List of HTTP/RPC clients" you are directed to the following page currently



<img width="1124" alt="Screenshot 2023-12-20 at 4 50 01 PM" src="https://github.com/ipfs/kubo/assets/11562951/86d84249-a545-404a-b28a-bcc0e85d5004">


If you select the link to the Go client it is currently broken.

<img width="1132" alt="Screenshot 2023-12-20 at 4 50 11 PM" src="https://github.com/ipfs/kubo/assets/11562951/96c5313b-7dee-4f74-bc4f-67854bb10b85">


I think it is meant to go up two levels to the client/rpc page in the kubo repo which shows an example there and is more useful. 