### PR TITLE
feat: Better self-service commands for DHT providing [skip changelog]

### DIFF
--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -24,7 +24,6 @@ var BitswapCmd = &cmds.Command{
 		"stat":      bitswapStatCmd,
 		"wantlist":  showWantlistCmd,
 		"ledger":    ledgerCmd,
-		"reprovide": reprovideCmd,
 	},
 }
 
@@ -198,31 +197,5 @@ prints the ledger associated with a given peer.
 				out.Sent, out.Recv)
 			return nil
 		}),
-	},
-}
-
-var reprovideCmd = &cmds.Command{
-	Helptext: cmds.HelpText{
-		Tagline: "Trigger reprovider.",
-		ShortDescription: `
-Trigger reprovider to announce our data to network.
-`,
-	},
-	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		nd, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
-		if !nd.IsOnline {
-			return ErrNotOnline
-		}
-
-		err = nd.Provider.Reprovide(req.Context)
-		if err != nil {
-			return err
-		}
-
-		return nil
 	},
 }

--- a/core/commands/routing.go
+++ b/core/commands/routing.go
@@ -42,6 +42,7 @@ var RoutingCmd = &cmds.Command{
 		"get":       getValueRoutingCmd,
 		"put":       putValueRoutingCmd,
 		"provide":   provideRefRoutingCmd,
+		"reprovide": reprovideRoutingCmd,
 	},
 }
 
@@ -233,6 +234,33 @@ var provideRefRoutingCmd = &cmds.Command{
 		}),
 	},
 	Type: routing.QueryEvent{},
+}
+
+var reprovideRoutingCmd = &cmds.Command{
+	Status: cmds.Experimental,
+	Helptext: cmds.HelpText{
+		Tagline: "Trigger reprovider.",
+		ShortDescription: `
+Trigger reprovider to announce our data to network.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		nd, err := cmdenv.GetNode(env)
+		if err != nil {
+			return err
+		}
+
+		if !nd.IsOnline {
+			return ErrNotOnline
+		}
+
+		err = nd.Provider.Reprovide(req.Context)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
 }
 
 func provideKeys(ctx context.Context, r routing.Routing, cids []cid.Cid) error {

--- a/core/commands/stat_provide.go
+++ b/core/commands/stat_provide.go
@@ -53,7 +53,10 @@ This interface is not stable and may change from release to release.
 			fmt.Fprintf(wtr, "TotalProvides:\t%s\n", humanNumber(s.TotalProvides))
 			fmt.Fprintf(wtr, "AvgProvideDuration:\t%s\n", humanDuration(s.AvgProvideDuration))
 			fmt.Fprintf(wtr, "LastReprovideDuration:\t%s\n", humanDuration(s.LastReprovideDuration))
-			fmt.Fprintf(wtr, "LastReprovideBatchSize:\t%s\n", humanNumber(s.LastReprovideBatchSize))
+			if !s.LastRun.IsZero() {
+				fmt.Fprintf(wtr, "LastRun:\t%s\n", humanTime(s.LastRun))
+				fmt.Fprintf(wtr, "NextRun:\t%s\n", humanTime(s.NextRun))
+			}
 			return nil
 		}),
 	},
@@ -62,6 +65,10 @@ This interface is not stable and may change from release to release.
 
 func humanDuration(val time.Duration) string {
 	return val.Truncate(time.Microsecond).String()
+}
+
+func humanTime(val time.Time) string {
+	return val.Format("2006-01-02 15:04:05")
 }
 
 func humanNumber[T constraints.Float | constraints.Integer](n T) string {


### PR DESCRIPTION
Fixes issue #10265. Better self-service commands for DHT providing. Moved the reprovide command to routing, added LastRun and NextRun stats.
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
