### PR TITLE
fix(autotls): store certificates at the location from the repo path

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -152,7 +152,7 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 
 		// Services (resource management)
 		fx.Provide(libp2p.ResourceManager(bcfg.Repo.Path(), cfg.Swarm, userResourceOverrides)),
-		maybeProvide(libp2p.P2PForgeCertMgr(cfg.AutoTLS), enableAutoTLS),
+		maybeProvide(libp2p.P2PForgeCertMgr(bcfg.Repo.Path(), cfg.AutoTLS), enableAutoTLS),
 		maybeInvoke(libp2p.StartP2PAutoTLS, enableAutoTLS),
 		fx.Provide(libp2p.AddrFilters(cfg.Swarm.AddrFilters)),
 		fx.Provide(libp2p.AddrsFactory(cfg.Addresses.Announce, cfg.Addresses.AppendAnnounce, cfg.Addresses.NoAnnounce)),

--- a/core/node/libp2p/addrs.go
+++ b/core/node/libp2p/addrs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	logging "github.com/ipfs/go-log"
 	version "github.com/ipfs/kubo"
@@ -132,12 +133,9 @@ func ListenOn(addresses []string) interface{} {
 	}
 }
 
-func P2PForgeCertMgr(cfg config.AutoTLS) interface{} {
+func P2PForgeCertMgr(repoPath string, cfg config.AutoTLS) interface{} {
 	return func() (*p2pforge.P2PForgeCertMgr, error) {
-		storagePath, err := config.Path("", "p2p-forge-certs")
-		if err != nil {
-			return nil, err
-		}
+		storagePath := filepath.Join(repoPath, "p2p-forge-certs")
 
 		forgeLogger := logging.Logger("autotls").Desugar()
 		certStorage := &certmagic.FileStorage{Path: storagePath}

--- a/docs/config.md
+++ b/docs/config.md
@@ -512,7 +512,8 @@ Kubo will obtain and set up a trusted PKI TLS certificate for it, making it dial
 >   - Right now, this is NOT used for hosting a [Gateway](#gateway) over HTTPS (that use case still requires manual TLS setup on reverse proxy, and your own domain).
 
 > [!TIP]
-> Debugging can be enabled by setting environment variable `GOLOG_LOG_LEVEL="error,autotls=debug,p2p-forge/client=debug"`
+> - Debugging can be enabled by setting environment variable `GOLOG_LOG_LEVEL="error,autotls=debug,p2p-forge/client=debug"`
+> - Certificates are stored in `$IPFS_PATH/p2p-forge-certs`. Removing directory and restarting daemon will trigger certificate rotation.
 
 Default: `false`
 
@@ -530,7 +531,7 @@ Type: `optionalString`
 ### `AutoTLS.RegistrationEndpoint`
 
 Optional override of [p2p-forge] HTTP registration API.
-Do not change this unless you self-host [p2p-forge].
+Do not change this unless you self-host [p2p-forge] under own domain.
 
 > [!IMPORTANT]
 > The default endpoint performs [libp2p Peer ID Authentication over HTTP](https://github.com/libp2p/specs/blob/master/http/peer-id-auth.md)
@@ -553,6 +554,10 @@ Type: `optionalString`
 ### `AutoTLS.CAEndpoint`
 
 Optional override of CA ACME API used by [p2p-forge] system.
+Do not change this unless you self-host [p2p-forge] under own domain.
+
+> [!IMPORTANT]
+> CAA DNS record at `libp2p.direct` limits CA choice to Let's Encrypt. If you want to use a different CA, use your own domain.
 
 Default: [certmagic.LetsEncryptProductionCA](https://pkg.go.dev/github.com/caddyserver/certmagic#pkg-constants) (see [community.letsencrypt.org discussion](https://community.letsencrypt.org/t/feedback-on-raising-certificates-per-registered-domain-to-enable-peer-to-peer-networking/223003))
 


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

This slipped through the crack, but it's basically the same fix as https://github.com/ipfs/kubo/pull/10492. We meant to get this in between when that PR landed and the initial AutoTLS one did but forgot. Could use a test to make sure it's correct before merging so we don't have to test it out with multiple repo paths manually.