### PR TITLE
feat: add entrypoint.sh and allow to specify more cli flags [skip changelog]

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Execute the daemon subcommand by default
+/sbin/tini -s -- /usr/local/bin/start_ipfs daemon \
+    --migrate=true \
+    --agent-version-suffix=docker \
+    ${CMD_EXTRA_FLAGS}


### PR DESCRIPTION
This pr adds the option to specify multiple cli flags to the kubo command without rebuilding the docker image by providing a `CMD_EXTRA_FLAGS` env variable.
