### PR TITLE
chore: switch back to release helia-interop

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -70,27 +70,9 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ github.job }}-helia-
       - run: sudo apt update
       - run: sudo apt install -y libxkbcommon0 libxdamage1 libgbm1 libpango-1.0-0 libcairo2 # dependencies for playwright
-
-      # TODO: for now run against version from https://github.com/ipfs/helia/pull/584
-      - name: Checkout helia-interop with provisional fix
-        uses: actions/checkout@v4
-        with:
-          repository: ipfs/helia
-          ref: ab6b385787075ad9932f24362293b3bb82ff1d96
-          path: helia
-      - name: Run provisional build of helia
-        run: npm i && npm run build
-        working-directory: helia
-      - name: Run provisional build of helia-interop
-        run: npm i && npm run build && npx .
-        working-directory: helia/packages/interop
+      - run: npx --package @helia/interop helia-interop
         env:
           KUBO_BINARY: ${{ github.workspace }}/cmd/ipfs/ipfs
-
-      # TODO: switch back to release once https://github.com/ipfs/helia/pull/584 ships
-      #- run: npx --package @helia/interop helia-interop
-      #  env:
-      #    KUBO_BINARY: ${{ github.workspace }}/cmd/ipfs/ipfs
   ipfs-webui:
     needs: [interop-prep]
     runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}


### PR DESCRIPTION
We were running fix from https://github.com/ipfs/helia/pull/584, once it ships it is time to switch back to released version.

Context:
https://github.com/ipfs/helia/pull/584#issuecomment-2343839607

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
