### PR TITLE
chore: increase time of sync-release-assets

### DIFF
--- a/.github/workflows/sync-release-assets.yml
+++ b/.github/workflows/sync-release-assets.yml
@@ -16,7 +16,7 @@ jobs:
   dist-ipfs-tech:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
     runs-on: "ubuntu-latest"
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: ipfs/download-ipfs-distribution-action@v1
       - uses: ipfs/start-ipfs-daemon-action@v1


### PR DESCRIPTION
Need to increase the time so we can release 0.26.0-rc1. It seems that getting the assets is taking a bit longer than normal https://github.com/ipfs/kubo/actions/runs/7486931561/job/20378282844

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
