### PR TITLE
fix(rpc): restore and reprecate `bitswap reprovide`

### DIFF
--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -21,15 +21,27 @@ var BitswapCmd = &cmds.Command{
 	},
 
 	Subcommands: map[string]*cmds.Command{
-		"stat":     bitswapStatCmd,
-		"wantlist": showWantlistCmd,
-		"ledger":   ledgerCmd,
+		"stat":      bitswapStatCmd,
+		"wantlist":  showWantlistCmd,
+		"ledger":    ledgerCmd,
+		"reprovide": deprecatedBitswapReprovideCmd,
 	},
 }
 
 const (
 	peerOptionName = "peer"
 )
+
+var deprecatedBitswapReprovideCmd = &cmds.Command{
+	Status: cmds.Deprecated,
+	Helptext: cmds.HelpText{
+		Tagline: "Deprecated command to announce to bitswap. Use 'ipfs routing reprovide' instead.",
+		ShortDescription: `
+'ipfs bitswap reprovide' is a legacy plumbing command used to announce to DHT.
+Deprecated, use modern 'ipfs routing reprovide' instead.`,
+	},
+	Run: reprovideRoutingCmd.Run, // alias to routing reprovide to not break existing users
+}
 
 var showWantlistCmd = &cmds.Command{
 	Helptext: cmds.HelpText{

--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -20,6 +20,7 @@ func TestCommands(t *testing.T) {
 		"/add",
 		"/bitswap",
 		"/bitswap/ledger",
+		"/bitswap/reprovide",
 		"/bitswap/stat",
 		"/bitswap/wantlist",
 		"/block",

--- a/docs/changelogs/v0.34.md
+++ b/docs/changelogs/v0.34.md
@@ -6,28 +6,20 @@
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
-  - [JSON config validation](#json-config-validation)
-  - [Reprovide command moved to routing](#reprovide-command-moved-to-routing)
-  - [Additional stats for Accelerated DHT Reprovides](#additional-stats-for-accelerated-dht-reprovides)
-- [📝 Changelog](#-changelog)
+  - [RPC and CLI command changes](#rpc-and-cli-command-changes)
   - [Bitswap improvements from Boxo](#bitswap-improvements-from-boxo)
+- [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
 ### Overview
 
 ### 🔦 Highlights
 
-#### JSON config validation
+#### RPC and CLI command changes
 
-`ipfs config` is now validating json fields ([#10679](https://github.com/ipfs/kubo/pull/10679)).
-
-#### Reprovide command moved to routing
-
-Moved the `bitswap reprovide` command to `routing reprovide`. ([#10677](https://github.com/ipfs/kubo/pull/10677))
-
-#### Additional stats for Accelerated DHT Reprovides
-
-The `stats reprovide` command now shows additional stats for the DHT Accelerated Client, indicating the last and next `reprovide` times. ([#10677](https://github.com/ipfs/kubo/pull/10677))
+- `ipfs config` is now validating json fields ([#10679](https://github.com/ipfs/kubo/pull/10679)).
+- Deprecated the `bitswap reprovide` command. Make sure to switch to modern `routing reprovide`. ([#10677](https://github.com/ipfs/kubo/pull/10677))
+- The `stats reprovide` command now shows additional stats for [`Routing.AcceleratedDHTClient`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingaccelerateddhtclient), indicating the last and next `reprovide` times. ([#10677](https://github.com/ipfs/kubo/pull/10677))
 
 #### Bitswap improvements from Boxo
 


### PR DESCRIPTION
https://github.com/ipfs/kubo/pull/10677 removed command without properly deprecating it first, this restores it and marks as deprecated

without this, we would break every user who manually calls removed `bitswap reprovide` via their cron

cc @guillaumemichel  and @gsergey418alt for visibility – in the future make sure we keep old command working and deprecate it first, we can remove it after at least 1 release with deprecation being announced :pray: 

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
