### PR TITLE
fix: increase provider sample size

### DIFF
--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -14,8 +14,12 @@ import (
 	"go.uber.org/fx"
 )
 
+// The size of a batch that will be used for calculating average announcement
+// time per CID, inside of boxo/provider.ThroughputReport
+// and in 'ipfs stats provide' report.
+const sampledBatchSize = 1000
+
 func ProviderSys(reprovideInterval time.Duration, acceleratedDHTClient bool) fx.Option {
-	const magicThroughputReportCount = 128
 	return fx.Provide(func(lc fx.Lifecycle, cr irouting.ProvideManyRouter, keyProvider provider.KeyChanFunc, repo repo.Repo, bs blockstore.Blockstore) (provider.System, error) {
 		opts := []provider.Option{
 			provider.Online(cr),
@@ -105,7 +109,7 @@ https://github.com/ipfs/kubo/blob/master/docs/config.md#routingaccelerateddhtcli
 							keysProvided, avgProvideSpeed, count, avgProvideSpeed*time.Duration(count), reprovideInterval)
 					}
 					return false
-				}, magicThroughputReportCount))
+				}, sampledBatchSize))
 		}
 		sys, err := provider.New(repo.Datastore(), opts...)
 		if err != nil {


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

We had "magic number" 128 without any explanation.

Turns out the number informs many things, namely:
- The size of a batch that will be used for calculating average announcement time per CID, inside of `boxo/provider.ThroughputReport`
- the batch size in the output of `ipfs stats provide` command



This PR updates description + increases batch to 1000k to avoid false-positives asking users to enable accelerated clients when a desktop is under temporary load spike.