### PR TITLE
fix(autotls): renewal and AutoTLS.ShortAddrs

### DIFF
--- a/config/autotls.go
+++ b/config/autotls.go
@@ -23,6 +23,9 @@ type AutoTLS struct {
 
 	// Optional override of CA ACME API used by p2p-forge system
 	CAEndpoint *OptionalString `json:",omitempty"`
+
+	// Optional, controls if features like AutoWSS should generate shorter /dnsX instead of /ipX/../sni/..
+	ShortAddrs Flag `json:",omitempty"`
 }
 
 const (
@@ -31,4 +34,5 @@ const (
 	DefaultRegistrationEndpoint = p2pforge.DefaultForgeEndpoint
 	DefaultCAEndpoint           = p2pforge.DefaultCAEndpoint
 	DefaultAutoWSS              = true // requires AutoTLS.Enabled
+	DefaultAutoTLSShortAddrs    = true // requires AutoTLS.Enabled
 )

--- a/core/node/libp2p/addrs.go
+++ b/core/node/libp2p/addrs.go
@@ -136,11 +136,12 @@ func ListenOn(addresses []string) interface{} {
 func P2PForgeCertMgr(repoPath string, cfg config.AutoTLS, atlsLog *logging.ZapEventLogger) interface{} {
 	return func() (*p2pforge.P2PForgeCertMgr, error) {
 		storagePath := filepath.Join(repoPath, "p2p-forge-certs")
-
-		// TODO: this should not be necessary, but we do it to help tracking
-		// down any race conditions causing
-		// https://github.com/ipshipyard/p2p-forge/issues/8
 		rawLogger := atlsLog.Desugar()
+
+		// TODO: this should not be necessary after
+		// https://github.com/ipshipyard/p2p-forge/pull/42 but keep it here for
+		// now to help tracking down any remaining conditions causing
+		// https://github.com/ipshipyard/p2p-forge/issues/8
 		certmagic.Default.Logger = rawLogger.Named("default_fixme")
 		certmagic.DefaultACME.Logger = rawLogger.Named("default_acme_client_fixme")
 
@@ -153,6 +154,7 @@ func P2PForgeCertMgr(repoPath string, cfg config.AutoTLS, atlsLog *logging.ZapEv
 			p2pforge.WithForgeAuth(cfg.RegistrationToken.WithDefault(os.Getenv(p2pforge.ForgeAuthEnv))),
 			p2pforge.WithUserAgent(version.GetUserAgentVersion()),
 			p2pforge.WithCertificateStorage(certStorage),
+			p2pforge.WithShortForgeAddrs(cfg.ShortAddrs.WithDefault(config.DefaultAutoTLSShortAddrs)),
 		)
 		if err != nil {
 			return nil, err

--- a/docs/changelogs/v0.33.md
+++ b/docs/changelogs/v0.33.md
@@ -104,7 +104,7 @@ We have fixed a number of issues that were triggered by writing or copying many 
 - update `boxo` to [v0.27.0](https://github.com/ipfs/boxo/releases/tag/v0.27.0) (incl. [v0.25.0](https://github.com/ipfs/boxo/releases/tag/v0.25.0) + [v0.26.0](https://github.com/ipfs/boxo/releases/tag/v0.26.0) )
 - update `go-libp2p` to [v0.38.2](https://github.com/libp2p/go-libp2p/releases/tag/v0.38.2) (incl. [v0.37.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.37.1) + [v0.37.2](https://github.com/libp2p/go-libp2p/releases/tag/v0.37.2) + [v0.38.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.38.0) + [v0.38.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.38.1))
 - update `go-libp2p-kad-dht` to [v0.28.2](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.28.2)
-- update `p2p-forge/client` to [v0.2.2](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.2.2) (incl. [v0.1.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.1.0), [v0.2.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.2.0), [v0.2.1](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.2.1))
+- update `p2p-forge/client` to [v0.3.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.3.0) (incl. [v0.1.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.1.0), [v0.2.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.2.0), [v0.2.1](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.2.1), [v0.2.2](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.2.2))
 - update `ipfs-webui` to [v4.4.2](https://github.com/ipfs/ipfs-webui/releases/tag/v4.4.2) (incl. [v4.4.1](https://github.com/ipfs/ipfs-webui/releases/tag/v4.4.1))
 
 #### Escape Redirect URL for Directory

--- a/docs/config.md
+++ b/docs/config.md
@@ -30,6 +30,7 @@ config file at runtime.
   - [`AutoTLS`](#autotls)
     - [`AutoTLS.Enabled`](#autotlsenabled)
     - [`AutoTLS.AutoWSS`](#autotlsautowss)
+    - [`AutoTLS.ShortAddrs`](#autotlsshortaddrs)
     - [`AutoTLS.DomainSuffix`](#autotlsdomainsuffix)
     - [`AutoTLS.RegistrationEndpoint`](#autotlsregistrationendpoint)
     - [`AutoTLS.RegistrationToken`](#autotlsregistrationtoken)
@@ -527,6 +528,17 @@ Type: `flag`
 Optional. Controls if Kubo should add `/tls/sni/*.libp2p.direct/ws` listener to every pre-existing `/tcp` port IFF no explicit `/ws` is defined in [`Addresses.Swarm`](#addressesswarm) already.
 
 Default: `true` (active only if `AutoTLS.Enabled` is `true` as well)
+
+Type: `flag`
+
+### `AutoTLS.ShortAddrs`
+
+Optional. Controls if final AutoTLS listeners are announced under shorter `/dnsX/A.B.C.D.peerid.libp2p.direct/tcp/4001/tls/ws` addresses instead of fully resolved `/ip4/A.B.C.D/tcp/4001/tls/sni/A-B-C-D.peerid.libp2p.direct/tls/ws`.
+
+> [!TIP]
+> The main use for AutoTLS is allowing connectivity from Secure Context in a web browser, and DNS lookup needs to happen there anyway, making `/dnsX` a more compact, more interoperable option without obvious downside.
+
+Default: `true`
 
 Type: `flag`
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/ipld/go-car/v2 v2.14.2 // indirect
 	github.com/ipld/go-codec-dagpb v1.6.0 // indirect
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
-	github.com/ipshipyard/p2p-forge v0.2.2 // indirect
+	github.com/ipshipyard/p2p-forge v0.3.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -407,8 +407,8 @@ github.com/ipld/go-ipld-prime v0.21.0 h1:n4JmcpOlPDIxBcY037SVfpd1G+Sj1nKZah0m6QH
 github.com/ipld/go-ipld-prime v0.21.0/go.mod h1:3RLqy//ERg/y5oShXXdx5YIp50cFGOanyMctpPjsvxQ=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:wZ8hH8UxeryOs4kJEJaiui/s00hDSbE37OKsL47g+Sw=
-github.com/ipshipyard/p2p-forge v0.2.2 h1:S8NlZ++AMIiXpOPjRGXg6Ob3Bb1K8wuBxRm2f9eRQWE=
-github.com/ipshipyard/p2p-forge v0.2.2/go.mod h1:L0TJMzniMEDjX8G+RB201U2woHvASwbsujNVDNVivDo=
+github.com/ipshipyard/p2p-forge v0.3.0 h1:mdeFqiq8ljX149OCQvveV0vOlKeIt4PWkJjXVfux/GE=
+github.com/ipshipyard/p2p-forge v0.3.0/go.mod h1:L0TJMzniMEDjX8G+RB201U2woHvASwbsujNVDNVivDo=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/ipld/go-car/v2 v2.14.2
 	github.com/ipld/go-codec-dagpb v1.6.0
 	github.com/ipld/go-ipld-prime v0.21.0
-	github.com/ipshipyard/p2p-forge v0.2.2
+	github.com/ipshipyard/p2p-forge v0.3.0
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/ipld/go-ipld-prime v0.21.0 h1:n4JmcpOlPDIxBcY037SVfpd1G+Sj1nKZah0m6QH
 github.com/ipld/go-ipld-prime v0.21.0/go.mod h1:3RLqy//ERg/y5oShXXdx5YIp50cFGOanyMctpPjsvxQ=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:wZ8hH8UxeryOs4kJEJaiui/s00hDSbE37OKsL47g+Sw=
-github.com/ipshipyard/p2p-forge v0.2.2 h1:S8NlZ++AMIiXpOPjRGXg6Ob3Bb1K8wuBxRm2f9eRQWE=
-github.com/ipshipyard/p2p-forge v0.2.2/go.mod h1:L0TJMzniMEDjX8G+RB201U2woHvASwbsujNVDNVivDo=
+github.com/ipshipyard/p2p-forge v0.3.0 h1:mdeFqiq8ljX149OCQvveV0vOlKeIt4PWkJjXVfux/GE=
+github.com/ipshipyard/p2p-forge v0.3.0/go.mod h1:L0TJMzniMEDjX8G+RB201U2woHvASwbsujNVDNVivDo=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0 h1:Vc/s0QbQtoxX8MwwSLWWh+xNNZvM3Lw7NsTcHrvvhMc=

--- a/test/cli/harness/peering.go
+++ b/test/cli/harness/peering.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"testing"
 
 	"github.com/ipfs/kubo/config"
@@ -14,6 +15,13 @@ type Peering struct {
 }
 
 func NewRandPort() int {
+	if a, err := net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+		var l *net.TCPListener
+		if l, err = net.ListenTCP("tcp", a); err == nil {
+			defer l.Close()
+			return l.Addr().(*net.TCPAddr).Port
+		}
+	}
 	n := rand.Int()
 	return 3000 + (n % 1000)
 }

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/ipfs/kubo v0.31.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.6.0 // indirect
 	github.com/ipld/go-ipld-prime v0.21.0 // indirect
-	github.com/ipshipyard/p2p-forge v0.2.2 // indirect
+	github.com/ipshipyard/p2p-forge v0.3.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -364,8 +364,8 @@ github.com/ipld/go-codec-dagpb v1.6.0 h1:9nYazfyu9B1p3NAgfVdpRco3Fs2nFC72DqVsMj6
 github.com/ipld/go-codec-dagpb v1.6.0/go.mod h1:ANzFhfP2uMJxRBr8CE+WQWs5UsNa0pYtmKZ+agnUw9s=
 github.com/ipld/go-ipld-prime v0.21.0 h1:n4JmcpOlPDIxBcY037SVfpd1G+Sj1nKZah0m6QH9C2E=
 github.com/ipld/go-ipld-prime v0.21.0/go.mod h1:3RLqy//ERg/y5oShXXdx5YIp50cFGOanyMctpPjsvxQ=
-github.com/ipshipyard/p2p-forge v0.2.2 h1:S8NlZ++AMIiXpOPjRGXg6Ob3Bb1K8wuBxRm2f9eRQWE=
-github.com/ipshipyard/p2p-forge v0.2.2/go.mod h1:L0TJMzniMEDjX8G+RB201U2woHvASwbsujNVDNVivDo=
+github.com/ipshipyard/p2p-forge v0.3.0 h1:mdeFqiq8ljX149OCQvveV0vOlKeIt4PWkJjXVfux/GE=
+github.com/ipshipyard/p2p-forge v0.3.0/go.mod h1:L0TJMzniMEDjX8G+RB201U2woHvASwbsujNVDNVivDo=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=


### PR DESCRIPTION
This PR is part of #10560 and #10580 
- updates to p2p-forge/client to version with fix from https://github.com/ipshipyard/p2p-forge/pull/42
- adds `AutoTLS.ShortAddrs` flag and enables it by default to benefit from shorter addrs discussed in https://github.com/ipshipyard/p2p-forge/pull/40

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


