### PR TITLE
feat: run AutoNAT V2 service in addition to V1

### DIFF
--- a/config/autonat.go
+++ b/config/autonat.go
@@ -20,6 +20,9 @@ const (
 	// AutoNATServiceDisabled indicates that the user has disabled the
 	// AutoNATService.
 	AutoNATServiceDisabled
+	// AutoNATServiceEnabledV1Only forces use of V1 and disables V2
+	// (used for testing)
+	AutoNATServiceEnabledV1Only
 )
 
 func (m *AutoNATServiceMode) UnmarshalText(text []byte) error {
@@ -30,6 +33,8 @@ func (m *AutoNATServiceMode) UnmarshalText(text []byte) error {
 		*m = AutoNATServiceEnabled
 	case "disabled":
 		*m = AutoNATServiceDisabled
+	case "legacy-v1":
+		*m = AutoNATServiceEnabledV1Only
 	default:
 		return fmt.Errorf("unknown autonat mode: %s", string(text))
 	}
@@ -44,6 +49,8 @@ func (m AutoNATServiceMode) MarshalText() ([]byte, error) {
 		return []byte("enabled"), nil
 	case AutoNATServiceDisabled:
 		return []byte("disabled"), nil
+	case AutoNATServiceEnabledV1Only:
+		return []byte("legacy-v1"), nil
 	default:
 		return nil, fmt.Errorf("unknown autonat mode: %d", m)
 	}

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -105,7 +105,9 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 		// to dhtclient.
 		fallthrough
 	case config.AutoNATServiceEnabled:
-		autonat = fx.Provide(libp2p.AutoNATService(cfg.AutoNAT.Throttle))
+		autonat = fx.Provide(libp2p.AutoNATService(cfg.AutoNAT.Throttle, false))
+	case config.AutoNATServiceEnabledV1Only:
+		autonat = fx.Provide(libp2p.AutoNATService(cfg.AutoNAT.Throttle, true))
 	}
 
 	enableRelayTransport := cfg.Swarm.Transports.Network.Relay.WithDefault(true) // nolint

--- a/core/node/libp2p/nat.go
+++ b/core/node/libp2p/nat.go
@@ -9,7 +9,7 @@ import (
 
 var NatPortMap = simpleOpt(libp2p.NATPortMap())
 
-func AutoNATService(throttle *config.AutoNATThrottleConfig) func() Libp2pOpts {
+func AutoNATService(throttle *config.AutoNATThrottleConfig, v1only bool) func() Libp2pOpts {
 	return func() (opts Libp2pOpts) {
 		opts.Opts = append(opts.Opts, libp2p.EnableNATService())
 		if throttle != nil {
@@ -20,6 +20,13 @@ func AutoNATService(throttle *config.AutoNATThrottleConfig) func() Libp2pOpts {
 					throttle.Interval.WithDefault(time.Minute),
 				),
 			)
+		}
+
+		// While V1 still exists and V2 rollout is in progress
+		// (https://github.com/ipfs/kubo/issues/10091) we check a flag that
+		// allows users to disable V2 and run V1-only mode
+		if !v1only {
+			opts.Opts = append(opts.Opts, libp2p.EnableAutoNATv2())
 		}
 		return opts
 	}

--- a/docs/changelogs/v0.30.md
+++ b/docs/changelogs/v0.30.md
@@ -7,6 +7,7 @@
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [WebRTC-Direct Transport enabled by default](#webrtc-direct-transport-enabled-by-default)
+  - [AutoNAT V2 Service Introduced Alongside V1](#autonat-v2-service-introduced-alongside-v1)
   - [Automated `ipfs version check`](#automated-ipfs-version-check)
   - [Version Suffix Configuration](#version-suffix-configuration)
 - [📝 Changelog](#-changelog)
@@ -26,6 +27,12 @@ Learn more: [`Swarm.Transports.Network.WebRTCDirect`](https://github.com/ipfs/ku
 
 > [!NOTE]
 > Kubo 0.30 includes a migration for existing users that adds `/webrtc-direct` listener on the same UDP port as `/udp/{port}/quic-v1`. This supports the WebRTC-Direct rollout by reusing preexisting UDP firewall settings and port mappings created for QUIC.
+
+#### AutoNAT V2 Service Introduced Alongside V1
+
+The AutoNAT service enables nodes to determine their public reachability on the internet. AutoNAT V2 enhances this protocol with improved features. In this release, Kubo will offer both V1 and V2 services to other peers, although it will continue to use only V1 when acting as a client. Future releases will phase out V1, transitioning clients to utilize V2 exclusively.
+
+For more details, see the [Deployment Plan for AutoNAT V2](https://github.com/ipfs/kubo/issues/10091) and [`AutoNAT`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autonat) configuration options.
 
 #### Automated `ipfs version check`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -552,7 +552,7 @@ Type: `array[string]`
 
 ## `AutoNAT`
 
-Contains the configuration options for the [AutoNAT]() service. The AutoNAT service
+Contains the configuration options for the libp2p's [AutoNAT](https://github.com/libp2p/specs/tree/master/autonat) service. The AutoNAT service
 helps other nodes on the network determine if they're publicly reachable from
 the rest of the internet.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -552,7 +552,7 @@ Type: `array[string]`
 
 ## `AutoNAT`
 
-Contains the configuration options for the AutoNAT service. The AutoNAT service
+Contains the configuration options for the [AutoNAT]() service. The AutoNAT service
 helps other nodes on the network determine if they're publicly reachable from
 the rest of the internet.
 
@@ -561,13 +561,22 @@ the rest of the internet.
 When unset (default), the AutoNAT service defaults to _enabled_. Otherwise, this
 field can take one of two values:
 
-* "enabled" - Enable the service (unless the node determines that it, itself,
-  isn't reachable by the public internet).
-* "disabled" - Disable the service.
+* `enabled` - Enable the V1+V2 service (unless the node determines that it,
+  itself, isn't reachable by the public internet).
+* `legacy-v1` - Same as `enabled` but only V1 service is enabled. Used for testing
+  during as few releases as we [transition to V2](https://github.com/ipfs/kubo/issues/10091), will be removed in the future.
+* `disabled` - Disable the service.
 
 Additional modes may be added in the future.
 
-Type: `string` (one of `"enabled"` or `"disabled"`)
+> [!IMPORTANT]
+> We are in the progress of [rolling out AutoNAT V2](https://github.com/ipfs/kubo/issues/10091).
+> Right now, by default, a publicly diallable Kubo provides both V1 and V2 service to other peers,
+> but only V1 is used by Kubo as a client. In a future release we will remove V1 and switch client to use V2.
+
+Default: `enabled`
+
+Type: `optionalString`
 
 ### `AutoNAT.Throttle`
 


### PR DESCRIPTION
This PR is part of #10091 proposed by @sukunrt. 

It enables V2 (https://github.com/libp2p/specs/pull/538) alongside V1, and adds configuration option that allows disabling V2 (just in case).


## TODO

- [x] `EnableAutoNATv2` in addition to V1 by default 
- [x] configuration option to restore old default (run V1-only) 
- [x] changelong