### PR TITLE
config: introduce Import section

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Experimental Experiments
 	Plugins      Plugins
 	Pinning      Pinning
+	Import       Import
 
 	Internal Internal // experimental/unstable options
 }

--- a/config/import.go
+++ b/config/import.go
@@ -1,0 +1,17 @@
+package config
+
+const (
+	DefaultCidVersion      = 0
+	DefaultUnixFSRawLeaves = false
+	DefaultUnixFSChunker   = "size-262144"
+	DefaultHashFunction    = "sha2-256"
+)
+
+// Import configures the default options for ingesting data. This affects commands
+// that ingest data, such as 'ipfs add', 'ipfs dag put, 'ipfs block put', 'ipfs files write'.
+type Import struct {
+	CidVersion      OptionalInteger
+	UnixFSRawLeaves Flag
+	UnixFSChunker   OptionalString
+	HashFunction    OptionalString
+}

--- a/config/profile.go
+++ b/config/profile.go
@@ -204,6 +204,28 @@ fetching may be degraded.
 			return nil
 		},
 	},
+	"legacy-cid-v0": {
+		Description: `Makes UnixFS import produce legacy CIDv0 with no raw leaves, sha2-256 and 256 KiB chunks.`,
+
+		Transform: func(c *Config) error {
+			c.Import.CidVersion = *NewOptionalInteger(0)
+			c.Import.UnixFSRawLeaves = False
+			c.Import.UnixFSChunker = *NewOptionalString("size-262144")
+			c.Import.HashFunction = *NewOptionalString("sha2-256")
+			return nil
+		},
+	},
+	"test-cid-v1": {
+		Description: `Makes UnixFS import produce modern CIDv1 with raw leaves, sha2-256 and 1 MiB chunks.`,
+
+		Transform: func(c *Config) error {
+			c.Import.CidVersion = *NewOptionalInteger(1)
+			c.Import.UnixFSRawLeaves = True
+			c.Import.UnixFSChunker = *NewOptionalString("size-1048576")
+			c.Import.HashFunction = *NewOptionalString("sha2-256")
+			return nil
+		},
+	},
 }
 
 func getAvailablePort() (port int, err error) {

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -87,7 +87,7 @@ into an object of the specified format.
 		cmds.StringOption("store-codec", "Codec that the stored object will be encoded with").WithDefault("dag-cbor"),
 		cmds.StringOption("input-codec", "Codec that the input object is encoded in").WithDefault("dag-json"),
 		cmds.BoolOption("pin", "Pin this object when adding."),
-		cmds.StringOption("hash", "Hash function to use").WithDefault("sha2-256"),
+		cmds.StringOption("hash", "Hash function to use"),
 		cmdutils.AllowBigBlockOption,
 	},
 	Run:  dagPut,

--- a/core/commands/dag/put.go
+++ b/core/commands/dag/put.go
@@ -7,6 +7,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	ipldlegacy "github.com/ipfs/go-ipld-legacy"
+	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core/commands/cmdenv"
 	"github.com/ipfs/kubo/core/commands/cmdutils"
 	"github.com/ipld/go-ipld-prime/multicodec"
@@ -32,10 +33,24 @@ func dagPut(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) e
 		return err
 	}
 
+	nd, err := cmdenv.GetNode(env)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := nd.Repo.Config()
+	if err != nil {
+		return err
+	}
+
 	inputCodec, _ := req.Options["input-codec"].(string)
 	storeCodec, _ := req.Options["store-codec"].(string)
 	hash, _ := req.Options["hash"].(string)
 	dopin, _ := req.Options["pin"].(bool)
+
+	if hash == "" {
+		hash = cfg.Import.HashFunction.WithDefault(config.DefaultHashFunction)
+	}
 
 	var icodec mc.Code
 	if err := icodec.Set(inputCodec); err != nil {

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/core/commands/cmdenv"
 
@@ -802,18 +803,28 @@ See '--to-files' in 'ipfs add --help' for more information.
 			return err
 		}
 
+		nd, err := cmdenv.GetNode(env)
+		if err != nil {
+			return err
+		}
+
+		cfg, err := nd.Repo.Config()
+		if err != nil {
+			return err
+		}
+
 		create, _ := req.Options[filesCreateOptionName].(bool)
 		mkParents, _ := req.Options[filesParentsOptionName].(bool)
 		trunc, _ := req.Options[filesTruncateOptionName].(bool)
 		flush, _ := req.Options[filesFlushOptionName].(bool)
 		rawLeaves, rawLeavesDef := req.Options[filesRawLeavesOptionName].(bool)
 
-		prefix, err := getPrefixNew(req)
-		if err != nil {
-			return err
+		if !rawLeavesDef && cfg.Import.UnixFSRawLeaves != config.Default {
+			rawLeavesDef = true
+			rawLeaves = cfg.Import.UnixFSRawLeaves.WithDefault(config.DefaultUnixFSRawLeaves)
 		}
 
-		nd, err := cmdenv.GetNode(env)
+		prefix, err := getPrefixNew(req)
 		if err != nil {
 			return err
 		}

--- a/docs/changelogs/v0.29.md
+++ b/docs/changelogs/v0.29.md
@@ -7,6 +7,7 @@
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [Add search functionality for pin names](#add-search-functionality-for-pin-names)
+  - [Customizing `ipfs add` defaults](#customizing-ipfs-add-defaults)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -18,9 +19,15 @@
 
 It is now possible to search for pins by name. To do so, use `ipfs pin ls --name "SomeName"`. The search is case-sensitive and will return all pins having a name which contains the exact word provided.
 
-#### Global configuration for data ingestion
+#### Customizing `ipfs add` defaults
 
-A new configuration section, `Import`, was introduced. This section allows to override the default values of options used across several commands that do data ingestion. Read more in the [config documentation](../config.md).
+This release supports overriding global data ingestion defaults used by commands like `ipfs add` via user-defined [`Import.*` configuration options](../config.md#import).
+The hash function, CID version, or UnixFS raw leaves and chunker behaviors can be set once, and used as the new implicit default for `ipfs add`.
+
+> [!TIP]
+> As a convenience, two CID [profiles](../config.md#profile) are provided: `legacy-cid-v0` and `test-cid-v1`.
+> A test profile that defaults to modern CIDv1 can be applied via `ipfs config profile apply test-cid-v1`.
+> We encourage users to try it and report any issues.
 
 ### 📝 Changelog
 

--- a/docs/changelogs/v0.29.md
+++ b/docs/changelogs/v0.29.md
@@ -18,6 +18,10 @@
 
 It is now possible to search for pins by name. To do so, use `ipfs pin ls --name "SomeName"`. The search is case-sensitive and will return all pins having a name which contains the exact word provided.
 
+#### Global configuration for data ingestion
+
+A new configuration section, `Import`, was introduced. This section allows to override the default values of options used across several commands that do data ingestion. Read more in the [config documentation](../config.md).
+
 ### 📝 Changelog
 
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/config.md
+++ b/docs/config.md
@@ -175,6 +175,11 @@ config file at runtime.
   - [`DNS`](#dns)
     - [`DNS.Resolvers`](#dnsresolvers)
     - [`DNS.MaxCacheTTL`](#dnsmaxcachettl)
+  - [`Import`](#import)
+    - [`Import.CidVersion`](#importcidversion)
+    - [`Import.UnixFSRawLeaves`](#importunixfsrawleaves)
+    - [`Import.UnixFSChunker`](#importunixfschunker)
+    - [`Import.HashFunction`](#importhashfunction)
 
 ## Profiles
 
@@ -2377,3 +2382,42 @@ Note: this does NOT work with Go's default DNS resolver. To make this a global s
 Default: Respect DNS Response TTL
 
 Type: `optionalDuration`
+
+## `Import`
+
+Options to configure the default options used for ingesting data, in commands such as `ipfs add` or `ipfs block put`. All affected commands are detailed per option.
+
+Note that using flags will override the options defined here.
+
+### `Import.CidVersion`
+
+The default CID version. Commands affected: `ipfs add`.
+
+Default: `0`
+
+Type: `optionalInteger`
+
+### `Import.UnixFSRawLeaves`
+
+The default UnixFS raw leaves option. Commands affected: `ipfs add`, `ipfs files write`.
+
+Default: `false`
+
+Type: `flag`
+
+### `Import.UnixFSChunker`
+
+The default UnixFS chunker. Commands affected: `ipfs add`.
+
+Default: `size-262144`
+
+Type: `optionalString`
+
+
+### `Import.HashFunction`
+
+The default hash function. Commands affected: `ipfs add`, `ipfs block put`, `ipfs dag put`.
+
+Default: `sha2-256`
+
+Type: `optionalString`

--- a/docs/config.md
+++ b/docs/config.md
@@ -270,6 +270,21 @@ documented in `ipfs config profile --help`.
 
   Use this profile with caution.
 
+- `legacy-cid-v0`
+
+  Makes UnixFS import (`ipfs add`) produce legacy CIDv0 with no raw leaves, sha2-256 and 256 KiB chunks.
+
+  > [!WARNING]
+  > This profile is provided for legacy users and should not be used for new projects.
+
+- `test-cid-v1`
+
+  Makes UnixFS import (`ipfs add`) produce modern CIDv1 with raw leaves, sha2-256 and 1 MiB chunks.
+
+  > [!NOTE]
+  > This profile will become the new implicit default, provided for testing purposes.
+  > Follow [kubo#4143](https://github.com/ipfs/kubo/issues/4143) for more details.
+
 ## Types
 
 This document refers to the standard JSON types (e.g., `null`, `string`,
@@ -2401,7 +2416,7 @@ Type: `optionalInteger`
 
 The default UnixFS raw leaves option. Commands affected: `ipfs add`, `ipfs files write`.
 
-Default: `false`
+Default: `false` if `CidVersion=0`; `true` if `CidVersion=1`
 
 Type: `flag`
 
@@ -2412,7 +2427,6 @@ The default UnixFS chunker. Commands affected: `ipfs add`.
 Default: `size-262144`
 
 Type: `optionalString`
-
 
 ### `Import.HashFunction`
 

--- a/test/cli/add_test.go
+++ b/test/cli/add_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/ipfs/kubo/config"
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdd(t *testing.T) {
+	t.Parallel()
+
+	var (
+		shortString            = "hello world"
+		shortStringCidV0       = "Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD"
+		shortStringCidV1       = "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e"
+		shortStringCidV1Sha512 = "bafkrgqbqt3gerhas23vuzrapkdeqf4vu2dwxp3srdj6hvg6nhsug2tgyn6mj3u23yx7utftq3i2ckw2fwdh5qmhid5qf3t35yvkc5e5ottlw6"
+	)
+
+	t.Run("output cid version: default (CIDv0)", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init().StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString)
+		require.Equal(t, shortStringCidV0, cidStr)
+	})
+
+	t.Run("output cid version: follows configuration (CIDv0)", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init()
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.Import.CidVersion = *config.NewOptionalInteger(0)
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString)
+		require.Equal(t, shortStringCidV0, cidStr)
+	})
+
+	t.Run("output cid version: follows configuration (hash function)", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init()
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.Import.HashFunction = *config.NewOptionalString("sha2-512")
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString)
+		require.Equal(t, shortStringCidV1Sha512, cidStr)
+	})
+
+	t.Run("output cid version: follows configuration (CIDv1)", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init()
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.Import.CidVersion = *config.NewOptionalInteger(1)
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString)
+		require.Equal(t, shortStringCidV1, cidStr)
+	})
+
+	t.Run("output cid version: flag overrides configuration", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init()
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.Import.CidVersion = *config.NewOptionalInteger(1)
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString, "--cid-version", "0")
+		require.Equal(t, shortStringCidV0, cidStr)
+	})
+}

--- a/test/cli/add_test.go
+++ b/test/cli/add_test.go
@@ -12,13 +12,14 @@ func TestAdd(t *testing.T) {
 	t.Parallel()
 
 	var (
-		shortString            = "hello world"
-		shortStringCidV0       = "Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD"
-		shortStringCidV1       = "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e"
-		shortStringCidV1Sha512 = "bafkrgqbqt3gerhas23vuzrapkdeqf4vu2dwxp3srdj6hvg6nhsug2tgyn6mj3u23yx7utftq3i2ckw2fwdh5qmhid5qf3t35yvkc5e5ottlw6"
+		shortString                 = "hello world"
+		shortStringCidV0            = "Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD"              // cidv0 - dag-pb - sha2-256
+		shortStringCidV1            = "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e" // cidv1 - raw - sha2-256
+		shortStringCidV1NoRawLeaves = "bafybeihykld7uyxzogax6vgyvag42y7464eywpf55gxi5qpoisibh3c5wa" // cidv1 - dag-pb - sha2-256
+		shortStringCidV1Sha512      = "bafkrgqbqt3gerhas23vuzrapkdeqf4vu2dwxp3srdj6hvg6nhsug2tgyn6mj3u23yx7utftq3i2ckw2fwdh5qmhid5qf3t35yvkc5e5ottlw6"
 	)
 
-	t.Run("output cid version: default (CIDv0)", func(t *testing.T) {
+	t.Run("produced cid version: implicit default (CIDv0)", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init().StartDaemon()
 		defer node.StopDaemon()
@@ -27,7 +28,7 @@ func TestAdd(t *testing.T) {
 		require.Equal(t, shortStringCidV0, cidStr)
 	})
 
-	t.Run("output cid version: follows configuration (CIDv0)", func(t *testing.T) {
+	t.Run("produced cid version: follows user-set configuration Import.CidVersion=0", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init()
 		node.UpdateConfig(func(cfg *config.Config) {
@@ -40,7 +41,7 @@ func TestAdd(t *testing.T) {
 		require.Equal(t, shortStringCidV0, cidStr)
 	})
 
-	t.Run("output cid version: follows configuration (hash function)", func(t *testing.T) {
+	t.Run("produced cid multihash: follows user-set configuration in Import.HashFunction", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init()
 		node.UpdateConfig(func(cfg *config.Config) {
@@ -53,7 +54,7 @@ func TestAdd(t *testing.T) {
 		require.Equal(t, shortStringCidV1Sha512, cidStr)
 	})
 
-	t.Run("output cid version: follows configuration (CIDv1)", func(t *testing.T) {
+	t.Run("produced cid version: follows user-set configuration Import.CidVersion=1", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init()
 		node.UpdateConfig(func(cfg *config.Config) {
@@ -66,7 +67,7 @@ func TestAdd(t *testing.T) {
 		require.Equal(t, shortStringCidV1, cidStr)
 	})
 
-	t.Run("output cid version: flag overrides configuration", func(t *testing.T) {
+	t.Run("produced cid version: command flag overrides configuration in Import.CidVersion", func(t *testing.T) {
 		t.Parallel()
 		node := harness.NewT(t).NewNode().Init()
 		node.UpdateConfig(func(cfg *config.Config) {
@@ -77,5 +78,21 @@ func TestAdd(t *testing.T) {
 
 		cidStr := node.IPFSAddStr(shortString, "--cid-version", "0")
 		require.Equal(t, shortStringCidV0, cidStr)
+	})
+
+	t.Run("produced unixfs raw leaves: follows user-set configuration Import.UnixFSRawLeaves", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init()
+		node.UpdateConfig(func(cfg *config.Config) {
+			// CIDv1 defaults to  raw-leaves=true
+			cfg.Import.CidVersion = *config.NewOptionalInteger(1)
+			// disable manually
+			cfg.Import.UnixFSRawLeaves = config.False
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString)
+		require.Equal(t, shortStringCidV1NoRawLeaves, cidStr)
 	})
 }

--- a/test/cli/add_test.go
+++ b/test/cli/add_test.go
@@ -95,4 +95,24 @@ func TestAdd(t *testing.T) {
 		cidStr := node.IPFSAddStr(shortString)
 		require.Equal(t, shortStringCidV1NoRawLeaves, cidStr)
 	})
+
+	t.Run("ipfs init --profile=legacy-cid-v0 sets config that produces legacy CIDv0", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init("--profile=legacy-cid-v0")
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString)
+		require.Equal(t, shortStringCidV0, cidStr)
+	})
+
+	t.Run("ipfs init --profile=test-cid-v1 produces modern CIDv1", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init("--profile=test-cid-v1")
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(shortString)
+		require.Equal(t, shortStringCidV1, cidStr)
+	})
 }


### PR DESCRIPTION
This is an initial draft for an idea that @lidel and I were speaking about: a config section with the default data ingestion options. This would allow to easily change the defaults across the code-base easily in the future.

The largest problem at the moment is that the CID Version is, by default, 1 in some commands (`dag put`, `block put`) and 0 in others (`add`, except in cases where certain options are used). This was also the largest use case for this config section: being able to upgrade the default CID version in the future. However, we can't use this configuration option since not all commands use the same default at the moment.

My suggestion would be to investigate the possibility of changing the default of `ipfs add` to CIDv1, since this one seems to be the only one that still uses 0 as the default, except in some cases.

cc https://github.com/ipfs/kubo/issues/4143 