### PR TITLE
refactor(cmds): do not return errors embedded in result type

### DIFF
--- a/client/rpc/pin.go
+++ b/client/rpc/pin.go
@@ -87,7 +87,7 @@ func (api *PinAPI) Ls(ctx context.Context, pins chan<- iface.Pin, opts ...caopts
 			if err != io.EOF {
 				return err
 			}
-			return nil
+			break
 		}
 
 		c, err := cid.Parse(out.Cid)

--- a/client/rpc/pin.go
+++ b/client/rpc/pin.go
@@ -87,7 +87,7 @@ func (api *PinAPI) Ls(ctx context.Context, pins chan<- iface.Pin, opts ...caopts
 			if err != io.EOF {
 				return err
 			}
-			break
+			return nil
 		}
 
 		c, err := cid.Parse(out.Cid)
@@ -101,7 +101,6 @@ func (api *PinAPI) Ls(ctx context.Context, pins chan<- iface.Pin, opts ...caopts
 			return ctx.Err()
 		}
 	}
-	return nil
 }
 
 // IsPinned returns whether or not the given cid is pinned

--- a/client/rpc/unixfs.go
+++ b/client/rpc/unixfs.go
@@ -144,16 +144,12 @@ type lsOutput struct {
 	Objects []lsObject
 }
 
-func (api *UnixfsAPI) Ls(ctx context.Context, p path.Path, opts ...caopts.UnixfsLsOption) (<-chan iface.DirEntry, <-chan error) {
-	out := make(chan iface.DirEntry)
-	errOut := make(chan error, 1)
+func (api *UnixfsAPI) Ls(ctx context.Context, p path.Path, out chan<- iface.DirEntry, opts ...caopts.UnixfsLsOption) error {
+	defer close(out)
 
 	options, err := caopts.UnixfsLsOptions(opts...)
 	if err != nil {
-		errOut <- err
-		close(out)
-		close(errOut)
-		return out, errOut
+		return err
 	}
 
 	resp, err := api.core().Request("ls", p.String()).
@@ -162,79 +158,66 @@ func (api *UnixfsAPI) Ls(ctx context.Context, p path.Path, opts ...caopts.Unixfs
 		Option("stream", true).
 		Send(ctx)
 	if err != nil {
-		errOut <- err
-		close(out)
-		close(errOut)
-		return out, errOut
+		return err
 	}
 	if resp.Error != nil {
-		errOut <- resp.Error
-		close(out)
-		close(errOut)
-		return out, errOut
+		return err
 	}
+	defer resp.Close()
 
 	dec := json.NewDecoder(resp.Output)
 
-	go func() {
-		defer resp.Close()
-		defer close(out)
-		defer close(errOut)
-
-		for {
-			var link lsOutput
-			if err := dec.Decode(&link); err != nil {
-				if err != io.EOF {
-					errOut <- err
-				}
-				return
+	for {
+		var link lsOutput
+		if err = dec.Decode(&link); err != nil {
+			if err != io.EOF {
+				return err
 			}
-
-			if len(link.Objects) != 1 {
-				errOut <- errors.New("unexpected Objects len")
-				return
-			}
-
-			if len(link.Objects[0].Links) != 1 {
-				errOut <- errors.New("unexpected Links len")
-				return
-			}
-
-			l0 := link.Objects[0].Links[0]
-
-			c, err := cid.Decode(l0.Hash)
-			if err != nil {
-				errOut <- err
-				return
-			}
-
-			var ftype iface.FileType
-			switch l0.Type {
-			case unixfs.TRaw, unixfs.TFile:
-				ftype = iface.TFile
-			case unixfs.THAMTShard, unixfs.TDirectory, unixfs.TMetadata:
-				ftype = iface.TDirectory
-			case unixfs.TSymlink:
-				ftype = iface.TSymlink
-			}
-
-			select {
-			case out <- iface.DirEntry{
-				Name:   l0.Name,
-				Cid:    c,
-				Size:   l0.Size,
-				Type:   ftype,
-				Target: l0.Target,
-
-				Mode:    l0.Mode,
-				ModTime: l0.ModTime,
-			}:
-			case <-ctx.Done():
-			}
+			return nil
 		}
-	}()
 
-	return out, errOut
+		if len(link.Objects) != 1 {
+			return errors.New("unexpected Objects len")
+		}
+
+		if len(link.Objects[0].Links) != 1 {
+			return errors.New("unexpected Links len")
+		}
+
+		l0 := link.Objects[0].Links[0]
+
+		c, err := cid.Decode(l0.Hash)
+		if err != nil {
+			return err
+		}
+
+		var ftype iface.FileType
+		switch l0.Type {
+		case unixfs.TRaw, unixfs.TFile:
+			ftype = iface.TFile
+		case unixfs.THAMTShard, unixfs.TDirectory, unixfs.TMetadata:
+			ftype = iface.TDirectory
+		case unixfs.TSymlink:
+			ftype = iface.TSymlink
+		}
+
+		select {
+		case out <- iface.DirEntry{
+			Name:   l0.Name,
+			Cid:    c,
+			Size:   l0.Size,
+			Type:   ftype,
+			Target: l0.Target,
+
+			Mode:    l0.Mode,
+			ModTime: l0.ModTime,
+		}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
 }
 
 func (api *UnixfsAPI) core() *HttpApi {

--- a/client/rpc/unixfs.go
+++ b/client/rpc/unixfs.go
@@ -173,7 +173,7 @@ func (api *UnixfsAPI) Ls(ctx context.Context, p path.Path, out chan<- iface.DirE
 			if err != io.EOF {
 				return err
 			}
-			return nil
+			break
 		}
 
 		if len(link.Objects) != 1 {

--- a/client/rpc/unixfs.go
+++ b/client/rpc/unixfs.go
@@ -173,7 +173,7 @@ func (api *UnixfsAPI) Ls(ctx context.Context, p path.Path, out chan<- iface.DirE
 			if err != io.EOF {
 				return err
 			}
-			break
+			return nil
 		}
 
 		if len(link.Objects) != 1 {
@@ -216,8 +216,6 @@ func (api *UnixfsAPI) Ls(ctx context.Context, p path.Path, out chan<- iface.DirE
 			return ctx.Err()
 		}
 	}
-
-	return nil
 }
 
 func (api *UnixfsAPI) core() *HttpApi {

--- a/cmd/ipfs/kubo/pinmfs.go
+++ b/cmd/ipfs/kubo/pinmfs.go
@@ -183,7 +183,7 @@ func pinMFS(ctx context.Context, node pinMFSNode, cid cid.Cid, svcName string, s
 
 	// check if MFS pin exists (across all possible states) and inspect its CID
 	pinStatuses := []pinclient.Status{pinclient.StatusQueued, pinclient.StatusPinning, pinclient.StatusPinned, pinclient.StatusFailed}
-	lsPinCh, lsErrCh := c.Ls(ctx, pinclient.PinOpts.FilterName(pinName), pinclient.PinOpts.FilterStatus(pinStatuses...))
+	lsPinCh, lsErrCh := c.GoLs(ctx, pinclient.PinOpts.FilterName(pinName), pinclient.PinOpts.FilterStatus(pinStatuses...))
 	existingRequestID := "" // is there any pre-existing MFS pin with pinName (for any CID)?
 	pinning := false        // is CID for current MFS already being pinned?
 	pinTime := time.Now().UTC()

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -139,17 +139,11 @@ The JSON output contains type information.
 				return err
 			}
 
-			results, err := api.Unixfs().Ls(req.Context, pth,
+			results, errCh := api.Unixfs().Ls(req.Context, pth,
 				options.Unixfs.ResolveChildren(resolveSize || resolveType))
-			if err != nil {
-				return err
-			}
 
 			processLink, dirDone = processDir()
 			for link := range results {
-				if link.Err != nil {
-					return link.Err
-				}
 				var ftype unixfs_pb.Data_DataType
 				switch link.Type {
 				case iface.TFile:
@@ -173,6 +167,9 @@ The JSON output contains type information.
 				if err := processLink(paths[i], lsLink); err != nil {
 					return err
 				}
+			}
+			if err = <-errCh; err != nil {
+				return err
 			}
 			dirDone(i)
 		}

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -143,9 +144,9 @@ The JSON output contains type information.
 			}
 
 			results := make(chan iface.DirEntry)
-			var lsErr error
+			lsErr := make(chan error, 1)
 			go func() {
-				lsErr = api.Unixfs().Ls(lsCtx, pth, results,
+				lsErr <- api.Unixfs().Ls(lsCtx, pth, results,
 					options.Unixfs.ResolveChildren(resolveSize || resolveType))
 			}()
 
@@ -175,8 +176,8 @@ The JSON output contains type information.
 					return err
 				}
 			}
-			if lsErr != nil {
-				return lsErr
+			if err = <-lsErr; err != nil {
+				return err
 			}
 			dirDone(i)
 		}

--- a/core/commands/pin/pin.go
+++ b/core/commands/pin/pin.go
@@ -557,15 +557,8 @@ func pinLsAll(req *cmds.Request, typeStr string, detailed bool, name string, api
 		panic("unhandled pin type")
 	}
 
-	pins, err := api.Pin().Ls(req.Context, opt, options.Pin.Ls.Detailed(detailed), options.Pin.Ls.Name(name))
-	if err != nil {
-		return err
-	}
-
+	pins, errCh := api.Pin().Ls(req.Context, opt, options.Pin.Ls.Detailed(detailed), options.Pin.Ls.Name(name))
 	for p := range pins {
-		if err := p.Err(); err != nil {
-			return err
-		}
 		err = emit(PinLsOutputWrapper{
 			PinLsObject: PinLsObject{
 				Type: p.Type(),
@@ -577,8 +570,7 @@ func pinLsAll(req *cmds.Request, typeStr string, detailed bool, name string, api
 			return err
 		}
 	}
-
-	return nil
+	return <-errCh
 }
 
 const (

--- a/core/commands/pin/pin.go
+++ b/core/commands/pin/pin.go
@@ -557,13 +557,13 @@ func pinLsAll(req *cmds.Request, typeStr string, detailed bool, name string, api
 		panic("unhandled pin type")
 	}
 
-	var lsErr error
-	pins := make(chan iface.Pin)
+	pins := make(chan coreiface.Pin)
+	lsErr := make(chan error, 1)
 	lsCtx, cancel := context.WithCancel(req.Context)
 	defer cancel()
 
 	go func() {
-		lsErr = api.Pin().Ls(lsCtx, opt, pins, options.Pin.Ls.Detailed(detailed), options.Pin.Ls.Name(name))
+		lsErr <- api.Pin().Ls(lsCtx, pins, opt, options.Pin.Ls.Detailed(detailed), options.Pin.Ls.Name(name))
 	}()
 
 	for p := range pins {
@@ -578,7 +578,7 @@ func pinLsAll(req *cmds.Request, typeStr string, detailed bool, name string, api
 			return err
 		}
 	}
-	return lsErr
+	return <-lsErr
 }
 
 const (

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -351,12 +351,14 @@ func lsRemote(ctx context.Context, req *cmds.Request, c *pinclient.Client, out c
 		opts = append(opts, pinclient.PinOpts.FilterStatus(parsedStatuses...))
 	}
 
-	rmtOut, rmtErr := c.Ls(ctx, opts...)
-	for p := range rmtOut {
-		out <- p
-	}
-	return <-rmtErr
-	//return c.Ls2(ctx, out, opts...)
+	/*
+		rmtOut, rmtErr := c.Ls(ctx, opts...)
+		for p := range rmtOut {
+			out <- p
+		}
+		return <-rmtErr
+	*/
+	return c.Ls2(ctx, out, opts...)
 }
 
 var rmRemotePinCmd = &cmds.Command{

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -351,7 +351,7 @@ func lsRemote(ctx context.Context, req *cmds.Request, c *pinclient.Client, out c
 		opts = append(opts, pinclient.PinOpts.FilterStatus(parsedStatuses...))
 	}
 
-	return c.Ls2(ctx, out, opts...)
+	return c.Ls(ctx, out, opts...)
 }
 
 var rmRemotePinCmd = &cmds.Command{

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -351,13 +351,6 @@ func lsRemote(ctx context.Context, req *cmds.Request, c *pinclient.Client, out c
 		opts = append(opts, pinclient.PinOpts.FilterStatus(parsedStatuses...))
 	}
 
-	/*
-		rmtOut, rmtErr := c.Ls(ctx, opts...)
-		for p := range rmtOut {
-			out <- p
-		}
-		return <-rmtErr
-	*/
 	return c.Ls2(ctx, out, opts...)
 }
 

--- a/core/coreapi/pin.go
+++ b/core/coreapi/pin.go
@@ -352,11 +352,8 @@ func (api *PinAPI) pinLsAll(ctx context.Context, typeStr string, detailed bool, 
 					if emittedSet.Has(c) {
 						return true // skipped
 					}
-					addErr := AddToResultKeys(c, "", "indirect")
-					if addErr != nil {
-						return false
-					}
-					return true
+					addErr = AddToResultKeys(c, "", "indirect")
+					return addErr == nil
 				},
 				merkledag.SkipRoot(), merkledag.Concurrent(),
 			)

--- a/core/coreiface/pin.go
+++ b/core/coreiface/pin.go
@@ -47,8 +47,9 @@ type PinAPI interface {
 	// tree
 	Add(context.Context, path.Path, ...options.PinAddOption) error
 
-	// Ls returns list of pinned objects on this node
-	Ls(context.Context, ...options.PinLsOption) (<-chan Pin, <-chan error)
+	// Ls returns this node's pinned objects on the provided channel. The
+	// channel is closed when there are no more pins and an error is returned.
+	Ls(context.Context, chan<- Pin, ...options.PinLsOption) error
 
 	// IsPinned returns whether or not the given cid is pinned
 	// and an explanation of why its pinned

--- a/core/coreiface/pin.go
+++ b/core/coreiface/pin.go
@@ -18,9 +18,6 @@ type Pin interface {
 
 	// Type of the pin
 	Type() string
-
-	// if not nil, an error happened. Everything else should be ignored.
-	Err() error
 }
 
 // PinStatus holds information about pin health
@@ -51,7 +48,7 @@ type PinAPI interface {
 	Add(context.Context, path.Path, ...options.PinAddOption) error
 
 	// Ls returns list of pinned objects on this node
-	Ls(context.Context, ...options.PinLsOption) (<-chan Pin, error)
+	Ls(context.Context, ...options.PinLsOption) (<-chan Pin, <-chan error)
 
 	// IsPinned returns whether or not the given cid is pinned
 	// and an explanation of why its pinned

--- a/core/coreiface/tests/block.go
+++ b/core/coreiface/tests/block.go
@@ -323,12 +323,15 @@ func (tp *TestSuite) TestBlockPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pinsCh, errCh := api.Pin().Ls(ctx)
-	_, ok := <-pinsCh
-	if ok {
+	pinCh := make(chan coreiface.Pin)
+	go func() {
+		err = api.Pin().Ls(ctx, pinCh)
+	}()
+
+	for range pinCh {
 		t.Fatal("expected 0 pins")
 	}
-	if err = <-errCh; err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -342,7 +345,7 @@ func (tp *TestSuite) TestBlockPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pins, err := accPins(api.Pin().Ls(ctx))
+	pins, err := accPins(ctx, api)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/coreiface/tests/block.go
+++ b/core/coreiface/tests/block.go
@@ -323,8 +323,13 @@ func (tp *TestSuite) TestBlockPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pins, err := api.Pin().Ls(ctx); err != nil || len(pins) != 0 {
+	pinsCh, errCh := api.Pin().Ls(ctx)
+	_, ok := <-pinsCh
+	if ok {
 		t.Fatal("expected 0 pins")
+	}
+	if err = <-errCh; err != nil {
+		t.Fatal(err)
 	}
 
 	res, err := api.Block().Put(

--- a/core/coreiface/tests/pin.go
+++ b/core/coreiface/tests/pin.go
@@ -593,19 +593,15 @@ func assertNotPinned(t *testing.T, ctx context.Context, api iface.CoreAPI, p pat
 	}
 }
 
-func accPins(pins <-chan iface.Pin, err error) ([]iface.Pin, error) {
-	if err != nil {
+func accPins(pins <-chan iface.Pin, errs <-chan error) ([]iface.Pin, error) {
+	var results []iface.Pin
+
+	for pin := range pins {
+		results = append(results, pin)
+	}
+	if err := <-errs; err != nil {
 		return nil, err
 	}
 
-	var result []iface.Pin
-
-	for pin := range pins {
-		if pin.Err() != nil {
-			return nil, pin.Err()
-		}
-		result = append(result, pin)
-	}
-
-	return result, nil
+	return results, nil
 }

--- a/core/coreiface/tests/pin.go
+++ b/core/coreiface/tests/pin.go
@@ -67,7 +67,7 @@ func (tp *TestSuite) TestPinSimple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	list, err := accPins(api.Pin().Ls(ctx))
+	list, err := accPins(ctx, api)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func (tp *TestSuite) TestPinSimple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	list, err = accPins(api.Pin().Ls(ctx))
+	list, err = accPins(ctx, api)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	list, err := accPins(api.Pin().Ls(ctx))
+	list, err := accPins(ctx, api)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 		t.Errorf("unexpected pin list len: %d", len(list))
 	}
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Direct()))
+	list, err = accPins(ctx, api, opt.Pin.Ls.Direct())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 		t.Errorf("unexpected path, %s != %s", list[0].Path().String(), path.FromCid(nd3.Cid()).String())
 	}
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Recursive()))
+	list, err = accPins(ctx, api, opt.Pin.Ls.Recursive())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 		t.Errorf("unexpected path, %s != %s", list[0].Path().String(), path.FromCid(nd2.Cid()).String())
 	}
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Indirect()))
+	list, err = accPins(ctx, api, opt.Pin.Ls.Indirect())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,21 +436,21 @@ func getThreeChainedNodes(t *testing.T, ctx context.Context, api iface.CoreAPI, 
 func assertPinTypes(t *testing.T, ctx context.Context, api iface.CoreAPI, recusive, direct, indirect []cidContainer) {
 	assertPinLsAllConsistency(t, ctx, api)
 
-	list, err := accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Recursive()))
+	list, err := accPins(ctx, api, opt.Pin.Ls.Recursive())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assertPinCids(t, list, recusive...)
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Direct()))
+	list, err = accPins(ctx, api, opt.Pin.Ls.Direct())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assertPinCids(t, list, direct...)
 
-	list, err = accPins(api.Pin().Ls(ctx, opt.Pin.Ls.Indirect()))
+	list, err = accPins(ctx, api, opt.Pin.Ls.Indirect())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +500,7 @@ func assertPinCids(t *testing.T, pins []iface.Pin, cids ...cidContainer) {
 // assertPinLsAllConsistency verifies that listing all pins gives the same result as listing the pin types individually
 func assertPinLsAllConsistency(t *testing.T, ctx context.Context, api iface.CoreAPI) {
 	t.Helper()
-	allPins, err := accPins(api.Pin().Ls(ctx))
+	allPins, err := accPins(ctx, api)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +531,7 @@ func assertPinLsAllConsistency(t *testing.T, ctx context.Context, api iface.Core
 	}
 
 	for typeStr, pinProps := range typeMap {
-		pins, err := accPins(api.Pin().Ls(ctx, pinProps.PinLsOption))
+		pins, err := accPins(ctx, api, pinProps.PinLsOption)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -593,15 +593,19 @@ func assertNotPinned(t *testing.T, ctx context.Context, api iface.CoreAPI, p pat
 	}
 }
 
-func accPins(pins <-chan iface.Pin, errs <-chan error) ([]iface.Pin, error) {
-	var results []iface.Pin
+func accPins(ctx context.Context, api iface.CoreAPI, opts ...opt.PinLsOption) ([]iface.Pin, error) {
+	var err error
+	pins := make(chan iface.Pin)
+	go func() {
+		err = api.Pin().Ls(ctx, pins, opts...)
+	}()
 
+	var results []iface.Pin
 	for pin := range pins {
 		results = append(results, pin)
 	}
-	if err := <-errs; err != nil {
+	if err != nil {
 		return nil, err
 	}
-
 	return results, nil
 }

--- a/core/coreiface/tests/unixfs.go
+++ b/core/coreiface/tests/unixfs.go
@@ -544,7 +544,7 @@ func (tp *TestSuite) TestAddPinned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pins, err := accPins(api.Pin().Ls(ctx))
+	pins, err := accPins(ctx, api)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/coreiface/tests/unixfs.go
+++ b/core/coreiface/tests/unixfs.go
@@ -681,14 +681,11 @@ func (tp *TestSuite) TestLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entries, err := api.Unixfs().Ls(ctx, p)
-	if err != nil {
-		t.Fatal(err)
-	}
+	entries, errCh := api.Unixfs().Ls(ctx, p)
 
-	entry := <-entries
-	if entry.Err != nil {
-		t.Fatal(entry.Err)
+	entry, ok := <-entries
+	if !ok {
+		t.Fatal("expected another entry")
 	}
 	if entry.Size != 15 {
 		t.Errorf("expected size = 15, got %d", entry.Size)
@@ -702,9 +699,9 @@ func (tp *TestSuite) TestLs(t *testing.T) {
 	if entry.Cid.String() != "QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr" {
 		t.Errorf("expected cid = QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr, got %s", entry.Cid)
 	}
-	entry = <-entries
-	if entry.Err != nil {
-		t.Fatal(entry.Err)
+	entry, ok = <-entries
+	if !ok {
+		t.Fatal("expected another entry")
 	}
 	if entry.Type != coreiface.TSymlink {
 		t.Errorf("wrong type %s", entry.Type)
@@ -716,11 +713,12 @@ func (tp *TestSuite) TestLs(t *testing.T) {
 		t.Errorf("expected symlink target to be /foo/bar, got %s", entry.Target)
 	}
 
-	if l, ok := <-entries; ok {
-		t.Errorf("didn't expect a second link")
-		if l.Err != nil {
-			t.Error(l.Err)
-		}
+	_, ok = <-entries
+	if ok {
+		t.Errorf("didn't expect a another link")
+	}
+	if err = <-errCh; err != nil {
+		t.Error(err)
 	}
 }
 
@@ -779,13 +777,17 @@ func (tp *TestSuite) TestLsEmptyDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	links, err := api.Unixfs().Ls(ctx, p)
-	if err != nil {
+	links, errCh := api.Unixfs().Ls(ctx, p)
+	var count int
+	for range links {
+		count++
+	}
+	if err = <-errCh; err != nil {
 		t.Fatal(err)
 	}
 
-	if len(links) != 0 {
-		t.Fatalf("expected 0 links, got %d", len(links))
+	if count != 0 {
+		t.Fatalf("expected 0 links, got %d", count)
 	}
 }
 
@@ -808,13 +810,17 @@ func (tp *TestSuite) TestLsNonUnixfs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	links, err := api.Unixfs().Ls(ctx, path.FromCid(nd.Cid()))
-	if err != nil {
+	links, errCh := api.Unixfs().Ls(ctx, path.FromCid(nd.Cid()))
+	var count int
+	for range links {
+		count++
+	}
+	if err = <-errCh; err != nil {
 		t.Fatal(err)
 	}
 
-	if len(links) != 0 {
-		t.Fatalf("expected 0 links, got %d", len(links))
+	if count != 0 {
+		t.Fatalf("expected 0 links, got %d", count)
 	}
 }
 

--- a/core/coreiface/tests/unixfs.go
+++ b/core/coreiface/tests/unixfs.go
@@ -681,7 +681,11 @@ func (tp *TestSuite) TestLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entries, errCh := api.Unixfs().Ls(ctx, p)
+	errCh := make(chan error, 1)
+	entries := make(chan coreiface.DirEntry)
+	go func() {
+		errCh <- api.Unixfs().Ls(ctx, p, entries)
+	}()
 
 	entry, ok := <-entries
 	if !ok {
@@ -777,7 +781,12 @@ func (tp *TestSuite) TestLsEmptyDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	links, errCh := api.Unixfs().Ls(ctx, p)
+	errCh := make(chan error, 1)
+	links := make(chan coreiface.DirEntry)
+	go func() {
+		errCh <- api.Unixfs().Ls(ctx, p, links)
+	}()
+
 	var count int
 	for range links {
 		count++
@@ -810,7 +819,12 @@ func (tp *TestSuite) TestLsNonUnixfs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	links, errCh := api.Unixfs().Ls(ctx, path.FromCid(nd.Cid()))
+	errCh := make(chan error, 1)
+	links := make(chan coreiface.DirEntry)
+	go func() {
+		errCh <- api.Unixfs().Ls(ctx, path.FromCid(nd.Cid()), links)
+	}()
+
 	var count int
 	for range links {
 		count++

--- a/core/coreiface/unixfs.go
+++ b/core/coreiface/unixfs.go
@@ -2,6 +2,7 @@ package iface
 
 import (
 	"context"
+	"iter"
 	"os"
 	"time"
 
@@ -97,7 +98,6 @@ type UnixfsAPI interface {
 	Ls(context.Context, path.Path, ...options.UnixfsLsOption) (<-chan DirEntry, <-chan error)
 }
 
-/* TODO: Uncomment after go1.23 required.
 // LsIter returns a go iterator that allows ranging over DirEntry results.
 // Iteration stops if the context is canceled or if the iterator yields an
 // error.
@@ -120,9 +120,8 @@ func LsIter(ctx context.Context, api UnixfsAPI, p path.Path, opts ...options.Uni
 				return
 			}
 		}
-		if err != <-asyncErr; err != nil {
-			yield(nil, err)
+		if err := <-asyncErr; err != nil {
+			yield(DirEntry{}, err)
 		}
 	}
 }
-*/

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.23
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1
+	github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.37.2
 	github.com/multiformats/go-multiaddr v0.13.0
@@ -52,6 +52,8 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
+	github.com/gammazero/chanqueue v1.0.0 // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.23
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97
+	github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.37.2
 	github.com/multiformats/go-multiaddr v0.13.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.23
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d
+	github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.37.2
 	github.com/multiformats/go-multiaddr v0.13.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.23
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c
+	github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.37.2
 	github.com/multiformats/go-multiaddr v0.13.0

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.23
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda
+	github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.37.2
 	github.com/multiformats/go-multiaddr v0.13.0

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -164,6 +164,10 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/chanqueue v1.0.0 h1:FER/sMailGFA3DDvFooEkipAMU+3c9Bg3bheloPSz6o=
+github.com/gammazero/chanqueue v1.0.0/go.mod h1:fMwpwEiuUgpab0sH4VHiVcEoji1pSi+EIzeG4TPeKPc=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -298,8 +302,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1 h1:Ox1qTlON8qG46rUL7dDEwnIt7W9MhaidtvR/97RywWw=
-github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1/go.mod h1:Kxk43F+avGAsJSwhJW4isNYrpGwXHRJCvJ19Pt+MQc4=
+github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d h1:UgBskn6bIS4Qf2GrRkDDwMRYhMaPiwHuCSW1cp0m62Y=
+github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -302,8 +302,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 h1:jyDPeSYzI1TexvNPRuTeyHVk7gcrImN6MedfrgSB+U0=
-github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492 h1:kiS5+H+6aJeNWWDynuYu/ijgzkBTrInl++VFcNDgq+g=
+github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -302,8 +302,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c h1:tzST9q7koaEgJ1Xcu7D2/4D61ExvC0N3SSzCN/mEt/M=
-github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 h1:jyDPeSYzI1TexvNPRuTeyHVk7gcrImN6MedfrgSB+U0=
+github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -302,8 +302,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda h1:pw/JcDfod0D3nbOHhTBvnOFO0vhAV9+h7wJn3wx8ztM=
-github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c h1:tzST9q7koaEgJ1Xcu7D2/4D61ExvC0N3SSzCN/mEt/M=
+github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -302,8 +302,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d h1:UgBskn6bIS4Qf2GrRkDDwMRYhMaPiwHuCSW1cp0m62Y=
-github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda h1:pw/JcDfod0D3nbOHhTBvnOFO0vhAV9+h7wJn3wx8ztM=
+github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c
-	github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1
+	github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0
@@ -125,6 +125,8 @@ require (
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.6 // indirect
+	github.com/gammazero/chanqueue v1.0.0 // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/go-kit/log v0.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c
-	github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c
+	github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c
-	github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda
+	github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c
-	github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d
+	github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/ipfs-shipyard/nopfs v0.0.12
 	github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c
-	github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97
+	github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,10 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.6 h1:3+PzJTKLkvgjeTbts6msPJt4DixhT4YtFNf1gtGe3zc=
 github.com/gabriel-vasile/mimetype v1.4.6/go.mod h1:JX1qVKqZd40hUPpAfiNTe0Sne7hdfKSbOqqmkq8GCXc=
+github.com/gammazero/chanqueue v1.0.0 h1:FER/sMailGFA3DDvFooEkipAMU+3c9Bg3bheloPSz6o=
+github.com/gammazero/chanqueue v1.0.0/go.mod h1:fMwpwEiuUgpab0sH4VHiVcEoji1pSi+EIzeG4TPeKPc=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -362,8 +366,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1 h1:Ox1qTlON8qG46rUL7dDEwnIt7W9MhaidtvR/97RywWw=
-github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1/go.mod h1:Kxk43F+avGAsJSwhJW4isNYrpGwXHRJCvJ19Pt+MQc4=
+github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d h1:UgBskn6bIS4Qf2GrRkDDwMRYhMaPiwHuCSW1cp0m62Y=
+github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda h1:pw/JcDfod0D3nbOHhTBvnOFO0vhAV9+h7wJn3wx8ztM=
-github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c h1:tzST9q7koaEgJ1Xcu7D2/4D61ExvC0N3SSzCN/mEt/M=
+github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c h1:tzST9q7koaEgJ1Xcu7D2/4D61ExvC0N3SSzCN/mEt/M=
-github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 h1:jyDPeSYzI1TexvNPRuTeyHVk7gcrImN6MedfrgSB+U0=
+github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d h1:UgBskn6bIS4Qf2GrRkDDwMRYhMaPiwHuCSW1cp0m62Y=
-github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda h1:pw/JcDfod0D3nbOHhTBvnOFO0vhAV9+h7wJn3wx8ztM=
+github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c h1:7Uy
 github.com/ipfs-shipyard/nopfs/ipfs v0.13.2-0.20231027223058-cde3b5ba964c/go.mod h1:6EekK/jo+TynwSE/ZOiOJd4eEvRXoavEC3vquKtv4yI=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 h1:jyDPeSYzI1TexvNPRuTeyHVk7gcrImN6MedfrgSB+U0=
-github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492 h1:kiS5+H+6aJeNWWDynuYu/ijgzkBTrInl++VFcNDgq+g=
+github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1 // indirect
+	github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda // indirect
+	github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 // indirect
+	github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492 // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d // indirect
+	github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c // indirect
+	github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -162,6 +162,10 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
+github.com/gammazero/chanqueue v1.0.0 h1:FER/sMailGFA3DDvFooEkipAMU+3c9Bg3bheloPSz6o=
+github.com/gammazero/chanqueue v1.0.0/go.mod h1:fMwpwEiuUgpab0sH4VHiVcEoji1pSi+EIzeG4TPeKPc=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghostiam/protogetter v0.3.6 h1:R7qEWaSgFCsy20yYHNIJsU9ZOb8TziSRRxuAOTVKeOk=
 github.com/ghostiam/protogetter v0.3.6/go.mod h1:7lpeDnEJ1ZjL/YtyoN99ljO4z0pd3H0d18/t2dPBxHw=
@@ -318,8 +322,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1 h1:Ox1qTlON8qG46rUL7dDEwnIt7W9MhaidtvR/97RywWw=
-github.com/ipfs/boxo v0.24.4-0.20241125210908-37756ce2eeb1/go.mod h1:Kxk43F+avGAsJSwhJW4isNYrpGwXHRJCvJ19Pt+MQc4=
+github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d h1:UgBskn6bIS4Qf2GrRkDDwMRYhMaPiwHuCSW1cp0m62Y=
+github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -322,8 +322,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda h1:pw/JcDfod0D3nbOHhTBvnOFO0vhAV9+h7wJn3wx8ztM=
-github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c h1:tzST9q7koaEgJ1Xcu7D2/4D61ExvC0N3SSzCN/mEt/M=
+github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -322,8 +322,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 h1:jyDPeSYzI1TexvNPRuTeyHVk7gcrImN6MedfrgSB+U0=
-github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492 h1:kiS5+H+6aJeNWWDynuYu/ijgzkBTrInl++VFcNDgq+g=
+github.com/ipfs/boxo v0.24.4-0.20241203185533-3a3e8afa3492/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -322,8 +322,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d h1:UgBskn6bIS4Qf2GrRkDDwMRYhMaPiwHuCSW1cp0m62Y=
-github.com/ipfs/boxo v0.24.4-0.20241127172419-52a6a06b605d/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda h1:pw/JcDfod0D3nbOHhTBvnOFO0vhAV9+h7wJn3wx8ztM=
+github.com/ipfs/boxo v0.24.4-0.20241203042627-f06377d01dda/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -322,8 +322,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c h1:tzST9q7koaEgJ1Xcu7D2/4D61ExvC0N3SSzCN/mEt/M=
-github.com/ipfs/boxo v0.24.4-0.20241203095302-da800d8fa36c/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
+github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97 h1:jyDPeSYzI1TexvNPRuTeyHVk7gcrImN6MedfrgSB+U0=
+github.com/ipfs/boxo v0.24.4-0.20241203100953-39c797ea5f97/go.mod h1:lAoydO+oJhB1e7pUn4ju1Z1fuUIwy+zb0hQXRb/bu2g=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=


### PR DESCRIPTION
Asynchronous functions should return errors over channels instead of embedding the error in the result type.

Closes #9974
