### PR TITLE
chore: fix broken url in comment

### DIFF
--- a/tracing/doc.go
+++ b/tracing/doc.go
@@ -6,7 +6,7 @@
 //
 // Tracing is configured through environment variables, as consistent with the OpenTelemetry spec as possible:
 //
-// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
 //
 // OTEL_TRACES_EXPORTER: a comma-separated list of exporters:
 //   - otlp


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

The previous link has expired and has been replaced with the latest address.