### PR TITLE
dependabot: only update github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "11:00"
-    open-pull-requests-limit: 10
-    labels:
-      - "topic/dependencies"            
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We update go packages as part of the release cycle, dependant bots also never fixup all the `go.sum` in the repo so this is noisy failing PRs.