### PR TITLE
fix(cmds/add): disallow --wrap with --to-files

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -288,6 +288,10 @@ See 'dag export' and 'dag import' for more information.
 			return fmt.Errorf("%s and %s options are not compatible", onlyHashOptionName, toFilesOptionName)
 		}
 
+		if wrap && toFilesSet {
+			return fmt.Errorf("%s and %s options are not compatible", wrapOptionName, toFilesOptionName)
+		}
+
 		hashFunCode, ok := mh.Names[strings.ToLower(hashFunStr)]
 		if !ok {
 			return fmt.Errorf("unrecognized hash function: %q", strings.ToLower(hashFunStr))
@@ -373,6 +377,11 @@ See 'dag export' and 'dag import' for more information.
 
 				// creating MFS pointers when optional --to-files is set
 				if toFilesSet {
+					if addit.Name() == "" {
+						errCh <- fmt.Errorf("%s: cannot add unnamed files to MFS", toFilesOptionName)
+						return
+					}
+
 					if toFilesStr == "" {
 						toFilesStr = "/"
 					}

--- a/docs/changelogs/v0.33.md
+++ b/docs/changelogs/v0.33.md
@@ -6,6 +6,9 @@
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
+  - [Bitswap improvements from Boxo](#bitswap-improvements-from-boxo)
+  - [Using default `libp2p_rcmgr`  metrics](#using-default-libp2p_rcmgr--metrics)
+  - [`ipfs add --to-files` no longer works with `--wrap`](#ipfs-add---to-files-no-longer-works-with---wrap)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
@@ -24,6 +27,10 @@ Bespoke rcmgr metrics [were removed](https://github.com/ipfs/kubo/pull/9947), Ku
 This makes it easier to compare Kubo with custom implementations based on go-libp2p.
 If you depended on removed ones, please fill an issue to add them to the upstream [go-libp2p](https://github.com/libp2p/go-libp2p).
 
+#### `ipfs add --to-files` no longer works with `--wrap`
+
+Onboarding files and directories with `ipfs add --to-files` now requires non-empty names. due to this, The `--to-files` and `--wrap` options are now mutually exclusive ([#10612](https://github.com/ipfs/kubo/issues/10612)).
+
 #### 📦️ Dependency updates
 
 - update `boxo` to [v0.24.TODO](https://github.com/ipfs/boxo/releases/tag/v0.24.TODO)
@@ -31,7 +38,5 @@ If you depended on removed ones, please fill an issue to add them to the upstrea
 - update `p2p-forge/client` to [v0.1.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.1.0)
 
 ### 📝 Changelog
-
-- Fix: unnamed files in MFS. Disallow `--wrap` + `--to-files` when adding ([#10611](https://github.com/ipfs/kubo/issues/10611), [#10612](https://github.com/ipfs/kubo/issues/10612))
 
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/changelogs/v0.33.md
+++ b/docs/changelogs/v0.33.md
@@ -32,4 +32,6 @@ If you depended on removed ones, please fill an issue to add them to the upstrea
 
 ### 📝 Changelog
 
+- Fix: unnamed files in MFS. Disallow `--wrap` + `--to-files` when adding ([#10611](https://github.com/ipfs/kubo/issues/10611), [#10612](https://github.com/ipfs/kubo/issues/10612))
+
 ### 👨‍👩‍👧‍👦 Contributors

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -355,10 +355,10 @@ test_add_cat_file() {
     test_cmp expected actual
   '
 
-    test_must_fail "ipfs add with multiple files of same name but different dirs fails" '
+    test_expect_success "ipfs add with multiple files of same name but different dirs fails" '
       mkdir -p mountdir/same-file/ &&
       cp mountdir/hello.txt mountdir/same-file/hello.txt &&
-      ipfs add mountdir/hello.txt mountdir/same-file/hello.txt >actual &&
+      test_expect_code 1 ipfs add mountdir/hello.txt mountdir/same-file/hello.txt >actual &&
       rm mountdir/same-file/hello.txt  &&
       rmdir mountdir/same-file
     '
@@ -466,6 +466,15 @@ test_add_cat_file() {
     test_should_contain "test" lsout &&
     test_should_not_contain "mfs1.txt" lsout &&
     test_should_not_contain "mfs2.txt" lsout &&
+    ipfs files rm -r --force /mfs
+  '
+
+  # confirm -w and --to-files are exclusive
+  # context: https://github.com/ipfs/kubo/issues/10611
+  test_expect_success "ipfs add -r -w dir --to-files /mfs/subdir5/ errors (-w and --to-files are exclusive)" '
+    ipfs files mkdir -p /mfs/subdir5 &&
+    test_expect_code 1 ipfs add -r -w test --to-files /mfs/subdir5/ >actual 2>&1 &&
+    test_should_contain "Error" actual &&
     ipfs files rm -r --force /mfs
   '
 


### PR DESCRIPTION
Fixes #10611.

When we are adding to an MFS folder ("--to-files=folder/"), we append the filename to the folder name.

However, when wrapping, the wrapping folder has no name and `path.Base("")` returns `.`.

This creates a folder named "." inside the previous one. But mfs operations like `ls` think that "." is the current folder, and does not contemplate the option of a folder of name ".".

Dealing with unnamed files in MFS is in general a footgun, so this commits attempts to prohibit that case.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
