### PR TITLE
refactor: simplify logic for MFS remote pinning

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -586,7 +586,7 @@ take effect.
 	prometheus.MustRegister(&corehttp.IpfsNodeCollector{Node: node})
 
 	// start MFS pinning thread
-	startPinMFS(daemonConfigPollInterval, cctx, &ipfsPinMFSNode{node})
+	startPinMFS(cctx, daemonConfigPollInterval, &ipfsPinMFSNode{node})
 
 	// The daemon is *finally* ready.
 	fmt.Printf("Daemon is ready\n")


### PR DESCRIPTION
MFS pinning logis was returning errors on a channel, only to be logged by a separate goroutine. The errors were not used for any other purpose, so the logic could be significantly simplified by logging the error where it happened instead of returning it on a channel to be logged. This PR removes the unnecessary channel and logging goroutine.

A couple other minor simplifications and consistency changes were also made, such as passing a context as the first argument.
