### PR TITLE
improve(p2p-listener): ensure safe type assertion in stream handling

### DIFF
--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -52,8 +52,8 @@ func newListenersP2P(host p2phost.Host) *Listeners {
 		defer reg.RUnlock()
 
 		l := reg.Listeners[stream.Protocol()]
-		if l != nil {
-			go l.(*remoteListener).handleStream(stream)
+		if rl, ok := l.(*remoteListener); ok && rl != nil {
+			go rl.handleStream(stream)
 		}
 	})
 


### PR DESCRIPTION
- Replace direct type assertion with a safe type check and nil check
- Prevent potential runtime panics by ensuring `remoteListener` is valid

[skip changelog]
