### PR TITLE
docs: updated links and refs to external resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,7 +18,7 @@ body:
       label: Checklist
       description: Please verify that you've followed these steps
       options:
-        - label: This is a bug report, not a question. Ask questions on [discuss.ipfs.io](https://discuss.ipfs.io).
+        - label: This is a bug report, not a question. Ask questions on [discuss.ipfs.tech](https://discuss.ipfs.tech/c/help/13).
           required: true
         - label: I have searched on the [issue tracker](https://github.com/ipfs/kubo/issues?q=is%3Aissue) for my bug.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
  - name: Getting Help on IPFS
-   url: https://ipfs.io/help
+   url: https://ipfs.tech/help
    about: All information about how and where to get help on IPFS.
  - name: Kubo configuration reference
    url: https://github.com/ipfs/kubo/blob/master/docs/config.md#readme
@@ -9,9 +9,9 @@ contact_links:
  - name: Kubo experimental features docs
    url: https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md#readme
    about: Documentation on Private Networks, Filestore and other experimental features.
- - name: RPC API Reference
+ - name: Kubo RPC API Reference
    url: https://docs.ipfs.tech/reference/kubo/rpc/
    about: Documentation of all Kubo RPC API endpoints.
- - name: IPFS Official Forum
-   url: https://discuss.ipfs.io
+ - name: IPFS Official Discussion Forum
+   url: https://discuss.ipfs.tech
    about: Please post general questions, support requests, and discussions here.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -6,11 +6,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Suggest an enhancement to Kubo (the program). If you'd like to suggest an improvement to the IPFS protocol, please discuss it on [the forum](https://discuss.ipfs.io).
+        Suggest an enhancement to Kubo (the program). If you'd like to suggest an improvement to the IPFS protocol, please discuss it on [the forum](https://discuss.ipfs.tech).
 
         Issues in this repo must be specific, actionable, and well motivated. They should be starting points for _building_ new features, not brainstorming ideas.
 
-        If you have an idea you'd like to discuss, please open a new thread on [the forum](https://discuss.ipfs.io).
+        If you have an idea you'd like to discuss, please open a new thread on [the forum](https://discuss.ipfs.tech).
 
         **Example:**
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,11 +6,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Suggest a new feature in Kubo (the program). If you'd like to suggest an improvement to the IPFS protocol, please discuss it on [the forum](https://discuss.ipfs.io).
+        Suggest a new feature in Kubo (the program). If you'd like to suggest an improvement to the IPFS protocol, please discuss it on [the forum](https://discuss.ipfs.tech).
 
         Issues in this repo must be specific, actionable, and well motivated. They should be starting points for _building_ new features, not brainstorming ideas.
 
-        If you have an idea you'd like to discuss, please open a new thread on [the forum](https://discuss.ipfs.io).
+        If you have an idea you'd like to discuss, please open a new thread on [the forum](https://discuss.ipfs.tech).
 
         **Example:**
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,24 @@ Official images are published at https://hub.docker.com/r/ipfs/kubo/:
 
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/ipfs/kubo?color=blue&label=kubo%20docker%20image&logo=docker&sort=semver&style=flat-square&cacheSeconds=3600)](https://hub.docker.com/r/ipfs/kubo/)
 
-More info on how to run Kubo (go-ipfs) inside Docker can be found [here](https://docs.ipfs.tech/how-to/run-ipfs-inside-docker/).
+- 🟢 Releases
+  - `latest` and `release` tags always point at [the latest stable release](https://github.com/ipfs/kubo/releases/latest)
+  - `vN.N.N` points at a specific [release tag](https://github.com/ipfs/kubo/releases)
+  - These are production grade images.
+- 🟠 We also provide experimental developer builds
+  - `master-latest` always points at the `HEAD` of the `master` branch
+  - `master-YYYY-DD-MM-GITSHA` points at a specific commit from the `master` branch
+  - These tags are used by developers for internal testing, not intended for end users or production use.
+
+```console
+$ docker pull ipfs/kubo:latest
+$ docker run --rm -it --net=host ipfs/kubo:latest
+```
+
+To [customize your node](https://docs.ipfs.tech/install/run-ipfs-inside-docker/#customizing-your-node),
+pass necessary config via `-e` or by mounting scripts in the `/container-init.d`.
+
+Learn more at https://docs.ipfs.tech/install/run-ipfs-inside-docker/
 
 ### Official prebuilt binaries
 
@@ -428,7 +445,9 @@ We ❤️ all [our contributors](docs/AUTHORS); this project wouldn’t be what 
 
 This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
-Please reach out to us in one [chat](https://docs.ipfs.tech/community/chat/) rooms.
+Members of IPFS community provide Kubo support on [discussion forum category here](https://discuss.ipfs.tech/c/help/help-kubo/23).
+
+Need help with IPFS itself? Learn where to get help and support at https://ipfs.tech/help.
 
 ## License
 

--- a/cmd/ipfs/dist/README.md
+++ b/cmd/ipfs/dist/README.md
@@ -1,6 +1,7 @@
 # ipfs command line tool
 
-This is the [ipfs](http://ipfs.io) command line tool. It contains a full ipfs node.
+This is a [command line tool for interacting with Kubo](https://docs.ipfs.tech/install/command-line/),
+an [IPFS](https://ipfs.tech) implementation. It contains a full IPFS node.
 
 ## Install
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -90,7 +90,7 @@ This section covers tasks to be done during each release.
   - [ ] create and merge the PR which updates `dists/kubo/versions` and `dists/go-ipfs/versions` (![](https://img.shields.io/badge/only-FINAL-green?style=flat-square) and `dists/kubo/current_version` and `dists/go-ipfs/current_version`)
     - [example](https://github.com/ipfs/distributions/pull/760)
   - [ ] wait for the [CI](https://github.com/ipfs/distributions/actions/workflows/main.yml) workflow run initiated by the merge to master to finish
-  - [ ] verify the release is available on [dist.ipfs.io](https://dist.ipfs.io/#kubo)
+  - [ ] verify the release is available on [dist.ipfs.tech](https://dist.ipfs.tech/#kubo)
   </details>
 - [ ] Publish the release to [NPM](https://www.npmjs.com/package/go-ipfs?activeTab=versions) <details><summary>using `./kuboreleaser release --version vX.Y.Z(-rcN) publish-to-npm` (⚠️ you might need to run the command a couple of times because GHA might not be able to see the new distribution straight away due to caching) or ...</summary>
   - [ ] run the [Release to npm](https://github.com/ipfs/npm-go-ipfs/actions/workflows/main.yml) workflow

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -13,7 +13,9 @@ Kubo's Gateway implementation follows [ipfs/specs: Specification for HTTP Gatewa
 By default, Kubo nodes run
 a [path gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway) at `http://127.0.0.1:8080/`
 and a [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://localhost:8080/`.
-Both support [trustless responses](https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval) as opt-in via `Accept` header.
+
+The path one also implements [trustless gateway spec](https://specs.ipfs.tech/http-gateways/trustless-gateway/)
+and supports [trustless responses](https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval) as opt-in via `Accept` header.
 
 Additional listening addresses and gateway behaviors can be set in the [config](#configuration) file.
 
@@ -65,7 +67,7 @@ Gateway](https://dnslink.dev/#example-ipfs-gateway) for instructions.
 When downloading files, browsers will usually guess a file's filename by looking
 at the last component of the path. Unfortunately, when linking *directly* to a
 file (with no containing directory), the final component is just a CID
-(`Qm...`). This isn't exactly user-friendly.
+(`bafy..` or `Qm...`). This isn't exactly user-friendly.
 
 To work around this issue, you can add a `filename=some_filename` parameter to
 your query string to explicitly specify the filename. For example:
@@ -89,6 +91,11 @@ or by sending `Accept: application/vnd.ipld.{format}` HTTP header with one of su
 
 ## Content-Types
 
+Majority of resources can be retrieved trustlessly by requesting specific content type via `Accept` header or `?format=raw|car|ipns-record` URL query parameter.
+
+See [trustless gateway specification](https://specs.ipfs.tech/http-gateways/trustless-gateway/)
+and [verifiable retrieval documentation](https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval) for more details.
+
 ### `application/vnd.ipld.raw`
 
 Returns a byte array for a single `raw` block.
@@ -106,3 +113,10 @@ Right now only 'full DAG' implicit selector is implemented.
 Support for user-provided IPLD selectors is tracked in https://github.com/ipfs/kubo/issues/8769.
 
 This is a rough equivalent of `ipfs dag export`.
+
+### `application/vnd.ipfs.ipns-record`
+
+Only works on `/ipns/{ipns-name}` content paths that use cryptographically signed [IPNS Records](https://specs.ipfs.tech/ipns/ipns-record/).
+
+Returns [IPNS Record in Protobuf Serialization Format](https://specs.ipfs.tech/ipns/ipns-record/#record-serialization-format)
+which can be verified on end client, without trusting gateway.

--- a/docs/http-rpc-clients.md
+++ b/docs/http-rpc-clients.md
@@ -6,3 +6,8 @@ Kubo provides official HTTP RPC  (`/api/v0`) clients for selected languages:
 |:--------:|:-------------------:|--------------------------------------------|
 | JS       | kubo-rpc-client     | https://github.com/ipfs/js-kubo-rpc-client |
 | Go       | `rpc`               | [`../client/rpc`](../client/rpc)           |
+
+There are community-maintained libraries for other languages,
+but the Kubo team does provide support for them, YMMV:
+
+- https://docs.ipfs.tech/reference/kubo-rpc-cli/

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -153,6 +153,6 @@ If you get authentication problems with Git, you might want to take a look at ht
 `git config --global credential.helper wincred`
 
 - **Anything else**  
-Please search [https://discuss.ipfs.io](https://discuss.ipfs.io/search?q=windows%20category%3A13) for any additional issues you may encounter. If you can't find any existing resolution, feel free to post a question asking for help.
+Please search [https://discuss.ipfs.tech](https://discuss.ipfs.tech/search?q=windows%20category%3A13) for any additional issues you may encounter. If you can't find any existing resolution, feel free to post a question asking for help.
 
 If you encounter a bug with `kubo` itself (not related to building) please use the [issue tracker](https://github.com/ipfs/kubo/issues) to report it.


### PR DESCRIPTION
Bunch of cosmetic docs fixes and improvement I had accumulated in local branch:
- `discuss.ipfs.io` → `discuss.ipfs.tech`
- improved Docker section in README
- added links to some specs, in relevant places