### PR TITLE
fix: switch lowpower profile to autoclient

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -174,7 +174,7 @@ functionality - performance of content discovery and data
 fetching may be degraded.
 `,
 		Transform: func(c *Config) error {
-			c.Routing.Type = NewOptionalString("dhtclient") // TODO: https://github.com/ipfs/kubo/issues/9480
+			c.Routing.Type = NewOptionalString("autoclient")
 			c.AutoNAT.ServiceMode = AutoNATServiceDisabled
 			c.Reprovider.Interval = NewOptionalDuration(0)
 


### PR DESCRIPTION
We missed this in https://github.com/ipfs/kubo/pull/9708

Closes #9480 (no need for delay, even when HTTP and DHT are raced, lowpower benefits from cached HTTP responses)