### PR TITLE
chore: remove Gateway.APICommands

### DIFF
--- a/config/gateway.go
+++ b/config/gateway.go
@@ -53,9 +53,6 @@ type Gateway struct {
 	// PathPrefixes was removed: https://github.com/ipfs/go-ipfs/issues/7702
 	PathPrefixes []string
 
-	// FIXME: Not yet implemented: https://github.com/ipfs/kubo/issues/8059
-	APICommands []string
-
 	// NoFetch configures the gateway to _not_ fetch blocks in response to
 	// requests.
 	NoFetch bool

--- a/config/init.go
+++ b/config/init.go
@@ -68,7 +68,6 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			NoFetch:      false,
 			PathPrefixes: []string{},
 			HTTPHeaders:  map[string][]string{},
-			APICommands:  []string{},
 		},
 		Reprovider: Reprovider{
 			Interval: nil,


### PR DESCRIPTION
Closes #8059 (we are shifting ecosystem towards removing /api/v0 from Gateway instad of fixing this)