### PR TITLE
feat: reprovider warning and announce-on|off profiles

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -174,10 +174,12 @@ functionality - performance of content discovery and data
 fetching may be degraded.
 `,
 		Transform: func(c *Config) error {
+			// Disable "server" services (dht, autonat, limited relay)
 			c.Routing.Type = NewOptionalString("autoclient")
 			c.AutoNAT.ServiceMode = AutoNATServiceDisabled
-			c.Reprovider.Interval = NewOptionalDuration(0)
+			c.Swarm.RelayService.Enabled = False
 
+			// Keep bare minimum connections around
 			lowWater := int64(20)
 			highWater := int64(40)
 			gracePeriod := time.Minute
@@ -185,6 +187,29 @@ fetching may be degraded.
 			c.Swarm.ConnMgr.LowWater = &OptionalInteger{value: &lowWater}
 			c.Swarm.ConnMgr.HighWater = &OptionalInteger{value: &highWater}
 			c.Swarm.ConnMgr.GracePeriod = &OptionalDuration{&gracePeriod}
+			return nil
+		},
+	},
+	"announce-off": {
+		Description: `Disables Reprovide system (and announcing to Amino DHT).
+
+		USE WITH CAUTION:
+		The main use case for this is setups with manual Peering.Peers config.
+		Data from this node will not be announced on the DHT. This will make
+		DHT-based routing an data retrieval impossible if this node is the only
+		one hosting it, and other peers are not already connected to it.
+`,
+		Transform: func(c *Config) error {
+			c.Reprovider.Interval = NewOptionalDuration(0) // 0 disables periodic reprovide
+			c.Experimental.StrategicProviding = true       // this is not a typo (the name is counter-intuitive)
+			return nil
+		},
+	},
+	"announce-on": {
+		Description: `Re-enables Reprovide system (reverts announce-off profile).`,
+		Transform: func(c *Config) error {
+			c.Reprovider.Interval = NewOptionalDuration(DefaultReproviderInterval) // have to apply explicit default because nil would be ignored
+			c.Experimental.StrategicProviding = false                              // this is not a typo (the name is counter-intuitive)
 			return nil
 		},
 	},

--- a/docs/changelogs/v0.31.md
+++ b/docs/changelogs/v0.31.md
@@ -6,12 +6,25 @@
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
+  - [`lowpower` profile no longer breaks DHT announcements](#lowpower-profile-no-longer-breaks-dht-announcements)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
 ### Overview
 
 ### 🔦 Highlights
+
+#### `lowpower` profile no longer breaks DHT announcements
+
+We've notices users were applying `lowpower` profile, and then reporting content routing issues. This was because `lowpower` disabled reprovider system and locally hosted data was no longer announced on Amino DHT.
+
+This release changes [`lowpower` profile](https://github.com/ipfs/kubo/blob/master/docs/config.md#lowpower-profile) to not change reprovider settings, ensuring the new users are not sabotaging themselves. It also adds [`annouce-on`](https://github.com/ipfs/kubo/blob/master/docs/config.md#announce-on-profile) and [`announce-off`](https://github.com/ipfs/kubo/blob/master/docs/config.md#announce-off-profile) profiles for controlling announcement settings separately.
+
+> [!IMPORTANT]
+> If you've ever applied the `lowpower` profile before, there is a high chance your node is not announcing to DHT anymore.
+> If you have `Reprovider.Interval` set to `0` you may want to wet it to `22h` (or run `ipfs config profile apply announce-on`) to fix your system.
+>
+> As a convenience, `ipfs daemon` will warn if reprovide system is disabled, creating oportinity to fix configuration if it was not intentional.
 
 ### 📝 Changelog
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -183,6 +183,8 @@ config file at runtime.
     - [`flatfs` profile](#flatfs-profile)
     - [`badgerds` profile](#badgerds-profile)
     - [`lowpower` profile](#lowpower-profile)
+    - [`announce-off` profile](#announce-off-profile)
+    - [`announce-on` profile](#announce-on-profile)
     - [`legacy-cid-v0` profile](#legacy-cid-v0-profile)
     - [`test-cid-v1` profile](#test-cid-v1-profile)
   - [Types](#types)
@@ -299,7 +301,7 @@ Map of HTTP headers to set on responses from the RPC (`/api/v0`) HTTP server.
 Example:
 ```json
 {
-	"Foo": ["bar"]
+  "Foo": ["bar"]
 }
 ```
 
@@ -534,27 +536,27 @@ Default:
 ```
 {
   "mounts": [
-	{
-	  "child": {
-		"path": "blocks",
-		"shardFunc": "/repo/flatfs/shard/v1/next-to-last/2",
-		"sync": true,
-		"type": "flatfs"
-	  },
-	  "mountpoint": "/blocks",
-	  "prefix": "flatfs.datastore",
-	  "type": "measure"
-	},
-	{
-	  "child": {
-		"compression": "none",
-		"path": "datastore",
-		"type": "levelds"
-	  },
-	  "mountpoint": "/",
-	  "prefix": "leveldb.datastore",
-	  "type": "measure"
-	}
+  {
+    "child": {
+    "path": "blocks",
+    "shardFunc": "/repo/flatfs/shard/v1/next-to-last/2",
+    "sync": true,
+    "type": "flatfs"
+    },
+    "mountpoint": "/blocks",
+    "prefix": "flatfs.datastore",
+    "type": "measure"
+  },
+  {
+    "child": {
+    "compression": "none",
+    "path": "datastore",
+    "type": "levelds"
+    },
+    "mountpoint": "/",
+    "prefix": "leveldb.datastore",
+    "type": "measure"
+  }
   ],
   "type": "mount"
 }
@@ -1126,7 +1128,7 @@ Example:
         "API" : {
           "Endpoint" : "https://pinningservice.tld:1234/my/api/path",
           "Key" : "someOpaqueKey"
-				}
+        }
       }
     }
   }
@@ -2420,18 +2422,30 @@ This profile may only be applied when first initializing the node.
 
 ### `lowpower` profile
 
-Reduces daemon overhead on the system. Affects node
-functionality - performance of content discovery and data
-fetching may be degraded.
+Reduces daemon overhead on the system by disabling optional swarm services.
+
+- [`Routing.Type`](#routingtype) set to `autoclient` (no DHT server, only client).
+- `Swarm.ConnMgr` set to maintain minimum number of p2p connections at a time.
+- Disables [`AutoNAT`](#autonat).
+- Disables [`Swam.RelayService`](#swarmrelayservice).
+
+> [!NOTE]
+> This profile is provided for legacy reasons.
+> With modern Kubo setting the above should not be necessary.
+
+### `announce-off` profile
+
+Disables [Reprovider](#reprovider) system (and announcing to Amino DHT).
 
 > [!CAUTION]
-> Local data won't be announced on routing systems like Amino DHT.
+> The main use case for this is setups with manual Peering.Peers config.
+> Data from this node will not be announced on the DHT. This will make
+> DHT-based routing an data retrieval impossible if this node is the only
+> one hosting it, and other peers are not already connected to it.
 
-- `Swarm.ConnMgr` set to maintain minimum number of p2p connections at a time.
-- Disables [`Reprovider`](#reprovider) service → no CID will be announced on Amino DHT and other routing systems(!)
-- Disables [`AutoNAT`](#autonat).
+### `announce-on` profile
 
-Use this profile with caution.
+(Re-)enables [Reprovider](#reprovider) system (reverts [`announce-off` profile](#annouce-off-profile).
 
 ### `legacy-cid-v0` profile
 


### PR DESCRIPTION
### TLDR

This PR aims to fix footgun that is `lowpower` profile + warn users who already sabotaged themselves by disabling reprovide system (not announcing to DHT).

### Details

Users running on raspberrypi or other "lowpower" server often sabotaged themselves by disabling announcements when applying poorly documented `lowpower` profile ([example](https://discuss.ipfs.tech/t/understanding-long-access-times/18514/3)). 

To make matters worse,  we've been prominently hinting that user should enable this profile to save resources, we did that in examples and docs ([example](http://web.archive.org/web/20240924162820/https://docs.ipfs.tech/install/command-line/#system-requirements) – i've hidden this footgun from our docs, but the harm is already done)

This PR moves announcement settings to a separate profile, removing the footgun from `lowpower` one + warns users who have it disabled (if it was intentional, user can ignore the message).

### TODO

- [x] announce-on/off profiles
- [x] `lowprofile` should not impact announcements
- [x] `ipfs daemon` should print warning when node is online but reprovide system is turned off
- [x] update docs/config
- [x] add changelog entry

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
