### PR TITLE
fix: error during config when running benchmarks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/ipld/go-car/v2 v2.13.1
 	github.com/ipld/go-codec-dagpb v1.6.0
 	github.com/ipld/go-ipld-prime v0.21.0
-	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,6 @@ github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7Bd
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0 h1:Vc/s0QbQtoxX8MwwSLWWh+xNNZvM3Lw7NsTcHrvvhMc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
-github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c h1:uUx61FiAa1GI6ZmVd2wf2vULeQZIKG66eybjNXKYCz4=
-github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c/go.mod h1:sdx1xVM9UuLw1tXnhJWN3piypTUO3vCIHYmG15KE/dU=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
 github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsjFq/qrU3Rar62tu1gASgGw6chQbSh/XgIIXCY=

--- a/test/bench/offline_add/main.go
+++ b/test/bench/offline_add/main.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/ipfs/kubo/thirdparty/unit"
 
+	random "github.com/ipfs/go-test/random"
 	config "github.com/ipfs/kubo/config"
-	random "github.com/jbenet/go-random"
 )
 
 func main() {
@@ -44,7 +44,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 				cmd.Env = env
 			}
 
-			cmd := exec.Command("ipfs", "init", "-b=2048")
+			cmd := exec.Command("ipfs", "init")
 			setupCmd(cmd)
 			if err := cmd.Run(); err != nil {
 				b.Fatal(err)
@@ -57,7 +57,11 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 			}
 			defer os.Remove(f.Name())
 
-			err = random.WritePseudoRandomBytes(amount, f, seed)
+			randReader := &io.LimitedReader{
+				R: random.NewSeededRand(seed),
+				N: amount,
+			}
+			_, err = io.Copy(f, randReader)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/test/bench/offline_add/main.go
+++ b/test/bench/offline_add/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"

--- a/test/integration/addcat_test.go
+++ b/test/integration/addcat_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/ipfs/boxo/bootstrap"
 	"github.com/ipfs/boxo/files"
 	logging "github.com/ipfs/go-log"
+	"github.com/ipfs/go-test/random"
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/core/coreapi"
 	mock "github.com/ipfs/kubo/core/mock"
 	"github.com/ipfs/kubo/thirdparty/unit"
-	"github.com/jbenet/go-random"
 	testutil "github.com/libp2p/go-libp2p-testing/net"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
@@ -84,12 +84,8 @@ func AddCatPowers(conf testutil.LatencyConfig, megabytesMax int64) error {
 }
 
 func RandomBytes(n int64) []byte {
-	var data bytes.Buffer
-	err := random.WritePseudoRandomBytes(n, &data, kSeed)
-	if err != nil {
-		panic(err)
-	}
-	return data.Bytes()
+	random.SetSeed(kSeed)
+	return random.Bytes(int(n))
 }
 
 func DirectAddCat(data []byte, conf testutil.LatencyConfig) error {


### PR DESCRIPTION
- Benchmarks were failing with error setting number of bits for ed25519 keys, which are the default now.
- Update the random data generation package to remove a dependency.
