### PR TITLE
fix some typos in docs

### DIFF
--- a/docs/add-code-flow.md
+++ b/docs/add-code-flow.md
@@ -1,6 +1,6 @@
 # IPFS : The `Add` command demystified
 
-The goal of this document is to capture the code flow for adding a file (see the `coreapi` package) using the IPFS CLI, in the process exploring some datastructures and packages like `ipld.Node` (aka `dagnode`), `FSNode`, `MFS`, etc.
+The goal of this document is to capture the code flow for adding a file (see the `coreapi` package) using the IPFS CLI, in the process exploring some data structures and packages like `ipld.Node` (aka `dagnode`), `FSNode`, `MFS`, etc.
 
 ## Concepts
 - [Files](https://github.com/ipfs/docs/issues/133)

--- a/docs/datastores.md
+++ b/docs/datastores.md
@@ -53,7 +53,7 @@ Uses [pebble](https://github.com/cockroachdb/pebble) as a key value store.
 }
 ```
 
-The following options are availble for tuning pebble.
+The following options are available for tuning pebble.
 If they are not configured (or assigned their zero-valued), then default values are used.
 
 * `bytesPerSync`: int, Sync sstables periodically in order to smooth out writes to disk. (default: 512KB)


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
