### PR TITLE
chore: trigger gc if disk at minimum free space limit

### DIFF
--- a/config/datastore.go
+++ b/config/datastore.go
@@ -22,6 +22,7 @@ const (
 
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
+	DiskMinFreePercent float64
 	StorageMax         string // in B, kB, kiB, MB, ...
 	StorageGCWatermark int64  // in percentage to multiply on StorageMax
 	GCPeriod           string // in ns, us, ms, s, m, h

--- a/config/init.go
+++ b/config/init.go
@@ -130,6 +130,7 @@ func addressesConfig() Addresses {
 // DefaultDatastoreConfig is an internal function exported to aid in testing.
 func DefaultDatastoreConfig() Datastore {
 	return Datastore{
+		DiskMinFreePercent: 95,
 		StorageMax:         "10GB",
 		StorageGCWatermark: 90, // 90%
 		GCPeriod:           "1h",

--- a/core/corerepo/gc_test.go
+++ b/core/corerepo/gc_test.go
@@ -1,0 +1,22 @@
+package corerepo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckDiskFull(t *testing.T) {
+	repoDir := t.TempDir()
+
+	full, err := checkDiskFull(repoDir, 99.9)
+	require.NoError(t, err)
+	require.False(t, full)
+
+	full, err = checkDiskFull(repoDir, 0.01)
+	require.NoError(t, err)
+	require.True(t, full)
+
+	_, err = checkDiskFull("/no/such/directory", 90)
+	require.Error(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/elgris/jsondiff v0.0.0-20160530203242-765b5c24c302
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5
 	github.com/fsnotify/fsnotify v1.7.0
+	github.com/gammazero/fsutil v0.1.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/gammazero/chanqueue v1.0.0 h1:FER/sMailGFA3DDvFooEkipAMU+3c9Bg3bheloP
 github.com/gammazero/chanqueue v1.0.0/go.mod h1:fMwpwEiuUgpab0sH4VHiVcEoji1pSi+EIzeG4TPeKPc=
 github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
 github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
+github.com/gammazero/fsutil v0.1.1 h1:sWMlUs9BhBIqnsV77B3eS1ZAedoJhCuTmLiF/qrLNlU=
+github.com/gammazero/fsutil v0.1.1/go.mod h1:HYJutEsW337gztmm4HTN4XrlQI6WRNWSOjcpcAhttME=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
Add check to see if the remaining free space is too low, and if so that should trigger GC to run.

- New config value: Datastore.DiskMinFreePercent
- Default value: 95

If the percentage of free space on the datastore volume drops below this amount than run GC. The percentage must be from 0 to 100. A value of 0 (unset) results in the default being used. A value of < 0 or > 100 disables this check.

Closes #10648
