### PR TITLE
Update pebble db to latest format by default

### DIFF
--- a/docs/changelogs/v0.34.md
+++ b/docs/changelogs/v0.34.md
@@ -9,6 +9,7 @@
   - [RPC and CLI command changes](#rpc-and-cli-command-changes)
   - [Bitswap improvements from Boxo](#bitswap-improvements-from-boxo)
   - [IPFS_LOG_LEVEL deprecated](#ipfs_log_level-deprecated)
+  - [Pebble datastore format upgrade](#pebble_datastore_format_update)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
 ### Overview
@@ -28,5 +29,10 @@ This release includes performance and reliability improvements and fixes for min
 #### `IPFS_LOG_LEVEL` deprecated
 
 The variable has been deprecated. Please use [`GOLOG_LOG_LEVEL`](https://github.com/ipfs/kubo/blob/master/docs/environment-variables.md#golog_log_level) instead for configuring logging levels.
+
+#### Pebble datastore format upgrade
+
+If the pebble database format is not explicitly set in the config, then automatically upgrade it to the latest format version supported by the release ob pebble used by kubo. This will ensure that the database format is sufficiently up-to-date to be compatible with a major version upgrade of pebble. This is necessary before upgrading to use pebble v2.
+
 
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/changelogs/v0.34.md
+++ b/docs/changelogs/v0.34.md
@@ -30,7 +30,7 @@ This release includes performance and reliability improvements and fixes for min
 
 The variable has been deprecated. Please use [`GOLOG_LOG_LEVEL`](https://github.com/ipfs/kubo/blob/master/docs/environment-variables.md#golog_log_level) instead for configuring logging levels.
 
-#### Pebble datastore format upgrade
+#### Pebble datastore format update
 
 If the pebble database format is not explicitly set in the config, then automatically upgrade it to the latest format version supported by the release ob pebble used by kubo. This will ensure that the database format is sufficiently up-to-date to be compatible with a major version upgrade of pebble. This is necessary before upgrading to use pebble v2.
 

--- a/plugin/plugins/pebbleds/pebbleds.go
+++ b/plugin/plugins/pebbleds/pebbleds.go
@@ -111,7 +111,7 @@ func (*pebbledsPlugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 		}
 
 		// Use latest version by default. This will ensure that format is
-		// comatible across database upgrades.
+		// compatible across database upgrades.
 		if formatMajorVersion == 0 {
 			formatMajorVersion = pebble.FormatNewest
 		}

--- a/plugin/plugins/pebbleds/pebbleds.go
+++ b/plugin/plugins/pebbleds/pebbleds.go
@@ -72,6 +72,11 @@ func (*pebbledsPlugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 		if err != nil {
 			return nil, err
 		}
+		fmv, err := getConfigInt("formatMajorVersion", params)
+		if err != nil {
+			return nil, err
+		}
+		formatMajorVersion := pebble.FormatMajorVersion(fmv)
 		l0CompactionThreshold, err := getConfigInt("l0CompactionThreshold", params)
 		if err != nil {
 			return nil, err
@@ -105,10 +110,17 @@ func (*pebbledsPlugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 			return nil, err
 		}
 
-		if bytesPerSync != 0 || disableWAL || l0CompactionThreshold != 0 || l0StopWritesThreshold != 0 || lBaseMaxBytes != 0 || maxConcurrentCompactions != 0 || memTableSize != 0 || memTableStopWritesThreshold != 0 || walBytesPerSync != 0 || walMinSyncSec != 0 {
+		// Use latest version by default. This will ensure that format is
+		// comatible across database upgrades.
+		if formatMajorVersion == 0 {
+			formatMajorVersion = pebble.FormatNewest
+		}
+
+		if bytesPerSync != 0 || disableWAL || formatMajorVersion != 0 || l0CompactionThreshold != 0 || l0StopWritesThreshold != 0 || lBaseMaxBytes != 0 || maxConcurrentCompactions != 0 || memTableSize != 0 || memTableStopWritesThreshold != 0 || walBytesPerSync != 0 || walMinSyncSec != 0 {
 			c.pebbleOpts = &pebble.Options{
 				BytesPerSync:                bytesPerSync,
 				DisableWAL:                  disableWAL,
+				FormatMajorVersion:          formatMajorVersion,
 				L0CompactionThreshold:       l0CompactionThreshold,
 				L0StopWritesThreshold:       l0StopWritesThreshold,
 				LBaseMaxBytes:               int64(lBaseMaxBytes),


### PR DESCRIPTION
If the pebble database format is not explicitly set in the config, then set it to the latest format version by default. This will ensure that the database format is sufficiently up-to-date to be compatible with a major version upgrade of pebble.
