### PR TITLE
fix(libp2p): streams config validation in resource manager

### DIFF
--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -491,7 +491,7 @@ resource manager System.ConnsInbound (%d) must be bigger than ConnMgr.HighWater 
 See: https://github.com/ipfs/kubo/blob/master/docs/libp2p-resource-management.md#how-does-the-resource-manager-resourcemgr-relate-to-the-connection-manager-connmgr
 `, rcm.System.ConnsInbound, highWater)
 	}
-	if rcm.System.Streams > rcmgr.DefaultLimit || rcm.System.Streams == rcmgr.BlockAllLimit && int64(rcm.System.Streams) <= highWater {
+	if (rcm.System.Streams > rcmgr.DefaultLimit || rcm.System.Streams == rcmgr.BlockAllLimit) && int64(rcm.System.Streams) <= highWater {
 		// nolint
 		return fmt.Errorf(`
 Unable to initialize libp2p due to conflicting resource manager limit configuration.

--- a/docs/changelogs/v0.28.md
+++ b/docs/changelogs/v0.28.md
@@ -70,6 +70,7 @@ The root CIDs of pinned content are now prioritized when announcing to the Amino
   - test: cleanup content blocking tests (#10360) ([ipfs/kubo#10360](https://github.com/ipfs/kubo/pull/10360))
   - docs: improve release issue template
   - chore: update version
+  - fix: libp2p streams config validation in resource manager ([ipfs/kubo#10435](https://github.com/ipfs/kubo/pull/10435))
 - github.com/ipfs/boxo (v0.18.0 -> v0.19.0):
   - Release v0.19.0 ([ipfs/boxo#598](https://github.com/ipfs/boxo/pull/598))
 - github.com/libp2p/go-libp2p (v0.33.0 -> v0.33.2):

--- a/docs/changelogs/v0.28.md
+++ b/docs/changelogs/v0.28.md
@@ -70,7 +70,6 @@ The root CIDs of pinned content are now prioritized when announcing to the Amino
   - test: cleanup content blocking tests (#10360) ([ipfs/kubo#10360](https://github.com/ipfs/kubo/pull/10360))
   - docs: improve release issue template
   - chore: update version
-  - fix: libp2p streams config validation in resource manager ([ipfs/kubo#10435](https://github.com/ipfs/kubo/pull/10435))
 - github.com/ipfs/boxo (v0.18.0 -> v0.19.0):
   - Release v0.19.0 ([ipfs/boxo#598](https://github.com/ipfs/boxo/pull/598))
 - github.com/libp2p/go-libp2p (v0.33.0 -> v0.33.2):


### PR DESCRIPTION
### Description

It seems like when configuring custom resource manager limits, the node fails to start with an error:

> Unable to initialize libp2p due to conflicting resource manager limit configuration.\nresource manager System.Streams (5000) must be bigger than ConnMgr.HighWater (2000)

With this fix the node starts - same if condition exists a few lines above for `rcm.System.ConnsInbound` and `rcm.System.Conns`.

### How to reproduce

Configure `ConnectionManager`:

```
    "ConnMgr": {
      "GracePeriod": "20s",
      "HighWater": 2000,
      "LowWater": 1500,
      "Type": "basic"
    },
```

and enable `ResourceManager`:
```
    "ResourceMgr": {
      "Enabled": true,
    },
```

and configure some resource limits, especially **streams**:

```
> cat libp2p-resource-limit-overrides.json
{
  "System": {
    "Streams": 5000,
    "StreamsInbound": 3500,
    "StreamsOutbound": 1500,
    "Conns": 5000,
    "ConnsInbound": 3500,
    "ConnsOutbound": 1500,
    "Memory": "2147483648"
  },
  "Transient": {
    "Streams": 300,
    "StreamsInbound": 100,
    "StreamsOutbound": 200,
    "Conns": 300,
    "ConnsInbound": 100,
    "ConnsOutbound": 200
  }
}
```

### Current behavior

Launching the `ipfs daemon` fails:

> Unable to initialize libp2p due to conflicting resource manager limit configuration.\nresource manager System.Streams (5000) must be bigger than ConnMgr.HighWater (2000)

### Expected behavior

`ipfs daemon` launches with configured limits without an error.