### PR TITLE
[skip changelog] Stop using github.com/pkg/errors

### DIFF
--- a/client/rpc/pin.go
+++ b/client/rpc/pin.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/ipfs/go-cid"
 	iface "github.com/ipfs/kubo/core/coreiface"
 	caopts "github.com/ipfs/kubo/core/coreiface/options"
-	"github.com/pkg/errors"
 )
 
 type PinAPI HttpApi

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
 	mbase "github.com/multiformats/go-multibase"
-	"github.com/pkg/errors"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	options "github.com/ipfs/kubo/core/coreiface/options"
@@ -351,7 +351,7 @@ func urlArgsDecoder(req *cmds.Request, env cmds.Environment) error {
 	for n, arg := range req.Arguments {
 		encoding, data, err := mbase.Decode(arg)
 		if err != nil {
-			return errors.Wrap(err, "URL arg must be multibase encoded")
+			return fmt.Errorf("URL arg must be multibase encoded: %w", err)
 		}
 
 		// Enforce URL-safe encoding is used for data passed via URL arguments

--- a/core/node/helpers.go
+++ b/core/node/helpers.go
@@ -2,9 +2,9 @@ package node
 
 import (
 	"context"
+	"errors"
 
 	"github.com/jbenet/goprocess"
-	"github.com/pkg/errors"
 	"go.uber.org/fx"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
@@ -197,6 +196,7 @@ require (
 	github.com/pion/transport/v2 v2.2.4 // indirect
 	github.com/pion/turn/v2 v2.1.4 // indirect
 	github.com/pion/webrtc/v3 v3.2.23 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect


### PR DESCRIPTION
Looks like `github.com/pkg/errors` isn't used in `kubo`. There were few places where `errors` from stdlib will work perfectly. One `errors.Wrap(err, "...")` got replaced with `fmt.Errorf`.