### PR TITLE
docs: update default ipns lifetime

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1130,7 +1130,7 @@ Type: `interval` or an empty string for the default.
 A time duration specifying the value to set on ipns records for their validity
 lifetime.
 
-Default: 24 hours.
+Default: 48 hours.
 
 Type: `interval` or an empty string for the default.
 


### PR DESCRIPTION
Updates the docs for the default lifetime based on the Boxo defaults

https://github.com/ipfs/boxo/blob/2559ec2c7b93ac6905fe83d7a4b38b8e9a703b0a/ipns/defaults.go#L10-L16