### PR TITLE
chore: stop using go-homedir

### DIFF
--- a/client/rpc/api.go
+++ b/client/rpc/api.go
@@ -20,10 +20,10 @@ import (
 	ipfs "github.com/ipfs/kubo"
 	iface "github.com/ipfs/kubo/core/coreiface"
 	caopts "github.com/ipfs/kubo/core/coreiface/options"
+	"github.com/ipfs/kubo/misc/fsutil"
 	dagpb "github.com/ipld/go-codec-dagpb"
 	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
-	"github.com/mitchellh/go-homedir"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
@@ -82,7 +82,7 @@ func NewPathApi(ipfspath string) (*HttpApi, error) {
 
 // ApiAddr reads api file in specified ipfs path.
 func ApiAddr(ipfspath string) (ma.Multiaddr, error) {
-	baseDir, err := homedir.Expand(ipfspath)
+	baseDir, err := fsutil.ExpandHome(ipfspath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ipfswatch/main.go
+++ b/cmd/ipfswatch/main.go
@@ -16,12 +16,12 @@ import (
 	core "github.com/ipfs/kubo/core"
 	coreapi "github.com/ipfs/kubo/core/coreapi"
 	corehttp "github.com/ipfs/kubo/core/corehttp"
+	"github.com/ipfs/kubo/misc/fsutil"
 	fsrepo "github.com/ipfs/kubo/repo/fsrepo"
 
 	fsnotify "github.com/fsnotify/fsnotify"
 	"github.com/ipfs/boxo/files"
 	process "github.com/jbenet/goprocess"
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 var (
@@ -57,7 +57,7 @@ func run(ipfsPath, watchPath string) error {
 	proc := process.WithParent(process.Background())
 	log.Printf("running IPFSWatch on '%s' using repo at '%s'...", watchPath, ipfsPath)
 
-	ipfsPath, err := homedir.Expand(ipfsPath)
+	ipfsPath, err := fsutil.ExpandHome(ipfsPath)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/ipfs/kubo/misc/fsutil"
 )
 
 // Config is used to load ipfs config files.
@@ -59,7 +59,7 @@ func PathRoot() (string, error) {
 	dir := os.Getenv(EnvDir)
 	var err error
 	if len(dir) == 0 {
-		dir, err = homedir.Expand(DefaultPathRoot)
+		dir, err = fsutil.ExpandHome(DefaultPathRoot)
 	}
 	return dir, err
 }

--- a/docs/changelogs/v0.32.md
+++ b/docs/changelogs/v0.32.md
@@ -37,7 +37,7 @@ See [`AutoTLS`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotls)
 The `github.com/mitchellh/go-homedir` repo is archived, no longer needed, and no longer maintained.
 
 - `homedir.Dir` is replaced by the stdlib `os.UserHomeDir`
-- `homedir.Expand` is replaced by fsutil.ExpandHome` in the `github.com/ipfs/kubo/misc/fsutil` package.
+- `homedir.Expand` is replaced by `fsutil.ExpandHome` in the `github.com/ipfs/kubo/misc/fsutil` package.
 - The new `github.com/ipfs/kubo/misc/fsutil` package contains file utility code previously located elsewhere in kubo. 
 
 ### 📝 Changelog

--- a/docs/changelogs/v0.32.md
+++ b/docs/changelogs/v0.32.md
@@ -8,6 +8,7 @@
 - [🔦 Highlights](#-highlights)
   - [🎯 AutoTLS: Automatic Certificates for libp2p WebSockets via `libp2p.direct`](#-autotls-automatic-certificates-for-libp2p-websockets-via-libp2pdirect)
   - [📦️ Boxo and go-libp2p updates](#-boxo-and-go-libp2p-updates)
+  - [Replaced dependency on archived `github.com/mitchellh/go-homedir`](replaced-go-homedir)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -30,6 +31,14 @@ See [`AutoTLS`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotls)
   - This update required removal of `Swarm.RelayService.MaxReservationsPerPeer` configuration option from Kubo. If you had it set, remove it from your configuration file.
 - update `go-libp2p-kad-dht` to [v0.27.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.27.0)
 - update `go-libp2p-pubsub` to [v0.12.0](https://github.com/libp2p/go-libp2p-pubsub/releases/tag/v0.12.0)
+
+### Replaced go-homedir
+
+The `github.com/mitchellh/go-homedir` repo is archived, no longer needed, and no longer maintained.
+
+- `homedir.Dir` is replaced by the stdlib `os.UserHomeDir`
+- `homedir.Expand` is replaced by fsutil.ExpandHome` in the `github.com/ipfs/kubo/misc/fsutil` package.
+- The new `github.com/ipfs/kubo/misc/fsutil` package contains file utility code previously located elsewhere in kubo. 
 
 ### 📝 Changelog
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -143,7 +143,6 @@ require (
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -538,7 +538,6 @@ github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,6 @@ require (
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.4
 	github.com/libp2p/go-libp2p-testing v0.12.0
 	github.com/libp2p/go-socket-activation v0.1.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/multiformats/go-multiaddr-dns v0.4.0
 	github.com/multiformats/go-multibase v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -632,7 +632,6 @@ github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/misc/fsutil/fsutil.go
+++ b/misc/fsutil/fsutil.go
@@ -1,0 +1,82 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// DirWritable checks if a directory is writable. If the directory does
+// not exist it is created with writable permission.
+func DirWritable(dir string) error {
+	if dir == "" {
+		return errors.New("directory not specified")
+	}
+
+	var err error
+	dir, err = ExpandHome(dir)
+	if err != nil {
+		return err
+	}
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Directory does not exist, so create it.
+			err = os.Mkdir(dir, 0775)
+			if err == nil {
+				return nil
+			}
+		}
+		if errors.Is(err, fs.ErrPermission) {
+			err = fs.ErrPermission
+		}
+		return fmt.Errorf("directory not writable: %s: %w", dir, err)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("not a directory: %s", dir)
+	}
+
+	// Directory exists, check that a file can be written.
+	file, err := os.CreateTemp(dir, "writetest")
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			err = fs.ErrPermission
+		}
+		return fmt.Errorf("directory not writable: %s: %w", dir, err)
+	}
+	file.Close()
+	return os.Remove(file.Name())
+}
+
+// ExpandHome expands the path to include the home directory if the path is
+// prefixed with `~`. If it isn't prefixed with `~`, the path is returned
+// as-is.
+func ExpandHome(path string) (string, error) {
+	if path == "" {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+// FileExists return true if the file exists
+func FileExists(filename string) bool {
+	_, err := os.Lstat(filename)
+	return !errors.Is(err, os.ErrNotExist)
+}

--- a/misc/fsutil/fsutil_test.go
+++ b/misc/fsutil/fsutil_test.go
@@ -1,0 +1,92 @@
+package fsutil_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ipfs/kubo/misc/fsutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirWritable(t *testing.T) {
+	err := fsutil.DirWritable("")
+	require.Error(t, err)
+
+	err = fsutil.DirWritable("~nosuchuser/tmp")
+	require.Error(t, err)
+
+	tmpDir := t.TempDir()
+
+	wrDir := filepath.Join(tmpDir, "readwrite")
+	err = fsutil.DirWritable(wrDir)
+	require.NoError(t, err)
+
+	// Check that DirWritable created directory.
+	fi, err := os.Stat(wrDir)
+	require.NoError(t, err)
+	require.True(t, fi.IsDir())
+
+	err = fsutil.DirWritable(wrDir)
+	require.NoError(t, err)
+
+	// If running on Windows, skip read-only directory tests.
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
+	roDir := filepath.Join(tmpDir, "readonly")
+	require.NoError(t, os.Mkdir(roDir, 0500))
+	err = fsutil.DirWritable(roDir)
+	require.ErrorIs(t, err, fs.ErrPermission)
+
+	roChild := filepath.Join(roDir, "child")
+	err = fsutil.DirWritable(roChild)
+	require.ErrorIs(t, err, fs.ErrPermission)
+}
+
+func TestFileExists(t *testing.T) {
+	fileName := filepath.Join(t.TempDir(), "somefile")
+	require.False(t, fsutil.FileExists(fileName))
+
+	file, err := os.Create(fileName)
+	require.NoError(t, err)
+	file.Close()
+
+	require.True(t, fsutil.FileExists(fileName))
+}
+
+func TestExpandHome(t *testing.T) {
+	dir, err := fsutil.ExpandHome("")
+	require.NoError(t, err)
+	require.Equal(t, "", dir)
+
+	origDir := filepath.Join("somedir", "somesub")
+	dir, err = fsutil.ExpandHome(origDir)
+	require.NoError(t, err)
+	require.Equal(t, origDir, dir)
+
+	_, err = fsutil.ExpandHome(filepath.FromSlash("~nosuchuser/somedir"))
+	require.Error(t, err)
+
+	homeEnv := "HOME"
+	if runtime.GOOS == "windows" {
+		homeEnv = "USERPROFILE"
+	}
+	origHome := os.Getenv(homeEnv)
+	defer os.Setenv(homeEnv, origHome)
+	homeDir := filepath.Join(t.TempDir(), "testhome")
+	os.Setenv(homeEnv, homeDir)
+
+	const subDir = "mytmp"
+	origDir = filepath.Join("~", subDir)
+	dir, err = fsutil.ExpandHome(origDir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(homeDir, subDir), dir)
+
+	os.Unsetenv(homeEnv)
+	_, err = fsutil.ExpandHome(origDir)
+	require.Error(t, err)
+}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -18,15 +18,14 @@ import (
 	dir "github.com/ipfs/kubo/thirdparty/dir"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 
-	util "github.com/ipfs/boxo/util"
 	ds "github.com/ipfs/go-datastore"
 	measure "github.com/ipfs/go-ds-measure"
 	lockfile "github.com/ipfs/go-fs-lock"
 	logging "github.com/ipfs/go-log"
 	config "github.com/ipfs/kubo/config"
 	serialize "github.com/ipfs/kubo/config/serialize"
+	"github.com/ipfs/kubo/misc/fsutil"
 	"github.com/ipfs/kubo/repo/fsrepo/migrations"
-	homedir "github.com/mitchellh/go-homedir"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -207,7 +206,7 @@ func open(repoPath string, userConfigFilePath string) (repo.Repo, error) {
 }
 
 func newFSRepo(rpath string, userConfigFilePath string) (*FSRepo, error) {
-	expPath, err := homedir.Expand(filepath.Clean(rpath))
+	expPath, err := fsutil.ExpandHome(filepath.Clean(rpath))
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +238,7 @@ func configIsInitialized(path string) bool {
 	if err != nil {
 		return false
 	}
-	if !util.FileExists(configFilename) {
+	if !fsutil.FileExists(configFilename) {
 		return false
 	}
 	return true
@@ -269,7 +268,7 @@ func initSpec(path string, conf map[string]interface{}) error {
 		return err
 	}
 
-	if util.FileExists(fn) {
+	if fsutil.FileExists(fn) {
 		return nil
 	}
 

--- a/repo/fsrepo/migrations/ipfsdir.go
+++ b/repo/fsrepo/migrations/ipfsdir.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/ipfs/kubo/misc/fsutil"
 )
 
 const (
@@ -16,10 +16,6 @@ const (
 	defIpfsDir  = ".ipfs"
 	versionFile = "version"
 )
-
-func init() {
-	homedir.DisableCache = true
-}
 
 // IpfsDir returns the path of the ipfs directory.  If dir specified, then
 // returns the expanded version dir.  If dir is "", then return the directory
@@ -31,14 +27,14 @@ func IpfsDir(dir string) (string, error) {
 		dir = os.Getenv(envIpfsPath)
 	}
 	if dir != "" {
-		dir, err = homedir.Expand(dir)
+		dir, err = fsutil.ExpandHome(dir)
 		if err != nil {
 			return "", err
 		}
 		return dir, nil
 	}
 
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/repo/fsrepo/misc.go
+++ b/repo/fsrepo/misc.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	config "github.com/ipfs/kubo/config"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/ipfs/kubo/misc/fsutil"
 )
 
 // BestKnownPath returns the best known fsrepo path. If the ENV override is
@@ -15,7 +15,7 @@ func BestKnownPath() (string, error) {
 	if os.Getenv(config.EnvDir) != "" {
 		ipfsPath = os.Getenv(config.EnvDir)
 	}
-	ipfsPath, err := homedir.Expand(ipfsPath)
+	ipfsPath, err := fsutil.ExpandHome(ipfsPath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The `github.com/mitchellh/go-homedir` repo is archived, no longer needed, and no longer maintained.

- `homedir.Dir` is replaced by the stdlib `os.UserHomeDir`
- `homedir.Expand` is replaced by `fsutil.ExpandHome` in the `github.com/ipfs/kubo/misc/fsutil` package.

Additional functionality, such as `DirWritable` and `FileExists` was moved into or included in the `github.com/ipfs/kubo/misc/fsutil` package.
