### PR TITLE
docs: clarify Gateway.ExposeRoutingAPI

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -762,11 +762,15 @@ Type: `flag`
 
 ### `Gateway.ExposeRoutingAPI`
 
-An optional flag to expose Kubo `Routing` system on the gateway port as a [Routing
-V1](https://specs.ipfs.tech/routing/routing-v1/) endpoint.  This only affects your
-local gateway, at `127.0.0.1`.
+An optional flag to expose Kubo `Routing` system on the gateway port
+as a [`/routing/v1`](https://specs.ipfs.tech/routing/routing-v1/) endpoint on `127.0.0.1`.
+Use reverse proxy to expose it on a different hostname.
 
-This endpoint can be used by other Kubo instance, as illustrated in [`delegated_routing_v1_http_proxy_test.go`](https://github.com/ipfs/kubo/blob/master/test/cli/delegated_routing_v1_http_proxy_test.go).
+This endpoint can be used by other Kubo instance, as illustrated in
+[`delegated_routing_v1_http_proxy_test.go`](https://github.com/ipfs/kubo/blob/master/test/cli/delegated_routing_v1_http_proxy_test.go).
+Kubo will skip routing results which are not actionable, for example, all
+graphsync providers will be skipped. If you need a generic pass-through, see
+standalone router implementation named [someguy](https://github.com/ipfs/someguy).
 
 Default: `false`
 


### PR DESCRIPTION
The way I see `/routing/v1` in Kubo is that it returns only results that other Kubo instance would find useful. 

In that framing, limiting results to actionable routing results, and skipping  things we know won't work, such as graphsync providers is **a feature, not a bug**.

If we are ok with this, and document it (this PR), we can close #10195.

Thoughts @aschmahmann  @2color @hacdias ?

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
