### PR TITLE
fix(gw): negative entity-bytes beyond file size

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:
-  # hostnames expected by https://github.com/ipfs/gateway-conformance
+  # hostnames expected by https://github.com/hannahhoward/gateway-conformance
   GATEWAY_PUBLIC_GATEWAYS: |
     {
       "example.com": {
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.4
+        uses: hannahhoward/gateway-conformance/.github/actions/extract-fixtures@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
         with:
           output: fixtures
 
@@ -96,7 +96,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.4
+        uses: hannahhoward/gateway-conformance/.github/actions/test@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
         with:
           gateway-url: http://127.0.0.1:8080
           json: output.json
@@ -129,7 +129,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.4
+        uses: hannahhoward/gateway-conformance/.github/actions/extract-fixtures@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
         with:
           output: fixtures
 
@@ -202,7 +202,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.4
+        uses: hannahhoward/gateway-conformance/.github/actions/test@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
         with:
           gateway-url: http://127.0.0.1:8092
           json: output.json

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@c63414e696e0250110da8ae5479614193abaab85
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.5
         with:
           output: fixtures
 
@@ -96,7 +96,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@c63414e696e0250110da8ae5479614193abaab85
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.5
         with:
           gateway-url: http://127.0.0.1:8080
           json: output.json
@@ -129,7 +129,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@c63414e696e0250110da8ae5479614193abaab85
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.5
         with:
           output: fixtures
 
@@ -202,7 +202,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@c63414e696e0250110da8ae5479614193abaab85
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.5
         with:
           gateway-url: http://127.0.0.1:8092
           json: output.json

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:
-  # hostnames expected by https://github.com/hannahhoward/gateway-conformance
+  # hostnames expected by https://github.com/ipfs/gateway-conformance
   GATEWAY_PUBLIC_GATEWAYS: |
     {
       "example.com": {
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: hannahhoward/gateway-conformance/.github/actions/extract-fixtures@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@c63414e696e0250110da8ae5479614193abaab85
         with:
           output: fixtures
 
@@ -96,7 +96,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: hannahhoward/gateway-conformance/.github/actions/test@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
+        uses: ipfs/gateway-conformance/.github/actions/test@c63414e696e0250110da8ae5479614193abaab85
         with:
           gateway-url: http://127.0.0.1:8080
           json: output.json
@@ -129,7 +129,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: hannahhoward/gateway-conformance/.github/actions/extract-fixtures@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@c63414e696e0250110da8ae5479614193abaab85
         with:
           output: fixtures
 
@@ -202,7 +202,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: hannahhoward/gateway-conformance/.github/actions/test@7ed58d142a6a8295777f5a6a5bd4f8e68c179355
+        uses: ipfs/gateway-conformance/.github/actions/test@c63414e696e0250110da8ae5479614193abaab85
         with:
           gateway-url: http://127.0.0.1:8092
           json: output.json

--- a/Rules.mk
+++ b/Rules.mk
@@ -66,6 +66,10 @@ clean:
 	rm -rf $(CLEAN)
 .PHONY: clean
 
+mod_tidy:
+	@find . -name go.mod -execdir $(GOCC) mod tidy \;
+.PHONY: mod_tidy
+
 coverage: $(COVERAGE)
 .PHONY: coverage
 
@@ -119,6 +123,7 @@ help:
 	@echo '  build        - Build binary at ./cmd/ipfs/ipfs'
 	@echo '  nofuse       - Build binary with no fuse support'
 	@echo '  install      - Build binary and install into $$GOBIN'
+	@echo '  mod_tidy     - Remove unused dependencis from go.mod files'
 #	@echo '  dist_install - TODO: c.f. ./cmd/ipfs/dist/README.md'
 	@echo ''
 	@echo 'CLEANING TARGETS:'

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.20
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c
+	github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.32.2
 	github.com/multiformats/go-multiaddr v0.12.1

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.20
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f
+	github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.32.2
 	github.com/multiformats/go-multiaddr v0.12.1

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -260,8 +260,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f h1:GBc0SWZ39F3eq0UJLB1ASNvcyGuS1jqSzaoN3mhi8ss=
-github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
+github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8 h1:/d+3/JOYsHS4Uo+6WIxu2oHHlM5WjWOySYItN9V+YHs=
+github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -260,8 +260,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c h1:A18UHDQ4V2Ai6/YsrH7kfGjA1r5SrwjQR1Lqiq68YQU=
-github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
+github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f h1:GBc0SWZ39F3eq0UJLB1ASNvcyGuS1jqSzaoN3mhi8ss=
+github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c
-	github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c
+	github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c
-	github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f
+	github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f h1:GBc0SWZ39F3eq0UJLB1ASNvcyGuS1jqSzaoN3mhi8ss=
-github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
+github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8 h1:/d+3/JOYsHS4Uo+6WIxu2oHHlM5WjWOySYItN9V+YHs=
+github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c h1:A18UHDQ4V2Ai6/YsrH7kfGjA1r5SrwjQR1Lqiq68YQU=
-github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
+github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f h1:GBc0SWZ39F3eq0UJLB1ASNvcyGuS1jqSzaoN3mhi8ss=
+github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f // indirect
+	github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8 // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c // indirect
+	github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -342,8 +342,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c h1:A18UHDQ4V2Ai6/YsrH7kfGjA1r5SrwjQR1Lqiq68YQU=
-github.com/ipfs/boxo v0.17.1-0.20240124092521-3d57bce7998c/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
+github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f h1:GBc0SWZ39F3eq0UJLB1ASNvcyGuS1jqSzaoN3mhi8ss=
+github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -342,8 +342,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f h1:GBc0SWZ39F3eq0UJLB1ASNvcyGuS1jqSzaoN3mhi8ss=
-github.com/ipfs/boxo v0.17.1-0.20240125152138-648a9638166f/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
+github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8 h1:/d+3/JOYsHS4Uo+6WIxu2oHHlM5WjWOySYItN9V+YHs=
+github.com/ipfs/boxo v0.17.1-0.20240125173442-bf34cd0777d8/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=


### PR DESCRIPTION
This PR aims to do end-to-end smoke-test and validation of upstream fixes:

- Run tests from https://github.com/ipfs/gateway-conformance/pull/190
- Against fix from https://github.com/ipfs/boxo/pull/523


## TODO

- [x] make gateway-conformance test on this PR greeen
  - done, small fixes of top of Hannah's changes: https://github.com/ipfs/gateway-conformance/pull/190/commits/7ed58d142a6a8295777f5a6a5bd4f8e68c179355, https://github.com/ipfs/boxo/pull/523/commits/c3931cfaf4b36ec0e5def1499177a2b3c3bf6478
- [x] switch this PR to gateway-conformance release with https://github.com/ipfs/gateway-conformance/pull/190
- [x] switch this PR to boxo main branch commit with https://github.com/ipfs/boxo/pull/523
- [x] PR ipfs/specs with one sentence that says `entity-bytes` range overflows in both directions SHOULD be ignored / truncated: done https://github.com/ipfs/specs/pull/460