### PR TITLE
Cleanup old workaround for libp2phttp

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -930,10 +930,6 @@ func serveTrustlessGatewayOverLibp2p(cctx *oldcmds.Context) (<-chan error, error
 		StreamHost: node.PeerHost,
 	}
 
-	tmpProtocol := protocol.ID("/kubo/delete-me")
-	h.SetHTTPHandler(tmpProtocol, http.NotFoundHandler())
-	h.WellKnownHandler.RemoveProtocolMeta(tmpProtocol)
-
 	h.WellKnownHandler.AddProtocolMeta(gatewayProtocolID, p2phttp.ProtocolMeta{Path: "/"})
 	h.ServeMux = http.NewServeMux()
 	h.ServeMux.Handle("/", handler)


### PR DESCRIPTION
While reviewing Kubo's usage here I found this workaround for an issue I introduced initially (Sorry!).

Now that Kubo is on the latest go-libp2p, the workaround is no longer needed.