### PR TITLE
feat: support line comments in config

### DIFF
--- a/config/serialize/serialize.go
+++ b/config/serialize/serialize.go
@@ -1,4 +1,4 @@
-package fsrepo
+package serialize
 
 import (
 	"bufio"

--- a/config/serialize/serialize.go
+++ b/config/serialize/serialize.go
@@ -1,12 +1,14 @@
 package fsrepo
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ipfs/kubo/config"
 
@@ -16,6 +18,25 @@ import (
 // ErrNotInitialized is returned when we fail to read the config because the
 // repo doesn't exist.
 var ErrNotInitialized = errors.New("ipfs not initialized, please run 'ipfs init'")
+
+// removeCommentLines reads from the provided io.Reader, removes lines that
+// start with "//", and writes the result to the provided io.Writer.
+func removeCommentLines(r io.Reader, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimLeft(line, " ")
+		if !strings.HasPrefix(trimmed, "//") {
+			if _, err := writer.WriteString(line + "\n"); err != nil {
+				return err
+			}
+		}
+	}
+	return scanner.Err()
+}
 
 // ReadConfigFile reads the config from `filename` into `cfg`.
 func ReadConfigFile(filename string, cfg interface{}) error {
@@ -27,7 +48,17 @@ func ReadConfigFile(filename string, cfg interface{}) error {
 		return err
 	}
 	defer f.Close()
-	if err := json.NewDecoder(f).Decode(cfg); err != nil {
+
+	// Remove line comments (any line that has `\s*//`)
+	r, w := io.Pipe()
+	go func() {
+		if err := removeCommentLines(f, w); err != nil {
+			w.CloseWithError(err)
+			return
+		}
+		w.Close()
+	}()
+	if err := json.NewDecoder(r).Decode(cfg); err != nil {
 		return fmt.Errorf("failure to decode config: %w", err)
 	}
 	return nil

--- a/config/serialize/serialize_test.go
+++ b/config/serialize/serialize_test.go
@@ -1,4 +1,4 @@
-package fsrepo
+package serialize
 
 import (
 	"os"

--- a/plugin/loader/loader.go
+++ b/plugin/loader/loader.go
@@ -12,7 +12,7 @@ import (
 	config "github.com/ipfs/kubo/config"
 	"github.com/ipld/go-ipld-prime/multicodec"
 
-	serialize "github.com/ipfs/kubo/config/serialize"
+	"github.com/ipfs/kubo/config/serialize"
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/core/coreapi"
 	plugin "github.com/ipfs/kubo/plugin"

--- a/plugin/loader/loader.go
+++ b/plugin/loader/loader.go
@@ -1,7 +1,6 @@
 package loader
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +12,7 @@ import (
 	config "github.com/ipfs/kubo/config"
 	"github.com/ipld/go-ipld-prime/multicodec"
 
+	serialize "github.com/ipfs/kubo/config/serialize"
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/core/coreapi"
 	plugin "github.com/ipfs/kubo/plugin"
@@ -132,13 +132,7 @@ func readPluginsConfig(repoRoot string, userConfigFile string) (config.Plugins, 
 		return config.Plugins{}, err
 	}
 
-	cfgFile, err := os.Open(cfgPath)
-	if err != nil {
-		return config.Plugins{}, err
-	}
-	defer cfgFile.Close()
-
-	err = json.NewDecoder(cfgFile).Decode(&cfg)
+	err = serialize.ReadConfigFile(cfgPath, &cfg)
 	if err != nil {
 		return config.Plugins{}, err
 	}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -23,7 +23,7 @@ import (
 	lockfile "github.com/ipfs/go-fs-lock"
 	logging "github.com/ipfs/go-log"
 	config "github.com/ipfs/kubo/config"
-	serialize "github.com/ipfs/kubo/config/serialize"
+	"github.com/ipfs/kubo/config/serialize"
 	"github.com/ipfs/kubo/misc/fsutil"
 	"github.com/ipfs/kubo/repo/fsrepo/migrations"
 	ma "github.com/multiformats/go-multiaddr"


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Adds support for commenting out sections of your `.ipfs/config`

I find myself wanting to comment out sections as I tweak the config. But no strong preference here. Take it or leave it.