### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/config/serialize/serialize.go
+++ b/config/serialize/serialize.go
@@ -68,5 +68,5 @@ func Load(filename string) (*config.Config, error) {
 		return nil, err
 	}
 
-	return &cfg, err
+	return &cfg, nil
 }


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

use a more straightforward return value