### PR TITLE
feat: enables searching pins by name

### DIFF
--- a/core/commands/pin/pin.go
+++ b/core/commands/pin/pin.go
@@ -362,6 +362,7 @@ Example:
 		cmds.BoolOption(pinQuietOptionName, "q", "Write just hashes of objects."),
 		cmds.BoolOption(pinStreamOptionName, "s", "Enable streaming of pins as they are discovered."),
 		cmds.BoolOption(pinNamesOptionName, "n", "Enable displaying pin names (slower)."),
+		cmds.StringOption(pinNameOptionName, "Display only pins with the given name."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
@@ -372,6 +373,7 @@ Example:
 		typeStr, _ := req.Options[pinTypeOptionName].(string)
 		stream, _ := req.Options[pinStreamOptionName].(bool)
 		displayNames, _ := req.Options[pinNamesOptionName].(bool)
+		name, _ := req.Options[pinNameOptionName].(string)
 
 		switch typeStr {
 		case "all", "direct", "indirect", "recursive":
@@ -397,7 +399,7 @@ Example:
 		if len(req.Arguments) > 0 {
 			err = pinLsKeys(req, typeStr, api, emit)
 		} else {
-			err = pinLsAll(req, typeStr, displayNames, api, emit)
+			err = pinLsAll(req, typeStr, displayNames || name != "", name, api, emit)
 		}
 		if err != nil {
 			return err
@@ -537,7 +539,7 @@ func pinLsKeys(req *cmds.Request, typeStr string, api coreiface.CoreAPI, emit fu
 	return nil
 }
 
-func pinLsAll(req *cmds.Request, typeStr string, detailed bool, api coreiface.CoreAPI, emit func(value PinLsOutputWrapper) error) error {
+func pinLsAll(req *cmds.Request, typeStr string, detailed bool, name string, api coreiface.CoreAPI, emit func(value PinLsOutputWrapper) error) error {
 	enc, err := cmdenv.GetCidEncoder(req)
 	if err != nil {
 		return err
@@ -555,7 +557,7 @@ func pinLsAll(req *cmds.Request, typeStr string, detailed bool, api coreiface.Co
 		panic("unhandled pin type")
 	}
 
-	pins, err := api.Pin().Ls(req.Context, opt, options.Pin.Ls.Detailed(detailed))
+	pins, err := api.Pin().Ls(req.Context, opt, options.Pin.Ls.Detailed(detailed), options.Pin.Ls.Name(name))
 	if err != nil {
 		return err
 	}

--- a/core/commands/pin/pin.go
+++ b/core/commands/pin/pin.go
@@ -362,7 +362,7 @@ Example:
 		cmds.BoolOption(pinQuietOptionName, "q", "Write just hashes of objects."),
 		cmds.BoolOption(pinStreamOptionName, "s", "Enable streaming of pins as they are discovered."),
 		cmds.BoolOption(pinNamesOptionName, "n", "Enable displaying pin names (slower)."),
-		cmds.StringOption(pinNameOptionName, "Display only pins with the given name."),
+		cmds.StringOption(pinNameOptionName, "Display pins with names that contain the value provided (case-sensitive, exact match)."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)

--- a/core/coreapi/pin.go
+++ b/core/coreapi/pin.go
@@ -282,7 +282,7 @@ func (api *PinAPI) pinLsAll(ctx context.Context, typeStr string, detailed bool, 
 	emittedSet := cid.NewSet()
 
 	AddToResultKeys := func(c cid.Cid, pinName, typeStr string) error {
-		if emittedSet.Visit(c) && (name == "" || name == pinName) {
+		if emittedSet.Visit(c) && (name == "" || strings.Contains(pinName, name)) {
 			select {
 			case out <- &pinInfo{
 				pinType: typeStr,

--- a/core/coreapi/pin.go
+++ b/core/coreapi/pin.go
@@ -3,6 +3,7 @@ package coreapi
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	bserv "github.com/ipfs/boxo/blockservice"
 	offline "github.com/ipfs/boxo/exchange/offline"

--- a/core/coreiface/options/pin.go
+++ b/core/coreiface/options/pin.go
@@ -12,6 +12,7 @@ type PinAddSettings struct {
 type PinLsSettings struct {
 	Type     string
 	Detailed bool
+	Name     string
 }
 
 // PinIsPinnedSettings represent the settings for PinAPI.IsPinned
@@ -201,6 +202,13 @@ func (pinLsOpts) pinType(t string) PinLsOption {
 func (pinLsOpts) Detailed(detailed bool) PinLsOption {
 	return func(settings *PinLsSettings) error {
 		settings.Detailed = detailed
+		return nil
+	}
+}
+
+func (pinLsOpts) Name(name string) PinLsOption {
+	return func(settings *PinLsSettings) error {
+		settings.Name = name
 		return nil
 	}
 }

--- a/docs/changelogs/v0.29.md
+++ b/docs/changelogs/v0.29.md
@@ -6,12 +6,16 @@
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
+  - [Add search functionality for pin names](#add-search-functionality-for-pin-names)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
 ### Overview
 
 ### 🔦 Highlights
+
+#### Add search functionality for pin names
+It is now possible to search for pins by name. To do so, use `ipfs pin ls --name "SomeName"`. The search is case-sensitive and will return all pins with the exact name provided.
 
 ### 📝 Changelog
 

--- a/docs/changelogs/v0.29.md
+++ b/docs/changelogs/v0.29.md
@@ -15,7 +15,7 @@
 ### 🔦 Highlights
 
 #### Add search functionality for pin names
-It is now possible to search for pins by name. To do so, use `ipfs pin ls --name "SomeName"`. The search is case-sensitive and will return all pins with the exact name provided.
+It is now possible to search for pins by name. To do so, use `ipfs pin ls --name "SomeName"`. The search is case-sensitive and will return all pins having a name which contains the exact word provided.
 
 ### 📝 Changelog
 

--- a/docs/changelogs/v0.29.md
+++ b/docs/changelogs/v0.29.md
@@ -15,6 +15,7 @@
 ### 🔦 Highlights
 
 #### Add search functionality for pin names
+
 It is now possible to search for pins by name. To do so, use `ipfs pin ls --name "SomeName"`. The search is case-sensitive and will return all pins having a name which contains the exact word provided.
 
 ### 📝 Changelog

--- a/test/cli/pins_test.go
+++ b/test/cli/pins_test.go
@@ -242,6 +242,43 @@ func TestPins(t *testing.T) {
 		require.NotContains(t, lsOut, outADetailed)
 	})
 
+	t.Run("test listing pins with specific name", func(t *testing.T) {
+		print("test pinning with names cli text output")
+		t.Parallel()
+
+		node := harness.NewT(t).NewNode().Init()
+		cidAStr := node.IPFSAddStr(RandomStr(1000), "--pin=false")
+		cidBStr := node.IPFSAddStr(RandomStr(1000), "--pin=false")
+		cidCStr := node.IPFSAddStr(RandomStr(1000), "--pin=false")
+
+		outA := cidAStr + " recursive testPin"
+		outB := cidBStr + " recursive testPin"
+		outC := cidCStr + " recursive randPin"
+
+		_ = node.IPFS("pin", "add", "--name", "testPin", cidAStr)
+		lsOut := pinLs(node, "-t=recursive", "--name=testPin")
+		require.Contains(t, lsOut, outA)
+		lsOut = pinLs(node, "-t=recursive", "--name=randomLabel")
+		require.NotContains(t, lsOut, outA)
+
+		_ = node.IPFS("pin", "add", "--name", "testPin", cidBStr)
+		lsOut = pinLs(node, "-t=recursive", "--name=testPin")
+		require.Contains(t, lsOut, outA)
+		require.Contains(t, lsOut, outB)
+
+		_ = node.IPFS("pin", "add", "--name", "randPin", cidCStr)
+		lsOut = pinLs(node, "-t=recursive", "--name=randPin")
+		require.NotContains(t, lsOut, outA)
+		require.NotContains(t, lsOut, outB)
+		require.Contains(t, lsOut, outC)
+
+		lsOut = pinLs(node, "-t=recursive", "--name=testPin")
+		require.Contains(t, lsOut, outA)
+		require.Contains(t, lsOut, outB)
+		require.NotContains(t, lsOut, outC)
+
+	})
+
 	t.Run("test overwriting pin with name", func(t *testing.T) {
 		t.Parallel()
 

--- a/test/cli/pins_test.go
+++ b/test/cli/pins_test.go
@@ -243,7 +243,6 @@ func TestPins(t *testing.T) {
 	})
 
 	t.Run("test listing pins which contains specific name", func(t *testing.T) {
-		print("test pinning with names cli text output")
 		t.Parallel()
 
 		node := harness.NewT(t).NewNode().Init()
@@ -276,7 +275,6 @@ func TestPins(t *testing.T) {
 		require.Contains(t, lsOut, outA)
 		require.Contains(t, lsOut, outB)
 		require.NotContains(t, lsOut, outC)
-
 	})
 
 	t.Run("test overwriting pin with name", func(t *testing.T) {

--- a/test/cli/pins_test.go
+++ b/test/cli/pins_test.go
@@ -242,7 +242,7 @@ func TestPins(t *testing.T) {
 		require.NotContains(t, lsOut, outADetailed)
 	})
 
-	t.Run("test listing pins with specific name", func(t *testing.T) {
+	t.Run("test listing pins which contains specific name", func(t *testing.T) {
 		print("test pinning with names cli text output")
 		t.Parallel()
 
@@ -256,18 +256,18 @@ func TestPins(t *testing.T) {
 		outC := cidCStr + " recursive randPin"
 
 		_ = node.IPFS("pin", "add", "--name", "testPin", cidAStr)
-		lsOut := pinLs(node, "-t=recursive", "--name=testPin")
+		lsOut := pinLs(node, "-t=recursive", "--name=test")
 		require.Contains(t, lsOut, outA)
 		lsOut = pinLs(node, "-t=recursive", "--name=randomLabel")
 		require.NotContains(t, lsOut, outA)
 
 		_ = node.IPFS("pin", "add", "--name", "testPin", cidBStr)
-		lsOut = pinLs(node, "-t=recursive", "--name=testPin")
+		lsOut = pinLs(node, "-t=recursive", "--name=test")
 		require.Contains(t, lsOut, outA)
 		require.Contains(t, lsOut, outB)
 
 		_ = node.IPFS("pin", "add", "--name", "randPin", cidCStr)
-		lsOut = pinLs(node, "-t=recursive", "--name=randPin")
+		lsOut = pinLs(node, "-t=recursive", "--name=rand")
 		require.NotContains(t, lsOut, outA)
 		require.NotContains(t, lsOut, outB)
 		require.Contains(t, lsOut, outC)


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
Closes #10281.

This PR introduces the possibility to perform a search on pin names (case-sensitive, exact search). The command `ipfs pin ls --name "pinName"` will return all the pins labeled as `pinName`.

Notes:
- The  [condition](https://github.com/ipfs/kubo/compare/master...gystemd:feat/cmd/pin-name?expand=1#diff-095e9f00f8915b84abaca1d8f94c5d557ab78dc205fa217842679fb12dfd036fR402) `displayNames || name != ""`  is implemented to prevent redundancy in specifying the `--name `option. This ensures that users can simply use `ipfs ls --name A `instead of `ipfs ls --names --name A`.