### PR TITLE
Correct spelling and improve readability in documentation

### DIFF
--- a/docs/add-code-flow.md
+++ b/docs/add-code-flow.md
@@ -1,6 +1,6 @@
 # IPFS : The `Add` command demystified
 
-The goal of this document is to capture the code flow for adding a file (see the `coreapi` package) using the IPFS CLI, in the process exploring some datastructures and packages like `ipld.Node` (aka `dagnode`), `FSNode`, `MFS`, etc.
+The goal of this document is to capture the code flow for adding a file (see the `coreapi` package) using the IPFS CLI, in the process exploring some data structures and packages like `ipld.Node` (aka `dagnode`), `FSNode`, `MFS`, etc.
 
 ## Concepts
 - [Files](https://github.com/ipfs/docs/issues/133)

--- a/docs/datastores.md
+++ b/docs/datastores.md
@@ -53,7 +53,7 @@ Uses [pebble](https://github.com/cockroachdb/pebble) as a key value store.
 }
 ```
 
-The following options are availble for tuning pebble.
+The following options are available for tuning pebble.
 If they are not configured (or assigned their zero-valued), then default values are used.
 
 * `bytesPerSync`: int, Sync sstables periodically in order to smooth out writes to disk. (default: 512KB)


### PR DESCRIPTION
**Description:**

This pull request addresses a couple of spelling and readability issues in the documentation files.

### Changes made:

1. **File:** `docs/add-code-flow.md`
   - **Change:** "datastructures" → "data structures"  
     **Reason:** The term "data structures" should be two words instead of a single word for better readability and consistency with common usage.

2. **File:** `docs/datastores.md`
   - **Change:** "availble" → "available"  
     **Reason:** Corrected the typo in the word "availble" to "available" in the section discussing the "pebbleds" datastore.

These changes are important because they improve the clarity and correctness of the documentation. While "datastructures" is not technically wrong, separating it into "data structures" is the more widely accepted form and improves readability. Similarly, the typo in "availble" could cause confusion and looks unprofessional, so it was corrected to "available" to maintain accuracy.

**Impact:**
These corrections enhance the overall user experience by ensuring the documentation is clear, precise, and free from typographical errors.

**Thank you for reviewing this update!**