### PR TITLE
core/corehttp: wrap hostname option with otelhttp

### DIFF
--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -62,7 +62,12 @@ func HostnameOption() ServeOption {
 		}
 
 		childMux := http.NewServeMux()
-		mux.Handle("/", gateway.NewHostnameHandler(config, backend, childMux))
+
+		var handler http.Handler
+		handler = gateway.NewHostnameHandler(config, backend, childMux)
+		handler = otelhttp.NewHandler(handler, "HostnameGateway")
+
+		mux.Handle("/", handler)
 		return childMux, nil
 	}
 }


### PR DESCRIPTION
We were missing the OTel handler in the hostname option, so not all requests with traceparent were getting attached to the traceparent header.