### PR TITLE
config: remove all options that are marked as REMOVED

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -68,7 +68,6 @@ const (
 	routingOptionAutoClientKwd = "autoclient"
 	unencryptTransportKwd      = "disable-transport-encryption"
 	unrestrictedAPIAccessKwd   = "unrestricted-api"
-	writableKwd                = "writable"
 	enablePubSubKwd            = "enable-pubsub-experiment"
 	enableIPNSPubSubKwd        = "enable-namesys-pubsub"
 	enableMultiplexKwd         = "enable-mplex-experiment"
@@ -164,7 +163,6 @@ Headers.
 		cmds.StringOption(initProfileOptionKwd, "Configuration profiles to apply for --init. See ipfs init --help for more"),
 		cmds.StringOption(routingOptionKwd, "Overrides the routing option").WithDefault(routingOptionDefaultKwd),
 		cmds.BoolOption(mountKwd, "Mounts IPFS to the filesystem using FUSE (experimental)"),
-		cmds.BoolOption(writableKwd, "Enable legacy Gateway.Writable (REMOVED)"),
 		cmds.StringOption(ipfsMountKwd, "Path to the mountpoint for IPFS (if using --mount). Defaults to config setting."),
 		cmds.StringOption(ipnsMountKwd, "Path to the mountpoint for IPNS (if using --mount). Defaults to config setting."),
 		cmds.BoolOption(unrestrictedAPIAccessKwd, "Allow API access to unlisted hashes"),
@@ -803,15 +801,6 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 		return nil, fmt.Errorf("serveHTTPGateway: GetConfig() failed: %s", err)
 	}
 
-	writable, writableOptionFound := req.Options[writableKwd].(bool)
-	if !writableOptionFound {
-		writable = cfg.Gateway.Writable.WithDefault(false)
-	}
-
-	if writable {
-		log.Fatalf("Support for Gateway.Writable and --writable has been REMOVED. Please remove it from your config file or CLI. Modern replacement tracked in https://github.com/ipfs/specs/issues/375")
-	}
-
 	listeners, err := sockets.TakeListeners("io.ipfs.gateway")
 	if err != nil {
 		return nil, fmt.Errorf("serveHTTPGateway: socket activation failed: %s", err)
@@ -874,10 +863,6 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 
 	if len(cfg.Gateway.RootRedirect) > 0 {
 		opts = append(opts, corehttp.RedirectOption("", cfg.Gateway.RootRedirect))
-	}
-
-	if len(cfg.Gateway.PathPrefixes) > 0 {
-		log.Fatal("Support for custom Gateway.PathPrefixes was removed: https://github.com/ipfs/go-ipfs/issues/7702")
 	}
 
 	node, err := cctx.ConstructNode()

--- a/config/discovery.go
+++ b/config/discovery.go
@@ -6,8 +6,4 @@ type Discovery struct {
 
 type MDNS struct {
 	Enabled bool
-
-	// DEPRECATED: the time between discovery rounds is no longer configurable
-	// See: https://github.com/ipfs/go-ipfs/pull/9048#discussion_r906814717
-	Interval *OptionalInteger `json:",omitempty"`
 }

--- a/config/gateway.go
+++ b/config/gateway.go
@@ -47,12 +47,6 @@ type Gateway struct {
 	// should be redirected.
 	RootRedirect string
 
-	// REMOVED: modern replacement tracked in https://github.com/ipfs/specs/issues/375
-	Writable Flag `json:",omitempty"`
-
-	// PathPrefixes was removed: https://github.com/ipfs/go-ipfs/issues/7702
-	PathPrefixes []string
-
 	// NoFetch configures the gateway to _not_ fetch blocks in response to
 	// requests.
 	NoFetch bool

--- a/config/init.go
+++ b/config/init.go
@@ -66,7 +66,6 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		Gateway: Gateway{
 			RootRedirect: "",
 			NoFetch:      false,
-			PathPrefixes: []string{},
 			HTTPHeaders:  map[string][]string{},
 		},
 		Reprovider: Reprovider{

--- a/config/swarm.go
+++ b/config/swarm.go
@@ -13,26 +13,6 @@ type SwarmConfig struct {
 	// DisableNatPortMap turns off NAT port mapping (UPnP, etc.).
 	DisableNatPortMap bool
 
-	// DisableRelay explicitly disables the relay transport.
-	//
-	// Deprecated: This flag is deprecated and is overridden by
-	// `Swarm.Transports.Relay` if specified.
-	DisableRelay bool `json:",omitempty"`
-
-	// EnableRelayHop makes this node act as a public relay v1
-	//
-	// Deprecated: The circuit v1 protocol is deprecated.
-	// Use `Swarm.RelayService` to configure the circuit v2 relay.
-	EnableRelayHop bool `json:",omitempty"`
-
-	// EnableAutoRelay enables the "auto relay user" feature.
-	// Node will find and use advertised public relays when it determines that
-	// it's not reachable from the public internet.
-	//
-	// Deprecated: This flag is deprecated and is overridden by
-	// `Swarm.RelayClient.Enabled` if specified.
-	EnableAutoRelay bool `json:",omitempty"`
-
 	// RelayClient controls the client side of "auto relay" feature.
 	// When enabled, the node will use relays if it is not publicly reachable.
 	RelayClient RelayClient
@@ -112,8 +92,6 @@ type Transports struct {
 	Security struct {
 		// Defaults to 100.
 		TLS Priority `json:",omitempty"`
-		// Defaults to 200.
-		SECIO Priority `json:",omitempty"`
 		// Defaults to 300.
 		Noise Priority `json:",omitempty"`
 	}
@@ -123,8 +101,6 @@ type Transports struct {
 	Multiplexers struct {
 		// Defaults to 100.
 		Yamux Priority `json:",omitempty"`
-		// Defaults to -1.
-		Mplex Priority `json:",omitempty"`
 	}
 }
 

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -122,24 +122,6 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 		}
 	}
 
-	// Force users to migrate old config.
-	// nolint
-	if cfg.Swarm.DisableRelay {
-		logger.Fatal("The 'Swarm.DisableRelay' config field was removed." +
-			"Use the 'Swarm.Transports.Network.Relay' instead.")
-	}
-	// nolint
-	if cfg.Swarm.EnableAutoRelay {
-		logger.Fatal("The 'Swarm.EnableAutoRelay' config field was removed." +
-			"Use the 'Swarm.RelayClient.Enabled' instead.")
-	}
-	// nolint
-	if cfg.Swarm.EnableRelayHop {
-		logger.Fatal("The `Swarm.EnableRelayHop` config field was removed.\n" +
-			"Use `Swarm.RelayService` to configure the circuit v2 relay.\n" +
-			"If you want to continue running a circuit v1 relay, please use the standalone relay daemon: https://dist.ipfs.tech/#libp2p-relay-daemon (with RelayV1.Enabled: true)")
-	}
-
 	// Gather all the options
 	opts := fx.Options(
 		BaseLibP2P,

--- a/core/node/libp2p/sec.go
+++ b/core/node/libp2p/sec.go
@@ -8,11 +8,6 @@ import (
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
 )
 
-const secioEnabledWarning = `The SECIO security transport was enabled in the config but is no longer supported.
-
-SECIO disabled by default in go-ipfs 0.7 removed in go-ipfs 0.9. Please remove
-Swarm.Transports.Security.SECIO from your IPFS config.`
-
 func Security(enabled bool, tptConfig config.Transports) interface{} {
 	if !enabled {
 		return func() (opts Libp2pOpts) {
@@ -21,10 +16,6 @@ func Security(enabled bool, tptConfig config.Transports) interface{} {
 			opts.Opts = append(opts.Opts, libp2p.NoSecurity)
 			return opts
 		}
-	}
-
-	if _, enabled := tptConfig.Security.SECIO.WithDefault(config.Disabled); enabled {
-		log.Error(secioEnabledWarning)
 	}
 
 	// Using the new config options.

--- a/core/node/libp2p/smux.go
+++ b/core/node/libp2p/smux.go
@@ -14,9 +14,6 @@ func makeSmuxTransportOption(tptConfig config.Transports) (libp2p.Option, error)
 	if prefs := os.Getenv("LIBP2P_MUX_PREFS"); prefs != "" {
 		return nil, fmt.Errorf("configuring muxers with LIBP2P_MUX_PREFS is no longer supported, use Swarm.Transports.Multiplexers")
 	}
-	if tptConfig.Multiplexers.Mplex != 0 {
-		return nil, fmt.Errorf("Swarm.Transports.Multiplexers.Mplex is no longer supported, remove it from your config, see https://github.com/libp2p/specs/issues/553")
-	}
 	if tptConfig.Multiplexers.Yamux < 0 {
 		return nil, fmt.Errorf("running libp2p with Swarm.Transports.Multiplexers.Yamux disabled is not supported")
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -2222,7 +2222,7 @@ Type: `priority`
 
 #### `Swarm.Transports.Security.SECIO`
 
-Support for SECIO has been removed. Please remove this option from your config.
+**REMOVED**:  support for SECIO has been removed. Please remove this option from your config.
 
 #### `Swarm.Transports.Security.Noise`
 


### PR DESCRIPTION
Most of the removed options are many years old. In addition, they've all been removed in past iterations of Kubo. Some options were marked as removed in the config.md, but we still had a warning in the code to let users know they have been removed.

I think it's been long enough for all of this options, and enough Kubo iterations in order to alert the users. It is good to keep it in the config.md for now so that people can actually check. However, I think it's time to remove them from the code itself.