### PR TITLE
test: cleanup content blocking tests

### DIFF
--- a/test/cli/content_blocking_test.go
+++ b/test/cli/content_blocking_test.go
@@ -34,8 +34,8 @@ func TestContentBlocking(t *testing.T) {
 	node := h.NewNode().Init("--empty-repo", "--profile=test")
 
 	// Create CIDs we use in test
-	h.WriteFile("blocked-dir/subdir/indirectly-blocked-file.txt", "indirectly blocked file content")
-	parentDirCID := node.IPFS("add", "--raw-leaves", "-Q", "-r", filepath.Join(h.Dir, "blocked-dir")).Stdout.Trimmed()
+	h.WriteFile("parent-dir/blocked-subdir/indirectly-blocked-file.txt", "indirectly blocked file content")
+	parentDirCID := node.IPFS("add", "--raw-leaves", "-Q", "-r", filepath.Join(h.Dir, "parent-dir")).Stdout.Trimmed()
 
 	h.WriteFile("directly-blocked-file.txt", "directly blocked file content")
 	blockedCID := node.IPFS("add", "--raw-leaves", "-Q", filepath.Join(h.Dir, "directly-blocked-file.txt")).Stdout.Trimmed()
@@ -50,7 +50,7 @@ func TestContentBlocking(t *testing.T) {
 		"//8526ba05eec55e28f8db5974cc891d0d92c8af69d386fc6464f1e9f372caf549\n" + // Legacy CID double-hash block: sha256(bafkqahtcnrxwg23fmqqgi33vmjwgk2dbonuca3dfm5qwg6jamnuwicq/)
 		"//e5b7d2ce2594e2e09901596d8e1f29fa249b74c8c9e32ea01eda5111e4d33f07\n" + // Legacy Path double-hash block: sha256(bafyaagyscufaqalqaacauaqiaejao43vmjygc5didacauaqiae/subpath)
 		"/ipfs/" + blockedCID + "\n" + // block specific CID
-		"/ipfs/" + parentDirCID + "/subdir*\n" + // block only specific subpath
+		"/ipfs/" + parentDirCID + "/blocked-subdir*\n" + // block only specific subpath
 		"/ipns/blocked-cid.example.com\n" +
 		"/ipns/blocked-dnslink.example.com\n")
 
@@ -109,7 +109,7 @@ func TestContentBlocking(t *testing.T) {
 		},
 		{
 			name: "indirectly blocked file (on a blocked subpath)",
-			path: "/ipfs/" + parentDirCID + "/subdir/indirectly-blocked-file.txt",
+			path: "/ipfs/" + parentDirCID + "/blocked-subdir/indirectly-blocked-file.txt",
 		},
 		{
 			name: "/ipns path that resolves to a blocked CID",

--- a/test/cli/content_blocking_test.go
+++ b/test/cli/content_blocking_test.go
@@ -115,6 +115,34 @@ func TestContentBlocking(t *testing.T) {
 		assert.False(t, has)
 	})
 
+	/* TODO: this was already broken in 0.26, but we should fix it
+	t.Run("Gateway returns CAR without directly blocked CID", func(t *testing.T) {
+		allowedDirWithDirectlyBlockedCID := node.IPFS("add", "--raw-leaves", "-Q", "-rw", filepath.Join(h.Dir, "directly-blocked-file.txt")).Stdout.Trimmed()
+		resp := client.Get("/ipfs/" + allowedDirWithDirectlyBlockedCID + "?format=car")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		bs, err := carstore.NewReadOnly(strings.NewReader(resp.Body), nil)
+		assert.NoError(t, err)
+
+		has, err := bs.Has(context.Background(), cid.MustParse(blockedCID))
+		assert.NoError(t, err)
+		assert.False(t, has, "Returned CAR should not include blockedCID")
+	})
+	*/
+
+	// Confirm CAR responses skip blocked subpaths
+	t.Run("Gateway returns CAR without blocked subpath", func(t *testing.T) {
+		resp := client.Get("/ipfs/" + allowedParentDirCID + "/subdir?format=car")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		bs, err := carstore.NewReadOnly(strings.NewReader(resp.Body), nil)
+		assert.NoError(t, err)
+
+		has, err := bs.Has(context.Background(), cid.MustParse(blockedSubDirCID))
+		assert.NoError(t, err)
+		assert.False(t, has, "Returned CAR should not include blockedSubDirCID")
+	})
+
 	// Ok, now the full list of test cases we want to cover in both CLI and Gateway
 	testCases := []struct {
 		name string

--- a/test/cli/content_blocking_test.go
+++ b/test/cli/content_blocking_test.go
@@ -306,5 +306,17 @@ func TestContentBlocking(t *testing.T) {
 			assert.NotEqual(t, string(body), "directly blocked file content")
 			assert.Contains(t, string(body), blockedMsg, bodyExpl)
 		})
+
+		t.Run("Denies Blocked CID as CAR", func(t *testing.T) {
+			t.Parallel()
+			resp, err := libp2pClient.Get(fmt.Sprintf("/ipfs/%s?format=car", blockedCID))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusGone, resp.StatusCode, statusExpl)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.NotContains(t, string(body), "directly blocked file content")
+			assert.Contains(t, string(body), blockedMsg, bodyExpl)
+		})
 	})
 }


### PR DESCRIPTION
This is a small cleanup / refactor after reviewing draft from https://github.com/ipfs/kubo/pull/10359

I've found a bug in ?format=car, not a regression or a blocker – filled separate bug https://github.com/ipfs/kubo/issues/10361