### PR TITLE
fix: typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ You can also install it through the Solus software center.
 
 #### Guix
 
-[Community Package for go-ipfs](https://packages.guix.gnu.org/packages/go-ipfs/0.11.0/) is no out-of-date.
+[Community Package for go-ipfs](https://packages.guix.gnu.org/packages/go-ipfs/0.11.0/) is now out-of-date.
 
 #### Snap
 


### PR DESCRIPTION
This pull request fixes a typo in the README.md file. Additionally, if required, the link to the current version of `go-ipfs` can be updated to the [latest version available](https://packages.guix.gnu.org/packages/go-ipfs/0.30.0/).

### Changes:
- Corrected a typo in the **Guix** section where "no out-of-date" was changed to "now out-of-date".

## Notes
If the current link to version `0.11.0` of `go-ipfs` is intended to remain as a historical reference, no changes are needed. Otherwise, the link can be updated to the latest version: [go-ipfs 0.30.0](https://packages.guix.gnu.org/packages/go-ipfs/0.30.0/).