### PR TITLE
Fix typos

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -48,8 +48,8 @@ Logging can also be configured at runtime, both globally and on a per-subsystem 
 
 Specifies the log message format.  It supports the following values:
 
-- `color` -- human readable, colorized (ANSI) output
-- `nocolor` -- human readable, plain-text output.
+- `color` -- human-readable, colorized (ANSI) output
+- `nocolor` -- human-readable, plain-text output.
 - `json` -- structured JSON.
 
 For example, to log structured JSON (for easier parsing):

--- a/docs/file-transfer.md
+++ b/docs/file-transfer.md
@@ -36,7 +36,7 @@ doesn't even know it has to connect to node A.
 
 ### Checking for existing connections 
 
-The first thing to do is to double check that both nodes are in fact running
+The first thing to do is to double-check that both nodes are in fact running
 and online. To do this, run `ipfs id` on each machine. If both nodes show some
 addresses (like the example below), then your nodes are online.
 


### PR DESCRIPTION
This pull request corrects several typographical errors in the documentation:

- In `environment-variables.md`, the term "human readable" is updated to "human-readable" for consistency.
- In `file-transfer.md`, "double check" is updated to "double-check" as per the standard usage for compound verbs.

These changes improve clarity and consistency across the documentation.
