### PR TITLE
chore(daemon): sort listeners

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -818,7 +818,17 @@ func printLibp2pPorts(node *core.IpfsNode) {
 			addrMap[host][protocol] = struct{}{}
 		}
 	}
-	for host, protocolsSet := range addrMap {
+
+	// Produce a sorted host:port list
+	hosts := make([]string, 0, len(addrMap))
+	for host := range addrMap {
+		hosts = append(hosts, host)
+	}
+	sort.Strings(hosts)
+
+	// Print listeners
+	for _, host := range hosts {
+		protocolsSet := addrMap[host]
 		protocols := make([]string, 0, len(protocolsSet))
 		for protocol := range protocolsSet {
 			protocols = append(protocols, protocol)


### PR DESCRIPTION
UX improvement based on user feedback when `0` (random port) is used for both TCP and UDP.

## Before

```
Swarm listening on [::1]:37388 (UDP)
Swarm listening on 192.168.50.102:59594 (UDP)
Swarm listening on 192.168.50.102:45445 (TCP)
Swarm listening on [::1]:48490 (UDP)
Swarm listening on 172.17.0.1:45445 (TCP)
Swarm listening on 192.168.50.102:60155 (UDP)
Swarm listening on 172.17.0.1:60155 (UDP)
Swarm listening on 127.0.0.1:57573 (UDP)
Swarm listening on 127.0.0.1:59594 (UDP)
Swarm listening on 172.17.0.1:59594 (UDP)
Swarm listening on [::1]:40151 (TCP)
Swarm listening on [::1]:54080 (UDP)
Swarm listening on 127.0.0.1:45445 (TCP)
Swarm listening on 192.168.50.102:57573 (UDP)
Swarm listening on 172.17.0.1:57573 (UDP)
Swarm listening on 127.0.0.1:60155 (UDP)
```

## After

```
Swarm listening on 127.0.0.1:38235 (TCP)
Swarm listening on 127.0.0.1:54515 (UDP)
Swarm listening on 127.0.0.1:59476 (UDP)
Swarm listening on 127.0.0.1:60875 (UDP)
Swarm listening on 172.17.0.1:38235 (TCP)
Swarm listening on 172.17.0.1:54515 (UDP)
Swarm listening on 172.17.0.1:59476 (UDP)
Swarm listening on 172.17.0.1:60875 (UDP)
Swarm listening on 192.168.50.102:38235 (TCP)
Swarm listening on 192.168.50.102:54515 (UDP)
Swarm listening on 192.168.50.102:59476 (UDP)
Swarm listening on 192.168.50.102:60875 (UDP)
Swarm listening on [::1]:35542 (UDP)
Swarm listening on [::1]:36413 (UDP)
Swarm listening on [::1]:43063 (TCP)
Swarm listening on [::1]:58548 (UDP)
```