### PR TITLE
fix: divide by zero fatal crash for reprovide rate check

### DIFF
--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -83,7 +83,11 @@ https://github.com/ipfs/kubo/blob/master/docs/config.md#routingaccelerateddhtcli
 					}
 
 					// How long per block that lasts us.
-					expectedProvideSpeed := reprovideInterval / time.Duration(count)
+					expectedProvideSpeed := reprovideInterval
+					if count > 0 {
+						expectedProvideSpeed = reprovideInterval / time.Duration(count)
+					}
+					
 					if avgProvideSpeed > expectedProvideSpeed {
 						logger.Errorf(`
 🔔🔔🔔 YOU ARE FALLING BEHIND DHT REPROVIDES! 🔔🔔🔔

--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -87,7 +87,7 @@ https://github.com/ipfs/kubo/blob/master/docs/config.md#routingaccelerateddhtcli
 					if count > 0 {
 						expectedProvideSpeed = reprovideInterval / time.Duration(count)
 					}
-					
+
 					if avgProvideSpeed > expectedProvideSpeed {
 						logger.Errorf(`
 🔔🔔🔔 YOU ARE FALLING BEHIND DHT REPROVIDES! 🔔🔔🔔


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

While I was running kubo on my instance, I was encountering somewhat frequent crashes of the process with the following stack trace:
```
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.331332+00:00 cannon-repo-snap-154780564-4013d1 systemd[1]: ipfs.service: Consumed 5min 27.300s CPU time.
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.331245+00:00 cannon-repo-snap-154780564-4013d1 systemd[1]: ipfs.service: Failed with result 'exit-code'.
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.330698+00:00 cannon-repo-snap-154780564-4013d1 systemd[1]: ipfs.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.296960+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: #011github.com/ipfs/boxo@v0.13.1/provider/reprovider.go:227 +0x88
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.296912+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: created by github.com/ipfs/boxo/provider.(*reprovider).run in goroutine 1
2024-04-25 20:41:17.361	
repo-sgp1                |                         | 2024-04-25T11:41:17.296775+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: #011github.com/ipfs/boxo@v0.13.1/provider/reprovider.go:373 +0x9f3

2024-04-25 20:41:17.361	
2024-04-25T11:41:17.296775+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: #011github.com/ipfs/boxo@v0.13.1/provider/reprovider.go:373 +0x9f3

2024-04-25 20:41:17.361	
2024-04-25T11:41:17.296741+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: github.com/ipfs/boxo/provider.(*reprovider).run.func1()
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.296704+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: #011github.com/ipfs/kubo@v0.23.0/core/node/provider.go:86 +0x535
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.296656+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: github.com/ipfs/kubo/core/node.ProviderSys.func1.1(0x0?, 0x0?, 0x80, 0x0?)
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.296583+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: goroutine 677 [running]:
2024-04-25 20:41:17.361	
2024-04-25T11:41:17.295863+00:00 cannon-repo-snap-154780564-4013d1 ipfs[23032]: panic: runtime error: integer divide by zero
```

I followed the stack trace to find the area where divide by 0 occurs. The solution seemed simple enough, so I went ahead and opened this PR with a simple change. I'm guessing that having a `0` count for reprovide is pretty bad, but will deal with that separately.

BTW I am not a go dev. My apologies if my solution seems too simplistic or a better way exists.

BTW it wasnt clear to me how/where I should update the changelog for this minor change. Please lmk. Thanks!