### PR TITLE
Added automated build of Debian package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
           name: kubo
           path: cmd/ipfs/ipfs
   debian-prep:
-    needs: [interop-prep]
     if: github.repository == 'ipfs/kubo' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - 'master'
-    tags:
-      - '*'
 
 env:
   GO_VERSION: 1.22.x
@@ -48,7 +46,7 @@ jobs:
           name: kubo
           path: cmd/ipfs/ipfs
   debian-prep:
-    if: github.repository == 'ipfs/kubo' || github.event_name == 'push'
+    needs: [interop-prep]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,12 +68,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-          fetch-depth: 0
+          fetch-depth: 1000
           fetch-tags: 'true'
       - run: |
           sudo apt-get update
           sudo apt-get install -y debhelper curl gcc sed gawk dpkg-dev build-essential
-          git fetch --prune --unshallow
           go mod vendor
           LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
           GOFLAGS="-mod=vendor" debuild -S -uc -us -d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,12 +82,7 @@ jobs:
         with:
           name: kubo-debian
           path: |
-            ../ipfs-kubo*.dsc
-            ../ipfs-kubo*.tar.xz
-            ../ipfs-kubo*.build
-            ../ipfs-kubo*.changes
-            ../ipfs-kubo*.deb
-            ../ipfs-kubo*.ddeb
+            packages/ipfs-kubo*.*
   helia-interop:
     needs: [interop-prep]
     runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           submodules: 'true'
           fetch-depth: 0
+          fetch-tags: 'true'
       - run: |
           sudo apt-get update
           sudo apt-get install -y debhelper curl gcc sed gawk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y debhelper curl gcc sed gawk dpkg-dev build-essential
+          git fetch --all
           go mod vendor
           LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
           GOFLAGS="-mod=vendor" debuild -S -uc -us -d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,6 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y debhelper curl gcc sed gawk dpkg-dev build-essential devscripts
-          git fetch -a
           go mod vendor
           LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
           GOFLAGS="-mod=vendor" debuild -S -uc -us -d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: 'true'
       - run: |
-          git fetch --tags
           sudo apt-get update
-          sudo apt-get install -y debhelper curl gcc sed gawk
+          sudo apt-get install -y debhelper curl gcc sed gawk dpkg-dev build-essential
+          git fetch --prune --unshallow
           go mod vendor
           LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
           GOFLAGS="-mod=vendor" debuild -S -uc -us -d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           name: kubo
           path: cmd/ipfs/ipfs
   debian-prep:
+    needs: [interop-prep]
     if: github.repository == 'ipfs/kubo' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -68,12 +69,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-          fetch-depth: 1000
-          fetch-tags: 'true'
+          fetch-depth: 0
       - run: |
           sudo apt-get update
-          sudo apt-get install -y debhelper curl gcc sed gawk dpkg-dev build-essential
-          git fetch --all
+          sudo apt-get install -y debhelper curl gcc sed gawk dpkg-dev build-essential devscripts
+          git fetch -a
           go mod vendor
           LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
           GOFLAGS="-mod=vendor" debuild -S -uc -us -d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: 'true'
       - run: |
+          git fetch --tags
           sudo apt-get update
           sudo apt-get install -y debhelper curl gcc sed gawk
           go mod vendor

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,12 +69,12 @@ jobs:
         with:
           submodules: 'true'
       - run: |
-        sudo apt-get update
-        sudo apt-get install -y debhelper curl gcc sed gawk
-        go mod vendor
-        LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
-        GOFLAGS="-mod=vendor" debuild -S -uc -us -d
-        GOFLAGS="-mod=vendor" debuild -b -uc -us -d
+          sudo apt-get update
+          sudo apt-get install -y debhelper curl gcc sed gawk
+          go mod vendor
+          LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
+          GOFLAGS="-mod=vendor" debuild -S -uc -us -d
+          GOFLAGS="-mod=vendor" debuild -b -uc -us -d
       - uses: actions/upload-artifact@v4
         with:
           name: kubo-debian

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - 'master'
+    tags:
+      - '*'
 
 env:
   GO_VERSION: 1.22.x
@@ -45,6 +47,44 @@ jobs:
         with:
           name: kubo
           path: cmd/ipfs/ipfs
+  debian-prep:
+    if: github.repository == 'ipfs/kubo' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TEST_DOCKER: 0
+      TEST_FUSE: 0
+      TEST_VERBOSE: 1
+      TRAVIS: 1
+      GIT_PAGER: cat
+      IPFS_CHECK_RCMGR_DEFAULTS: 1
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - run: |
+        sudo apt-get update
+        sudo apt-get install -y debhelper curl gcc sed gawk
+        go mod vendor
+        LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
+        GOFLAGS="-mod=vendor" debuild -S -uc -us -d
+        GOFLAGS="-mod=vendor" debuild -b -uc -us -d
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kubo-debian
+          path: |
+            ../ipfs-kubo*.dsc
+            ../ipfs-kubo*.tar.xz
+            ../ipfs-kubo*.build
+            ../ipfs-kubo*.changes
+            ../ipfs-kubo*.deb
+            ../ipfs-kubo*.ddeb
   helia-interop:
     needs: [interop-prep]
     runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
+          fetch-depth: 0
       - run: |
           sudo apt-get update
           sudo apt-get install -y debhelper curl gcc sed gawk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
           LC_TIME=en_US.UTF-8 ./debian/mkchangelog ./debian/changelog
           GOFLAGS="-mod=vendor" debuild -S -uc -us -d
           GOFLAGS="-mod=vendor" debuild -b -uc -us -d
+          mkdir packages
+          mv -v ../ipfs-kubo*.* packages/
       - uses: actions/upload-artifact@v4
         with:
           name: kubo-debian

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/examples/go-ipfs-as-a-library/example-folder/Qm*
 /parts
 /stage
 /prime
+.cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "debian"]
+	path = debian
+	url = https://github.com/twdragon/kubo-debian-pkg.git

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Before opening an issue, consider using one of the following locations to ensure
       - [Downloading builds using IPFS](#downloading-builds-using-ipfs)
   - [Unofficial Linux packages](#unofficial-linux-packages)
     - [ArchLinux](#arch-linux)
+    - [Gentoo Linux](#gentoo-linux)
     - [Nix](#nix)
     - [Solus](#solus)
     - [openSUSE](#opensuse)
@@ -199,6 +200,7 @@ $ ipfs get /ipns/dist.ipfs.tech/kubo/$VERSION/kubo_$VERSION_windows-amd64.zip   
 </a>
 
 - [ArchLinux](#arch-linux)
+- [Gentoo Linux](#gentoo-linux)
 - [Nix](#nix-linux)
 - [Solus](#solus)
 - [openSUSE](#opensuse)
@@ -215,6 +217,16 @@ $ ipfs get /ipns/dist.ipfs.tech/kubo/$VERSION/kubo_$VERSION_windows-amd64.zip   
 ```
 
 [![kubo-git via AUR](https://img.shields.io/static/v1?label=kubo-git&message=latest%40master&color=1793d1&logo=arch-linux&style=flat-square&cacheSeconds=3600)](https://aur.archlinux.org/packages/kubo/)
+
+#### <a name="gentoo-linux">Gentoo Linux</a>
+
+https://wiki.gentoo.org/wiki/Kubo
+
+```bash
+# emerge -a net-p2p/kubo
+```
+
+https://packages.gentoo.org/packages/net-p2p/kubo
 
 #### <a name="nix-linux">Nix</a>
 


### PR DESCRIPTION
This PR requests the re-introduction of the universal Github Actions-compatible CI pipeline that automates the building of the following entities:
1. Build-ready native **source package for Debian distribution** with installed Go compiler. The build could be done automatically by `devscripts` and `dpkg` toolchains.
2. **Binary Debian package** (`.deb` archive) built for the GitHub Action Runner's architecture.
3.  The build artifacts are uploaded to the runner space under the name `kubo-debian`.

-----

The handler scripts and maintainer scripts are taken from the [repository](https://github.com/twdragon/kubo-debian-pkg), which is now included in the Kubo repository as a submodule. Please feel free to ask for total copying of this repository's code and removing the submodule. In addition, please note that this repository also maintains the PPA-specific build pipeline for uploading the packages on [Ubuntu Launchpad](https://launchpad.net/~twdragon/+archive/ubuntu/ipfs).

-----

The package installs Kubo as a `systemd` service with the selected CPU/RAM accounting mode, bash completion script and networking profile, as described in the [dedicated discussion thread](https://discuss.ipfs.tech/t/ubuntu-ppa-for-kubo-is-now-revived/18331). It is also possible to install Kubo for a non-system user, but the node is still managed by `systemd`.

-----

The main intention under this PR is to provide the automated pipeline for building a Debian-compatible source package for downloading and building on the end user's side, but also it could be easily adapted for building binary packages for different architectures. If this PR will be considered a good addition to the Kubo pipelines, the cross-compilation toolchain will be introduced in the mainline, not PPA toolchain.