### PR TITLE
fix(cli): preserve hostname specified with --api in http request headers

### DIFF
--- a/cmd/ipfs/kubo/start.go
+++ b/cmd/ipfs/kubo/start.go
@@ -303,7 +303,10 @@ func makeExecutor(req *cmds.Request, env interface{}) (cmds.Executor, error) {
 	}
 
 	// Resolve the API addr.
-	apiAddr, err = resolveAddr(req.Context, apiAddr)
+	//
+	// Do not replace apiAddr with the resolved addr so that the requested
+	// hostname is kept for use in the request's HTTP header.
+	_, err = resolveAddr(req.Context, apiAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/changelogs/v0.30.md
+++ b/docs/changelogs/v0.30.md
@@ -13,6 +13,7 @@
   - [`/unix/` socket support in `Addresses.API`](#unix-socket-support-in-addressesapi)
   - [Cleaned Up `ipfs daemon` Startup Log](#cleaned-up-ipfs-daemon-startup-log)
   - [UnixFS 1.5: Mode and Modification Time Support](#unixfs-15-mode-and-modification-time-support)
+  - [Commands Preserve Specified Hostname](#commands-preserve-specified-hostname)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -129,6 +130,10 @@ Modification time support was also added to the Gateway. If present, value from 
 > [!NOTE]
 > Storing `mode` and `mtime` requires root block to be `dag-pb` and disabled `raw-leaves` setting to create envelope for storing the metadata.
 
+#### Commands Preserve Specified Hostname
+
+When executing a comman, if a hostname is specified by `--api=/dns4/<domain>/` the resulting HTTP request now contains the hostname, instead of the the IP address that the hostname resolved to, as was the previous behavior. This makes it easier for those trying to run kubo behind a reverse proxy using hostname-based rules.
+  
 ### 📝 Changelog
 
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/changelogs/v0.30.md
+++ b/docs/changelogs/v0.30.md
@@ -132,7 +132,7 @@ Modification time support was also added to the Gateway. If present, value from 
 
 #### Commands Preserve Specified Hostname
 
-When executing a comman, if a hostname is specified by `--api=/dns4/<domain>/` the resulting HTTP request now contains the hostname, instead of the the IP address that the hostname resolved to, as was the previous behavior. This makes it easier for those trying to run kubo behind a reverse proxy using hostname-based rules.
+When executing a [CLI command](https://docs.ipfs.tech/reference/kubo/cli/) over [Kubo RPC API](https://docs.ipfs.tech/reference/kubo/rpc/), if a hostname is specified by `--api=/dns4/<domain>/` the resulting HTTP request now contains the hostname, instead of the the IP address that the hostname resolved to, as was the previous behavior. This makes it easier for those trying to run Kubo behind a reverse proxy using hostname-based rules.
   
 ### 📝 Changelog
 

--- a/test/sharness/t0235-cli-request.sh
+++ b/test/sharness/t0235-cli-request.sh
@@ -28,7 +28,7 @@ test_expect_success "start nc" '
 '
 
 test_expect_success "can make http request against nc server" '
-  ipfs cat /ipfs/Qmabcdef --api /ip4/127.0.0.1/tcp/5005 &
+  ipfs cat /ipfs/Qmabcdef --api /dns4/localhost/tcp/5005 &
   IPFSPID=$!
 
   # handle request for /api/v0/version
@@ -78,6 +78,10 @@ test_expect_success "request looks good" '
 
 test_expect_success "api flag does not appear in request" '
   test_expect_code 1 grep "api=/ip4" nc_out
+'
+
+test_expect_success "host has dns name not ip address" '
+  grep "Host: localhost:5005" nc_out
 '
 
 test_done


### PR DESCRIPTION
- Replaces PR #10233 by @softwareplumber
- Add test to check for hostname in HTTP header

Note: It is necessary to keep the call to `resolveAddr` to check for a resolvable address, otherwise the host is reported as offline when the address should be reported as not resolvable.

Closes #10232

Thank you @softwareplumber for this solution.