### PR TITLE
Update Version: v0.30 [skip changelog]

### DIFF
--- a/version.go
+++ b/version.go
@@ -11,7 +11,7 @@ import (
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal.
-const CurrentVersionNumber = "0.30.0-dev"
+const CurrentVersionNumber = "0.31.0-dev"
 
 const ApiVersion = "/kubo/" + CurrentVersionNumber + "/" //nolint
 


### PR DESCRIPTION
> (generated by `kuboreleaser`)

This PR bumps master branch version as part of the v0.30 release (https://github.com/ipfs/kubo/issues/10436)
From now on, things that land in master needs will not be included in 0.30, and if need to, have  to be cherry picked to `release-v0.30.0` to be included in https://github.com/ipfs/kubo/pull/10490