### PR TITLE
chore: go 1.23(.2)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: actions/checkout@v4
       - run: docker build -t $IMAGE_NAME:$WIP_IMAGE_TAG .
       - run: docker run --rm $IMAGE_NAME:$WIP_IMAGE_TAG --version

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: protocol/cache-go-action@v1
         with:
           name: ${{ github.job }}
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: protocol/cache-go-action@v1
         with:
           name: ${{ github.job }}

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: actions/checkout@v4
       - run: make cmd/ipfs-try-build
         env:

--- a/.github/workflows/golang-analysis.yml
+++ b/.github/workflows/golang-analysis.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.x"
+          go-version: "1.23.x"
       - name: Check that go.mod is tidy
         uses: protocol/multiple-go-modules@v1.4
         with:

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -31,6 +31,6 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: actions/checkout@v4
       - run: make -O test_go_lint

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Check out Kubo
         uses: actions/checkout@v4
       - name: Install missing tools

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -10,7 +10,7 @@ on:
       - 'master'
 
 env:
-  GO_VERSION: 1.22.x
+  GO_VERSION: 1.23.x
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}

--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Checkout Kubo
         uses: actions/checkout@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22 AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.23 AS builder
 
 ARG TARGETOS TARGETARCH
 

--- a/docs/changelogs/v0.31.md
+++ b/docs/changelogs/v0.31.md
@@ -9,6 +9,7 @@
   - [Experimental Pebble Datastore](#experimental-pebble-datastore)
   - [New metrics](#new-metrics)
   - [`lowpower` profile no longer breaks DHT announcements](#lowpower-profile-no-longer-breaks-dht-announcements)
+  - [go 1.23, boxo 0.24 and go-libp2p 0.36.5](#go-123-boxo-024-and-go-libp2p-0365)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -42,6 +43,10 @@ This release changes [`lowpower` profile](https://github.com/ipfs/kubo/blob/mast
 > If you have `Reprovider.Interval` set to `0` you may want to wet it to `22h` (or run `ipfs config profile apply announce-on`) to fix your system.
 >
 > As a convenience, `ipfs daemon` will warn if reprovide system is disabled, creating oportinity to fix configuration if it was not intentional.
+
+#### go 1.23, boxo 0.24 and go-libp2p 0.36.5
+
+Various bugfixes. Please update.
 
 ### 📝 Changelog
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -1,6 +1,8 @@
 module github.com/ipfs/kubo/examples/kubo-as-a-library
 
-go 1.22
+go 1.23
+
+toolchain go1.23.2
 
 // Used to keep this in sync with the current version of kubo. You should remove
 // this if you copy this example.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/kubo
 
-go 1.22
+go 1.23
 
 require (
 	bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc


### PR DESCRIPTION
[go1.23.2 includes potential fix](https://github.com/golang/go/issues?q=milestone%3AGo1.23.2+label%3ACherryPickApproved) for issue described in https://github.com/ipfs/kubo/issues/10501


- [x] local A/B with 1.22 vs 1.23.2 confirming no regressions
  - [x] no longer leaks connections
  - [x] killing daemon via <kbd>^C</kbd> works
- [x] docker
- [x] ci

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Closes #10501
