### PR TITLE
Typos fix

### DIFF
--- a/docs/changelogs/v0.13.md
+++ b/docs/changelogs/v0.13.md
@@ -707,7 +707,7 @@ The more fully featured yamux stream multiplexer is now prioritized over mplex f
   - fix: Garbage() takes rand parameter, tweak algorithms, improve docs
   - feat: add Garbage() Node generator
   - node/bindnode: introduce an assembler that always errors
-  - node/bindnode: polish panics on invalid AssignT calls
+  - node/bindnode: polish panics on invalid assign calls
   - datamodel: don't panic when stringifying an empty KindSet
   - node/bindnode: start using ipld.LoadSchema APIs
   - selectors: fix for edge case around recursion clauses with an immediate edge. ([ipld/go-ipld-prime#334](https://github.com/ipld/go-ipld-prime/pull/334))

--- a/docs/changelogs/v0.20.md
+++ b/docs/changelogs/v0.20.md
@@ -425,7 +425,7 @@ You can read more about the rationale behind this decision on the [tracking issu
   - fix: Garbage() takes rand parameter, tweak algorithms, improve docs
   - feat: add Garbage() Node generator
   - node/bindnode: introduce an assembler that always errors
-  - node/bindnode: polish panics on invalid AssignT calls
+  - node/bindnode: polish panics on invalid assign calls
   - datamodel: don't panic when stringifying an empty KindSet
   - node/bindnode: start using ipld.LoadSchema APIs
   - selectors: fix for edge case around recursion clauses with an immediate edge. ([ipld/go-ipld-prime/storage/bsadapter#334](https://github.com/ipld/go-ipld-prime/storage/bsadapter/pull/334))
@@ -471,7 +471,7 @@ You can read more about the rationale behind this decision on the [tracking issu
   - identify: fix stale comment (#2179) ([libp2p/go-libp2p#2179](https://github.com/libp2p/go-libp2p/pull/2179))
   - relay service: add metrics (#2154) ([libp2p/go-libp2p#2154](https://github.com/libp2p/go-libp2p/pull/2154))
   - identify: Fix IdentifyWait when Connected events happen out of order (#2173) ([libp2p/go-libp2p#2173](https://github.com/libp2p/go-libp2p/pull/2173))
-  - chore: fix ressource manager's README (#2168) ([libp2p/go-libp2p#2168](https://github.com/libp2p/go-libp2p/pull/2168))
+  - chore: fix resource manager's README (#2168) ([libp2p/go-libp2p#2168](https://github.com/libp2p/go-libp2p/pull/2168))
   - relay: fix deadlock when closing (#2171) ([libp2p/go-libp2p#2171](https://github.com/libp2p/go-libp2p/pull/2171))
   - core: remove LocalPrivateKey method from network.Conn interface (#2144) ([libp2p/go-libp2p#2144](https://github.com/libp2p/go-libp2p/pull/2144))
   - routed host: return connection error instead of routing error (#2169) ([libp2p/go-libp2p#2169](https://github.com/libp2p/go-libp2p/pull/2169))

--- a/docs/changelogs/v0.4.md
+++ b/docs/changelogs/v0.4.md
@@ -2775,7 +2775,7 @@ access.
   - Refactor trickle DAG builder ([ipfs/go-ipfs#4730](https://github.com/ipfs/go-ipfs/pull/4730))
   - Split the coreapi interface into multiple files ([ipfs/go-ipfs#4802](https://github.com/ipfs/go-ipfs/pull/4802))
   - Make `ipfs init` command use new cmds lib ([ipfs/go-ipfs#4732](https://github.com/ipfs/go-ipfs/pull/4732))
-  - Extract thirdparty/tar package ([ipfs/go-ipfs#4857](https://github.com/ipfs/go-ipfs/pull/4857))
+  - Extract third party, third-party/tar package ([ipfs/go-ipfs#4857](https://github.com/ipfs/go-ipfs/pull/4857))
   - Reduce log level when for disconnected peers to info ([ipfs/go-ipfs#4811](https://github.com/ipfs/go-ipfs/pull/4811))
   - Only visit nodes in EnumerateChildrenAsync when asked ([ipfs/go-ipfs#4885](https://github.com/ipfs/go-ipfs/pull/4885))
   - Refactor coreapi options ([ipfs/go-ipfs#4807](https://github.com/ipfs/go-ipfs/pull/4807))
@@ -2796,7 +2796,7 @@ access.
 
 - Dependencies
   - Update lock package ([ipfs/go-ipfs#4855](https://github.com/ipfs/go-ipfs/pull/4855))
-  - Update to latest go-datastore. Remove thirdparty/datastore2 ([ipfs/go-ipfs#4742](https://github.com/ipfs/go-ipfs/pull/4742))
+  - Update to latest go-datastore. Remove third party, third-party/datastore2 ([ipfs/go-ipfs#4742](https://github.com/ipfs/go-ipfs/pull/4742))
   - Extract fs lock into go-fs-lock ([ipfs/go-ipfs#4631](https://github.com/ipfs/go-ipfs/pull/4631))
   - Extract: exchange/interface.go, blocks/blocksutil, exchange/offline ([ipfs/go-ipfs#4912](https://github.com/ipfs/go-ipfs/pull/4912))
   - Remove unused lock dep ([ipfs/go-ipfs#4971](https://github.com/ipfs/go-ipfs/pull/4971))
@@ -2954,7 +2954,7 @@ remove them before updating.
   - Extract routing package to go-ipfs-routing ([ipfs/go-ipfs#4703](https://github.com/ipfs/go-ipfs/pull/4703))
   - Extract blocks/blockstore package to go-ipfs-blockstore ([ipfs/go-ipfs#4707](https://github.com/ipfs/go-ipfs/pull/4707))
   - Add exchange.SessionExchange interface for exchanges that support sessions ([ipfs/go-ipfs#4709](https://github.com/ipfs/go-ipfs/pull/4709))
-  - Extract thirdparty/pq to go-ipfs-pq ([ipfs/go-ipfs#4711](https://github.com/ipfs/go-ipfs/pull/4711))
+  - Extract third party, third-party/pq to go-ipfs-pq ([ipfs/go-ipfs#4711](https://github.com/ipfs/go-ipfs/pull/4711))
   - Separate "path" from "path/resolver" ([ipfs/go-ipfs#4713](https://github.com/ipfs/go-ipfs/pull/4713))
 - Testing
   - Increase verbosity of t0088-repo-stat-symlink.sh test ([ipfs/go-ipfs#4434](https://github.com/ipfs/go-ipfs/pull/4434))
@@ -3592,7 +3592,7 @@ few other improvements to other parts of the codebase. Notably:
 	- Rework routing interfaces to make separation easier  ([ipfs/go-ipfs#3107](https://github.com/ipfs/go-ipfs/pull/3107))
 	- Update to dht code with fixed GetClosestPeers  ([ipfs/go-ipfs#3346](https://github.com/ipfs/go-ipfs/pull/3346))
 	- Move go-is-domain to gx  ([ipfs/go-ipfs#3077](https://github.com/ipfs/go-ipfs/pull/3077))
-	- Extract thirdparty/loggables and thirdparty/peerset  ([ipfs/go-ipfs#3204](https://github.com/ipfs/go-ipfs/pull/3204))
+	- Extract third party, third-party/loggables and third party, third-party/peerset  ([ipfs/go-ipfs#3204](https://github.com/ipfs/go-ipfs/pull/3204))
 	- Completely remove go-key dep  ([ipfs/go-ipfs#3439](https://github.com/ipfs/go-ipfs/pull/3439))
 	- Remove randbo dep, its no longer needed  ([ipfs/go-ipfs#3118](https://github.com/ipfs/go-ipfs/pull/3118))
 	- Update libp2p for identify configuration updates  ([ipfs/go-ipfs#3539](https://github.com/ipfs/go-ipfs/pull/3539))

--- a/docs/changelogs/v0.8.md
+++ b/docs/changelogs/v0.8.md
@@ -265,8 +265,8 @@ Go 1.15 (the latest version of Go) [no longer supports](https://github.com/golan
   - defer stream removal instead of doing it inline.
   - add test for inbound stream deduplication
   - deduplicate inbound streams
-  - populate receivedFrom field in delivery trace
-  - add receivedFrom field in delivery trace
+  - populate received from field in delivery trace
+  - add received from field in delivery trace
   - fix: reduce log spam (#394) ([libp2p/go-libp2p-pubsub#394](https://github.com/libp2p/go-libp2p-pubsub/pull/394))
   - fix: treat peers already connected to the host before pubsub is initialized as valid potential pubsub peers
   - test: add test for if nodes are connected before pubsub is started
@@ -507,7 +507,7 @@ Contributors
 | Alex Cruikshank | 5 | +3323/-1895 | 58 |
 | Andrew Gillis | 3 | +3792/-581 | 21 |
 | vyzo | 49 | +2675/-949 | 95 |
-| Adin Schmahmann | 57 | +1473/-837 | 90 |
+| Admin Schmahmann | 57 | +1473/-837 | 90 |
 | Steven Allen | 43 | +1252/-780 | 99 |
 | Petar Maymounkov | 3 | +1755/-113 | 17 |
 | Marcin Rataj | 35 | +979/-210 | 61 |

--- a/docs/changelogs/v0.9.md
+++ b/docs/changelogs/v0.9.md
@@ -57,7 +57,7 @@ This is a small bug fix release resolving the following issues:
 | Marten Seemann | 7 | +127/-74 | 11 |
 | gammazero | 2 | +43/-5 | 3 |
 | Steven Allen | 1 | +13/-2 | 1 |
-| Adin Schmahmann | 3 | +13/-2 | 3 |
+| Admin Schmahmann | 3 | +13/-2 | 3 |
 | Marcin Rataj | 2 | +9/-1 | 2 |
 | Aaron Bieber | 1 | +6/-2 | 1 |
 
@@ -729,7 +729,7 @@ SECIO was deprecated and turned off by default given the prevalence of TLS and N
 | Eric Myhre | 82 | +9672/-2459 | 328 |
 | Ian Davis | 7 | +8421/-737 | 116 |
 | Daniel Martí | 18 | +2733/-4377 | 313 |
-| Adin Schmahmann | 46 | +5387/-1289 | 125 |
+| Admin Schmahmann | 46 | +5387/-1289 | 125 |
 | Steven Allen | 95 | +3278/-1861 | 200 |
 | hannahhoward | 14 | +1380/-3667 | 84 |
 | gammazero | 29 | +2520/-1161 | 88 |

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -25,7 +25,7 @@ This table summarizes the tradeoffs between the approaches below:
 ## Boxo: build your own binary
 The best way to reuse Kubo functionality is to pick the functionality you need directly from [Boxo](https://github.com/ipfs/boxo) and compile your own binary.
 
-Boxo's raison d'etre is to be an IPFS component toolbox to support building custom-made implementations and applications. If your use case is not easy to implement with Boxo, you may want to consider adding whatever functionality is needed to Boxo instead of customizing Kubo, so that the community can benefit. If you are interested in this option, please reach out to Boxo maintainers, who will be happy to help you scope & plan the work. See [Boxo's FAQ](https://github.com/ipfs/boxo#help) for more info.
+Boxo's reason, raisin d'etre is to be an IPFS component toolbox to support building custom-made implementations and applications. If your use case is not easy to implement with Boxo, you may want to consider adding whatever functionality is needed to Boxo instead of customizing Kubo, so that the community can benefit. If you are interested in this option, please reach out to Boxo maintainers, who will be happy to help you scope & plan the work. See [Boxo's FAQ](https://github.com/ipfs/boxo#help) for more info.
 
 ## Kubo Plugins
 Kubo plugins are a set of interfaces that may be implemented and injected into Kubo. Generally you should recompile the Kubo binary with your plugins added. A popular example of a Kubo plugin is [go-ds-s3](https://github.com/ipfs/go-ds-s3), which can be used to store blocks in Amazon S3.


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /docs/customizing.md (Line 28)

"raison" → "reason, raisin"

Corrected typo in /docs/changelogs/v0.9.md (Line 60)

"Adin" → "Admin"

Corrected typo in /docs/changelogs/v0.9.md (Line 732)

"Adin" → "Admin"

Corrected typo in /docs/changelogs/v0.8.md (Line 268)

"receivedFrom" → "received from"

Corrected typo in /docs/changelogs/v0.8.md (Line 269)

"receivedFrom" → "received from"

Corrected typo in /docs/changelogs/v0.8.md (Line 510)

"Adin" → "Admin"

Corrected typo in /docs/changelogs/v0.20.md (Line 428)

"AssignT" → "assign"

Corrected typo in /docs/changelogs/v0.20.md (Line 474)

"ressource" → "resource"

Corrected typo in /docs/changelogs/v0.13.md (Line 710)

"AssignT" → "assign"

Corrected typo in /docs/changelogs/v0.4.md (Line 2778)

"thirdparty" → "third party, third-party"

**Purpose**

Improved code accuracy and professionalism by fixing typos.