### PR TITLE
test: fix the socat tests after the ubuntu 24.04 upgrade

### DIFF
--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -131,21 +131,21 @@ test_expect_success "ipfs help output looks good" '
 # check transport is encrypted by default and no plaintext is allowed
 
 test_expect_success SOCAT "default transport should support encryption (TLS, needs socat )" '
-  socat - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-tls &&
+  socat -s - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-tls &&
   grep -q "/tls" swarmnc &&
   test_must_fail grep -q "na" swarmnc ||
   test_fsh cat swarmnc
 '
 
 test_expect_success SOCAT "default transport should support encryption (Noise, needs socat )" '
-  socat - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-noise &&
+  socat -s - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-noise &&
   grep -q "/noise" swarmnc &&
   test_must_fail grep -q "na" swarmnc ||
   test_fsh cat swarmnc
 '
 
 test_expect_success SOCAT "default transport should not support plaintext (needs socat )" '
-  socat - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-plaintext &&
+  socat -s - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-plaintext &&
   grep -q "na" swarmnc &&
   test_must_fail grep -q "/plaintext" swarmnc ||
   test_fsh cat swarmnc

--- a/test/sharness/t0061-daemon-opts.sh
+++ b/test/sharness/t0061-daemon-opts.sh
@@ -18,7 +18,7 @@ apiaddr=$API_ADDR
 
 # Odd. this fails here, but the inverse works on t0060-daemon.
 test_expect_success SOCAT 'transport should be unencrypted ( needs socat )' '
-  socat - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-plaintext &&
+  socat -s - tcp:localhost:$SWARM_PORT,connect-timeout=1 > swarmnc < ../t0060-data/mss-plaintext &&
   grep -q "/plaintext" swarmnc &&
   test_must_fail grep -q "na" swarmnc ||
   test_fsh cat swarmnc


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Resolves #10682 

This PR adds [sloppy error handling flag](https://linux.die.net/man/1/socat) to the socat calls that started failing after the self-hosted GitHub Actions runners upgrade to Ubuntu 24.04.

It was tested here: https://github.com/ipfs/kubo/actions/runs/13038855183