### PR TITLE
fix(cli): support HTTPS in ipfs --api

### DIFF
--- a/cmd/ipfs/kubo/start.go
+++ b/cmd/ipfs/kubo/start.go
@@ -330,6 +330,11 @@ func makeExecutor(req *cmds.Request, env interface{}) (cmds.Executor, error) {
 	switch network {
 	case "tcp", "tcp4", "tcp6":
 		tpt = http.DefaultTransport
+		// RPC over HTTPS requires explicit schema in the address passed to cmdhttp.NewClient
+		httpAddr := apiAddr.String()
+		if !strings.HasPrefix(host, "http:") && !strings.HasPrefix(host, "https:") && (strings.Contains(httpAddr, "/https") || strings.Contains(httpAddr, "/tls/http")) {
+			host = "https://" + host
+		}
 	case "unix":
 		path := host
 		host = "unix"

--- a/docs/changelogs/v0.33.md
+++ b/docs/changelogs/v0.33.md
@@ -66,6 +66,11 @@ Onboarding files and directories with `ipfs add --to-files` now requires non-emp
 
 CLI and RPC client now supports accessing Kubo RPC over `https://` protocol when multiaddr ending with `/https` or `/tls/http` is passed to `ipfs --api`:
 
+```console
+$ ipfs id --api /dns/kubo-rpc.example.net/tcp/5001/tls/http
+# → https://kubo-rpc.example.net:5001
+```
+
 #### New options for faster writes: `WriteThrough`, `BlockKeyCacheSize`, `BatchMaxNodes`, `BatchMaxSize`
 
 Now that Kubo supports [`pebble`](https://github.com/ipfs/kubo/blob/master/docs/datastores.md#pebbleds) as a datastore backend, it becomes very useful to expose some additional configuration options for how the blockservice/blockstore/datastore combo behaves.

--- a/docs/changelogs/v0.33.md
+++ b/docs/changelogs/v0.33.md
@@ -12,6 +12,7 @@
   - [Using default `libp2p_rcmgr`  metrics](#using-default-libp2p_rcmgr--metrics)
   - [Flatfs does not `sync` on each write](#flatfs-does-not-sync-on-each-write)
   - [`ipfs add --to-files` no longer works with `--wrap`](#ipfs-add---to-files-no-longer-works-with---wrap)
+  - [`ipfs --api` supports HTTPS RPC endpoints](#ipfs---api-supports-https-rpc-endpoints)
   - [New options for faster writes: `WriteThrough`, `BlockKeyCacheSize`, `BatchMaxNodes`, `BatchMaxSize`](#new-options-for-faster-writes-writethrough-blockkeycachesize-batchmaxnodes-batchmaxsize)
   - [MFS stability with large number of writes](#mfs-stability-with-large-number-of-writes)
   - [📦️ Important dependency updates](#-important-dependency-updates)
@@ -61,6 +62,10 @@ The old default was overly conservative and caused performance issues in big rep
 
 Onboarding files and directories with `ipfs add --to-files` now requires non-empty names. due to this, The `--to-files` and `--wrap` options are now mutually exclusive ([#10612](https://github.com/ipfs/kubo/issues/10612)).
 
+#### `ipfs --api` supports HTTPS RPC endpoints
+
+CLI and RPC client now supports accessing Kubo RPC over `https://` protocol when multiaddr ending with `/https` or `/tls/http` is passed to `ipfs --api`:
+
 #### New options for faster writes: `WriteThrough`, `BlockKeyCacheSize`, `BatchMaxNodes`, `BatchMaxSize`
 
 Now that Kubo supports [`pebble`](https://github.com/ipfs/kubo/blob/master/docs/datastores.md#pebbleds) as a datastore backend, it becomes very useful to expose some additional configuration options for how the blockservice/blockstore/datastore combo behaves.
@@ -89,7 +94,6 @@ We have fixed a number of issues that were triggered by writing or copying many 
 - update `go-libp2p` to [v0.38.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.38.1) (incl. [v0.37.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.37.1) + [v0.37.2](https://github.com/libp2p/go-libp2p/releases/tag/v0.37.2) + [v0.38.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.38.0))
 - update `p2p-forge/client` to [v0.2.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.2.0) (incl. [v0.1.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.1.0))
 - update `ipfs-webui` to [v4.4.2](https://github.com/ipfs/ipfs-webui/releases/tag/v4.4.2) (incl. [v4.4.1](https://github.com/ipfs/ipfs-webui/releases/tag/v4.4.1))
-
 
 #### Escape Redirect URL for Directory
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/ipfs/go-ds-measure v0.2.0
 	github.com/ipfs/go-ds-pebble v0.4.0
 	github.com/ipfs/go-fs-lock v0.0.7
-	github.com/ipfs/go-ipfs-cmds v0.14.1-0.20250110194328-5b1af499e0a1
+	github.com/ipfs/go-ipfs-cmds v0.14.1
 	github.com/ipfs/go-ipld-cbor v0.2.0
 	github.com/ipfs/go-ipld-format v0.6.0
 	github.com/ipfs/go-ipld-git v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/ipfs/go-ds-measure v0.2.0
 	github.com/ipfs/go-ds-pebble v0.4.0
 	github.com/ipfs/go-fs-lock v0.0.7
-	github.com/ipfs/go-ipfs-cmds v0.14.0
+	github.com/ipfs/go-ipfs-cmds v0.14.1-0.20250110194328-5b1af499e0a1
 	github.com/ipfs/go-ipld-cbor v0.2.0
 	github.com/ipfs/go-ipld-format v0.6.0
 	github.com/ipfs/go-ipld-git v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/ipfs/go-ipfs-blockstore v1.3.1 h1:cEI9ci7V0sRNivqaOr0elDsamxXFxJMMMy7
 github.com/ipfs/go-ipfs-blockstore v1.3.1/go.mod h1:KgtZyc9fq+P2xJUiCAzbRdhhqJHvsw8u2Dlqy2MyRTE=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IWFJMcGIPQ=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
-github.com/ipfs/go-ipfs-cmds v0.14.1-0.20250110194328-5b1af499e0a1 h1:IJsO+hla34/mDMrIrErrgt18zIVU4JA0JhU8Zd4T1z4=
-github.com/ipfs/go-ipfs-cmds v0.14.1-0.20250110194328-5b1af499e0a1/go.mod h1:SCYxNUVPeVR05cE8DJ6wyH2+aQ8vPgjxxkxQWOXobzo=
+github.com/ipfs/go-ipfs-cmds v0.14.1 h1:TA8vBixPwXL3k7VtcbX3r4FQgw2m+jMOWlslUOlM9Rs=
+github.com/ipfs/go-ipfs-cmds v0.14.1/go.mod h1:SCYxNUVPeVR05cE8DJ6wyH2+aQ8vPgjxxkxQWOXobzo=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/ipfs/go-ipfs-blockstore v1.3.1 h1:cEI9ci7V0sRNivqaOr0elDsamxXFxJMMMy7
 github.com/ipfs/go-ipfs-blockstore v1.3.1/go.mod h1:KgtZyc9fq+P2xJUiCAzbRdhhqJHvsw8u2Dlqy2MyRTE=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IWFJMcGIPQ=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
-github.com/ipfs/go-ipfs-cmds v0.14.0 h1:sxdurhAHSdQr5VrSNJjc+t92uJObSNq+gRVm/wLZGMM=
-github.com/ipfs/go-ipfs-cmds v0.14.0/go.mod h1:zj2jN7bHJ4pDucRmqdq863AQYcsqdxXrfVkr9eqPfvo=
+github.com/ipfs/go-ipfs-cmds v0.14.1-0.20250110194328-5b1af499e0a1 h1:IJsO+hla34/mDMrIrErrgt18zIVU4JA0JhU8Zd4T1z4=
+github.com/ipfs/go-ipfs-cmds v0.14.1-0.20250110194328-5b1af499e0a1/go.mod h1:SCYxNUVPeVR05cE8DJ6wyH2+aQ8vPgjxxkxQWOXobzo=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=

--- a/test/cli/cli_https_test.go
+++ b/test/cli/cli_https_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIWithRemoteHTTPS(t *testing.T) {
+	tests := []struct{ addrSuffix string }{{"https"}, {"tls/http"}}
+	for _, tt := range tests {
+		t.Run("with "+tt.addrSuffix+" multiaddr", func(t *testing.T) {
+
+			// Create HTTPS test server
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.TLS == nil {
+					t.Error("Mocked Kubo RPC received plain HTTP request instead of HTTPS TLS Handshake")
+				}
+				_, _ = w.Write([]byte("OK"))
+			}))
+			defer server.Close()
+
+			serverURL, _ := url.Parse(server.URL)
+			_, port, _ := net.SplitHostPort(serverURL.Host)
+
+			// Create Kubo repo
+			node := harness.NewT(t).NewNode().Init()
+
+			// Attempt to talk to remote Kubo RPC endpoint over HTTPS
+			resp := node.RunIPFS("id", "--api", fmt.Sprintf("/ip4/127.0.0.1/tcp/%s/%s", port, tt.addrSuffix))
+
+			// Expect HTTPS error (confirming TLS and https:// were used, and not Cleartext HTTP)
+			require.Error(t, resp.Err)
+			require.Contains(t, resp.Stderr.String(), "Error: tls: failed to verify certificate: x509: certificate signed by unknown authority")
+
+			node.StopDaemon()
+
+		})
+	}
+}


### PR DESCRIPTION
Closes #10539

- [x] switch to release with https://github.com/ipfs/go-ipfs-cmds/pull/277
- [x] test that ensures `/tls/http`  forces `https://` and fails if cli `ipfs --api [..]/tls/http` talks plaintext

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
