### PR TITLE
chore: webui v4.2.1

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,11 +1,12 @@
 package corehttp
 
-// TODO: move to IPNS
-const WebUIPath = "/ipfs/bafybeidf7cpkwsjkq6xs3r6fbbxghbugilx3jtezbza7gua3k5wjixpmba" // v4.2.0
+// WebUI version confirmed to work with this Kubo version
+const WebUIPath = "/ipfs/bafybeigggyffcf6yfhx5irtwzx3cgnk6n3dwylkvcpckzhqqrigsxowjwe" // v4.2.1
 
 // WebUIPaths is a list of all past webUI paths.
 var WebUIPaths = []string{
 	WebUIPath,
+	"/ipfs/bafybeidf7cpkwsjkq6xs3r6fbbxghbugilx3jtezbza7gua3k5wjixpmba",
 	"/ipfs/bafybeiamycmd52xvg6k3nzr6z3n33de6a2teyhquhj4kspdtnvetnkrfim",
 	"/ipfs/bafybeieqdeoqkf7xf4aozd524qncgiloh33qgr25lyzrkusbcre4c3fxay",
 	"/ipfs/bafybeicyp7ssbnj3hdzehcibmapmpuc3atrsc4ch3q6acldfh4ojjdbcxe",


### PR DESCRIPTION
Patch release that removes unnecessary requests to countly.ipfs.io which is no longer online

https://github.com/ipfs/ipfs-webui/releases/tag/v4.2.1


@hacdias ok to include in [0.28 RC1](https://github.com/ipfs/kubo/issues/10353)? 

