### PR TITLE
fix: go version format in go.mod. [skip changelog]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/kubo
 
-go 1.23
+go 1.23.0
 
 require (
 	bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc


### PR DESCRIPTION
Fixes issue #10675.
I changed the go version in go.mod from 1.23 to 1.23.0, and the project built successfully.
https://stackoverflow.com/questions/78519711/toolchain-not-available-error-prevents-me-from-using-any-go-commands

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
