### PR TITLE
fix: config help

### DIFF
--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -48,13 +48,13 @@ file inside your IPFS repository (IPFS_PATH).
 
 Examples:
 
-Get the value of the 'Datastore.Path' key:
+Get the value of the 'Routing.Type' key:
 
-  $ ipfs config Datastore.Path
+  $ ipfs config Routing.Type
 
-Set the value of the 'Datastore.Path' key:
+Set the value of the 'Routing.Type' key:
 
-  $ ipfs config Datastore.Path ~/.ipfs/datastore
+  $ ipfs config Routing.Type auto
 
 Set multiple values in the 'Addresses.AppendAnnounce' array:
 


### PR DESCRIPTION
* `Datastore.Path` has been deprecated more than [7 years ago](https://github.com/ipfs/kubo/commit/5027b4b14f2fc60e808a39d3b3efc9316d8e511d#diff-757e54613dd89da7749369ffb9650951bf704bcbe1114de7390857092d1ef454R361)
* Replace it from `ipfs config --help` with `Routing.Type`