### PR TITLE
Replace go-random with random-data from go-test package

### DIFF
--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -388,8 +388,8 @@ github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fG
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
 github.com/ipfs/go-peertaskqueue v0.8.2 h1:PaHFRaVFdxQk1Qo3OKiHPYjmmusQy7gKQUaL8JDszAU=
 github.com/ipfs/go-peertaskqueue v0.8.2/go.mod h1:L6QPvou0346c2qPJNiJa6BvOibxDfaiPlqHInmzg0FA=
-github.com/ipfs/go-test v0.2.0 h1:tKJ722lo/c8+04Qm67BZ1XsI2UfTtF2hsfmxqkuBnHs=
-github.com/ipfs/go-test v0.2.0/go.mod h1:dzu+KB9cmWjuJnXFDYJwC25T3j1GcN57byN+ixmK39M=
+github.com/ipfs/go-test v0.2.1 h1:/D/a8xZ2JzkYqcVcV/7HYlCnc7bv/pKHQiX5TdClkPE=
+github.com/ipfs/go-test v0.2.1/go.mod h1:dzu+KB9cmWjuJnXFDYJwC25T3j1GcN57byN+ixmK39M=
 github.com/ipfs/go-unixfsnode v1.9.2 h1:0A12BYs4XOtDPJTMlwmNPlllDfqcc4yie4e919hcUXk=
 github.com/ipfs/go-unixfsnode v1.9.2/go.mod h1:v1nuMFHf4QTIhFUdPMvg1nQu7AqDLvIdwyvJ531Ot1U=
 github.com/ipfs/go-verifcid v0.0.3 h1:gmRKccqhWDocCRkC+a59g5QW7uJw5bpX9HWBevXa0zs=

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipfs/go-metrics-interface v0.0.1
 	github.com/ipfs/go-metrics-prometheus v0.0.3
-	github.com/ipfs/go-test v0.2.0
+	github.com/ipfs/go-test v0.2.1
 	github.com/ipfs/go-unixfsnode v1.9.2
 	github.com/ipld/go-car v0.6.2
 	github.com/ipld/go-car/v2 v2.14.2

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/ipfs/go-metrics-prometheus v0.0.3 h1:MVgBw30nE9eKC598ZQg+LIIbgIcx46NG
 github.com/ipfs/go-metrics-prometheus v0.0.3/go.mod h1:qjWVLyK+ZJrQuiyTqfgoECgKfd4b4lEtpQemAWomWc8=
 github.com/ipfs/go-peertaskqueue v0.8.2 h1:PaHFRaVFdxQk1Qo3OKiHPYjmmusQy7gKQUaL8JDszAU=
 github.com/ipfs/go-peertaskqueue v0.8.2/go.mod h1:L6QPvou0346c2qPJNiJa6BvOibxDfaiPlqHInmzg0FA=
-github.com/ipfs/go-test v0.2.0 h1:tKJ722lo/c8+04Qm67BZ1XsI2UfTtF2hsfmxqkuBnHs=
-github.com/ipfs/go-test v0.2.0/go.mod h1:dzu+KB9cmWjuJnXFDYJwC25T3j1GcN57byN+ixmK39M=
+github.com/ipfs/go-test v0.2.1 h1:/D/a8xZ2JzkYqcVcV/7HYlCnc7bv/pKHQiX5TdClkPE=
+github.com/ipfs/go-test v0.2.1/go.mod h1:dzu+KB9cmWjuJnXFDYJwC25T3j1GcN57byN+ixmK39M=
 github.com/ipfs/go-unixfsnode v1.9.2 h1:0A12BYs4XOtDPJTMlwmNPlllDfqcc4yie4e919hcUXk=
 github.com/ipfs/go-unixfsnode v1.9.2/go.mod h1:v1nuMFHf4QTIhFUdPMvg1nQu7AqDLvIdwyvJ531Ot1U=
 github.com/ipfs/go-verifcid v0.0.3 h1:gmRKccqhWDocCRkC+a59g5QW7uJw5bpX9HWBevXa0zs=

--- a/test/bin/Rules.mk
+++ b/test/bin/Rules.mk
@@ -58,10 +58,10 @@ $(d)/cid-fmt: github.com/ipfs/go-cidutil/cid-fmt
 	$(go-build-testdep)
 TGTS_$(d) += $(d)/cid-fmt
 
-.PHONY: github.com/jbenet/go-random/random
-$(d)/random: github.com/jbenet/go-random/random
+.PHONY: github.com/ipfs/go-test/cli/random-data
+$(d)/random-data: github.com/ipfs/go-test/cli/random-data
 	$(go-build-testdep)
-TGTS_$(d) += $(d)/random
+TGTS_$(d) += $(d)/random-data
 
 .PHONY: github.com/ipfs/go-test/cli/random-files
 $(d)/random-files: github.com/ipfs/go-test/cli/random-files

--- a/test/dependencies/dependencies.go
+++ b/test/dependencies/dependencies.go
@@ -7,9 +7,9 @@ import (
 	_ "github.com/Kubuxu/gocovmerge"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/ipfs/go-cidutil/cid-fmt"
+	_ "github.com/ipfs/go-test/cli/random-data"
 	_ "github.com/ipfs/go-test/cli/random-files"
 	_ "github.com/ipfs/hang-fds"
-	_ "github.com/jbenet/go-random/random"
 	_ "github.com/multiformats/go-multihash/multihash"
 	_ "gotest.tools/gotestsum"
 )

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golangci/golangci-lint v1.60.2
 	github.com/ipfs/go-cidutil v0.1.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipfs/go-test v0.2.0
+	github.com/ipfs/go-test v0.2.1
 	github.com/ipfs/hang-fds v0.1.0
 	github.com/ipfs/iptb v1.4.1
 	github.com/ipfs/iptb-plugins v0.5.1

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/ipfs/hang-fds v0.1.0
 	github.com/ipfs/iptb v1.4.1
 	github.com/ipfs/iptb-plugins v0.5.1
-	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/multiformats/go-multiaddr v0.14.0
 	github.com/multiformats/go-multihash v0.2.3
 	gotest.tools/gotestsum v1.12.0
@@ -65,7 +64,6 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 // indirect
 	github.com/fatih/color v1.17.0 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -351,8 +351,8 @@ github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fG
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
 github.com/ipfs/go-peertaskqueue v0.8.2 h1:PaHFRaVFdxQk1Qo3OKiHPYjmmusQy7gKQUaL8JDszAU=
 github.com/ipfs/go-peertaskqueue v0.8.2/go.mod h1:L6QPvou0346c2qPJNiJa6BvOibxDfaiPlqHInmzg0FA=
-github.com/ipfs/go-test v0.2.0 h1:tKJ722lo/c8+04Qm67BZ1XsI2UfTtF2hsfmxqkuBnHs=
-github.com/ipfs/go-test v0.2.0/go.mod h1:dzu+KB9cmWjuJnXFDYJwC25T3j1GcN57byN+ixmK39M=
+github.com/ipfs/go-test v0.2.1 h1:/D/a8xZ2JzkYqcVcV/7HYlCnc7bv/pKHQiX5TdClkPE=
+github.com/ipfs/go-test v0.2.1/go.mod h1:dzu+KB9cmWjuJnXFDYJwC25T3j1GcN57byN+ixmK39M=
 github.com/ipfs/hang-fds v0.1.0 h1:deBiFlWHsVGzJ0ZMaqscEqRM1r2O1rFZ59UiQXb1Xko=
 github.com/ipfs/hang-fds v0.1.0/go.mod h1:29VLWOn3ftAgNNgXg/al7b11UzuQ+w7AwtCGcTaWkbM=
 github.com/ipfs/iptb v1.4.1 h1:faXd3TKGPswbHyZecqqg6UfbES7RDjTKQb+6VFPKDUo=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -130,8 +130,6 @@ github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Z
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
-github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/uo=
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -368,8 +366,6 @@ github.com/ipshipyard/p2p-forge v0.3.0/go.mod h1:L0TJMzniMEDjX8G+RB201U2woHvASwb
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
-github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c h1:uUx61FiAa1GI6ZmVd2wf2vULeQZIKG66eybjNXKYCz4=
-github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c/go.mod h1:sdx1xVM9UuLw1tXnhJWN3piypTUO3vCIHYmG15KE/dU=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=

--- a/test/sharness/Rules.mk
+++ b/test/sharness/Rules.mk
@@ -4,8 +4,8 @@ SHARNESS_$(d) = $(d)/lib/sharness/sharness.sh
 
 T_$(d) = $(sort $(wildcard $(d)/t[0-9][0-9][0-9][0-9]-*.sh))
 
-DEPS_$(d) := test/bin/random test/bin/multihash test/bin/pollEndpoint \
-	   test/bin/iptb test/bin/go-sleep test/bin/random-files \
+DEPS_$(d) := test/bin/multihash test/bin/pollEndpoint test/bin/iptb \
+	   test/bin/go-sleep test/bin/random-data test/bin/random-files \
 	   test/bin/go-timeout test/bin/hang-fds test/bin/ma-pipe-unidir \
 	   test/bin/cid-fmt
 DEPS_$(d) += cmd/ipfs/ipfs

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -623,7 +623,7 @@ test_add_cat_expensive() {
   '
 
   test_expect_success EXPENSIVE "ipfs cat output hashed looks good" '
-    echo "11144f604a7e705e4d061e35fea728e0c6cc7f5ba5d5" >sha1_expected &&
+    echo "11141e8c04d7cd019cc0acf0311a8ca6cf2c18413c96" >sha1_expected &&
     test_cmp sha1_expected sha1_actual
   '
 

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -484,12 +484,12 @@ test_add_cat_5MB() {
   ADD_FLAGS="$1"
   EXP_HASH="$2"
 
-  test_expect_success "generate 5MB file using go-random" '
-    random 5242880 41 >mountdir/bigfile
+  test_expect_success "generate 5MB file using random-data" '
+    random-data -size=5242880 -seed=41 >mountdir/bigfile
   '
 
   test_expect_success "sha1 of the file looks ok" '
-    echo "11145620fb92eb5a49c9986b5c6844efda37e471660e" >sha1_expected &&
+    echo "11145b8c4bc8f87ea2fcfc3d55708b8cac2aadf12862" >sha1_expected &&
     multihash -a=sha1 -e=hex mountdir/bigfile >sha1_actual &&
     test_cmp sha1_expected sha1_actual
   '
@@ -594,12 +594,12 @@ test_add_cat_expensive() {
   ADD_FLAGS="$1"
   HASH="$2"
 
-  test_expect_success EXPENSIVE "generate 100MB file using go-random" '
-    random 104857600 42 >mountdir/bigfile
+  test_expect_success EXPENSIVE "generate 100MB file using random-data" '
+    random-data -size=104857600 -seed=42 >mountdir/bigfile
   '
 
   test_expect_success EXPENSIVE "sha1 of the file looks ok" '
-    echo "1114885b197b01e0f7ff584458dc236cb9477d2e736d" >sha1_expected &&
+    echo "11141e8c04d7cd019cc0acf0311a8ca6cf2c18413c96" >sha1_expected &&
     multihash -a=sha1 -e=hex mountdir/bigfile >sha1_actual &&
     test_cmp sha1_expected sha1_actual
   '
@@ -623,7 +623,7 @@ test_add_cat_expensive() {
   '
 
   test_expect_success EXPENSIVE "ipfs cat output hashed looks good" '
-    echo "1114885b197b01e0f7ff584458dc236cb9477d2e736d" >sha1_expected &&
+    echo "11144f604a7e705e4d061e35fea728e0c6cc7f5ba5d5" >sha1_expected &&
     test_cmp sha1_expected sha1_actual
   '
 
@@ -902,42 +902,42 @@ test_expect_success "'ipfs add -rn' output looks good" '
   test_cmp expected actual
 '
 
-test_expect_success "go-random is installed" '
-  type random
+test_expect_success "random-data is installed" '
+  type random-data
 '
 
-test_add_cat_5MB "" "QmSr7FqYkxYWGoSfy8ZiaMWQ5vosb18DQGCzjwEQnVHkTb"
+test_add_cat_5MB "" "QmapAfmzmeWYTNztMQEhUXFcSGrsax22WRG7YN9xLdMeQq"
 
-test_add_cat_5MB --raw-leaves "QmbdLHCmdi48eM8T7D67oXjA1S2Puo8eMfngdHhdPukFd6"
+test_add_cat_5MB --raw-leaves "QmabWSFaPusmiZaaVZLhEUtHcj8CCvVeUfkBpKqAkKVMiS"
 
 # note: the specified hash implies that internal nodes are stored
 # using CidV1 and leaves are stored using raw blocks
-test_add_cat_5MB --cid-version=1 "bafybeigfnx3tka2rf5ovv2slb7ymrt4zbwa3ryeqibe6fipyt5vgsrli3u"
+test_add_cat_5MB --cid-version=1 "bafybeifwdkm32fmukqwh3jofm6ma76bcqvn6opxstsnzmya7utboi4cb2m"
 
 # note: the specified hash implies that internal nodes are stored
 # using CidV1 and leaves are stored using CidV1 but using the legacy
 # format (i.e. not raw)
-test_add_cat_5MB '--cid-version=1 --raw-leaves=false' "bafybeieyifrgpjn3yengthr7qaj72ozm2aq3wm53srgeprc43w67qpvfqa"
+test_add_cat_5MB '--cid-version=1 --raw-leaves=false' "bafybeifq4unep5w4agr3nlynxidj2rymf6dzu6bf4ieqqildkboe5mdmne"
 
 # note: --hash=blake2b-256 implies --cid-version=1 which implies --raw-leaves=true
 # the specified hash represents the leaf nodes stored as raw leaves and
 # encoded with the blake2b-256 hash function
-test_add_cat_5MB '--hash=blake2b-256' "bafykbzacebnmjcl4sn37b3ehtibvf263oun2w6idghenrvlpehq5w5jqyvhjo"
+test_add_cat_5MB '--hash=blake2b-256' "bafykbzacebxcnlql4oc3mtscqn32aumqkqxxv3wt7dkyrphgh6lc2gckiq6bw"
 
 # the specified hash represents the leaf nodes stored as protoful nodes and
 # encoded with the blake2b-256 hash function
-test_add_cat_5MB '--hash=blake2b-256 --raw-leaves=false' "bafykbzaceaxiiykzgpbhnzlecffqm3zbuvhujyvxe5scltksyafagkyw4rjn2"
+test_add_cat_5MB '--hash=blake2b-256 --raw-leaves=false' "bafykbzacearibnoamkfmcagpfgk2sbgx65qftnsrh4ttd3g7ghooasfnyavme"
 
-test_add_cat_expensive "" "QmU9SWAPPmNEKZB8umYMmjYvN7VyHqABNvdA6GUi4MMEz3"
+test_add_cat_expensive "" "Qma1WZKC3jad7e3F7GEDvkFdhPLyMEhKszBF4nBUCBGh6c"
 
 # note: the specified hash implies that internal nodes are stored
 # using CidV1 and leaves are stored using raw blocks
-test_add_cat_expensive "--cid-version=1" "bafybeidkj5ecbhrqmzrcee2rw7qwsx24z3364qya3fnp2ktkg2tnsrewhi"
+test_add_cat_expensive "--cid-version=1" "bafybeibdfw7nsmb3erhej2k6v4eopaswsf5yfv2ikweqa3qsc5no4jywqu"
 
 # note: --hash=blake2b-256 implies --cid-version=1 which implies --raw-leaves=true
 # the specified hash represents the leaf nodes stored as raw leaves and
 # encoded with the blake2b-256 hash function
-test_add_cat_expensive '--hash=blake2b-256' "bafykbzaceb26fnq5hz5iopzamcb4yqykya5x6a4nvzdmcyuu4rj2akzs3z7r6"
+test_add_cat_expensive '--hash=blake2b-256' "bafykbzaceduy3thhmcf6ptfqzxberlvj7sgo4uokrvd6qwrhim6r3rgcb26qi"
 
 test_add_named_pipe
 

--- a/test/sharness/t0043-add-w.sh
+++ b/test/sharness/t0043-add-w.sh
@@ -53,7 +53,7 @@ add_w_r='QmUerh2irM8cngqJHLGKCn4AGBSyHYAUi8i8zyVzXKNYyb'
 
 test_add_w() {
 
-  test_expect_success "go-random-files is installed" '
+  test_expect_success "random-files is installed" '
     type random-files
   '
 

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -16,106 +16,106 @@ test_ls_cmd() {
     echo "test" >testData/f1 &&
     echo "data" >testData/f2 &&
     echo "hello" >testData/d1/a &&
-    random 128 42 >testData/d1/128 &&
+    random-data -size=128 -seed=42 >testData/d1/128 &&
     echo "world" >testData/d2/a &&
-    random 1024 42 >testData/d2/1024 &&
+    random-data -size=1024 -seed=42 >testData/d2/1024 &&
     echo "badname" >testData/d2/`echo -e "bad\x7fname.txt"` &&
     ipfs add -r testData >actual_add
   '
 
   test_expect_success "'ipfs add' output looks good" '
     cat <<-\EOF >expected_add &&
-added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
+added QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN testData/d1/128
 added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
-added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
+added QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 testData/d2/1024
 added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
 added QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn testData/d2/bad\x7fname.txt
 added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
 added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
-added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
-added Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy testData/d2
-added QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 testData
+added QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j testData/d1
+added Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW testData/d2
+added QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc testData
 EOF
     test_cmp expected_add actual_add
   '
-
+  
   test_expect_success "'ipfs ls <three dir hashes>' succeeds" '
-    ipfs ls QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
+    ipfs ls QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j >actual_ls
   '
 
   test_expect_success "'ipfs ls <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls &&
-QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss - d1/
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy - d2/
+QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc:
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j - d1/
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW - d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5 f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5 f2
 
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
-QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024 1024
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW:
+QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 1024 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6    a
 QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8    bad\x7fname.txt
 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
-QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128 128
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j:
+QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN 128 128
 QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 6   a
 EOF
     test_cmp expected_ls actual_ls
   '
 
   test_expect_success "'ipfs ls --size=false <three dir hashes>' succeeds" '
-    ipfs ls --size=false QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
+    ipfs ls --size=false QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j >actual_ls
   '
 
   test_expect_success "'ipfs ls <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls &&
-QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss d1/
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy d2/
+QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc:
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j d1/
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M f2
 
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
-QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW:
+QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL a
 QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn bad\x7fname.txt
 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
-QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j:
+QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN 128
 QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN a
 EOF
     test_cmp expected_ls actual_ls
   '
 
   test_expect_success "'ipfs ls --headers <three dir hashes>' succeeds" '
-    ipfs ls --headers QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_headers
+    ipfs ls --headers QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j >actual_ls_headers
   '
 
   test_expect_success "'ipfs ls --headers  <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_headers &&
-QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
+QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc:
 Hash                                           Size Name
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss -    d1/
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy -    d2/
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j -    d1/
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW -    d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5    f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5    f2
 
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW:
 Hash                                           Size Name
-QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024 1024
+QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 1024 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6    a
 QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8    bad\x7fname.txt
 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j:
 Hash                                           Size Name
-QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128  128
+QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN 128  128
 QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 6    a
 EOF
     test_cmp expected_ls_headers actual_ls_headers
   '
 
   test_expect_success "'ipfs ls --size=false --cid-base=base32 <three dir hashes>' succeeds" '
-    ipfs ls --size=false --cid-base=base32 $(cid-fmt -v 1 -b base32 %s QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss) >actual_ls_base32
+    ipfs ls --size=false --cid-base=base32 $(cid-fmt -v 1 -b base32 %s QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j) >actual_ls_base32
   '
 
   test_expect_success "'ipfs ls --size=false --cid-base=base32 <three dir hashes>' output looks good" '
@@ -132,99 +132,99 @@ test_ls_cmd_streaming() {
     echo "test" >testData/f1 &&
     echo "data" >testData/f2 &&
     echo "hello" >testData/d1/a &&
-    random 128 42 >testData/d1/128 &&
+    random-data -size=128 -seed=42 >testData/d1/128 &&
     echo "world" >testData/d2/a &&
-    random 1024 42 >testData/d2/1024 &&
+    random-data -size=1024 -seed=42 >testData/d2/1024 &&
     echo "badname" >testData/d2/`echo -e "bad\x7fname.txt"` &&
     ipfs add -r testData >actual_add
   '
 
   test_expect_success "'ipfs add' output looks good" '
     cat <<-\EOF >expected_add &&
-added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
+added QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN testData/d1/128
 added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
-added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
+added QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 testData/d2/1024
 added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
 added QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn testData/d2/bad\x7fname.txt
 added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
 added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
-added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
-added Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy testData/d2
-added QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 testData
+added QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j testData/d1
+added Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW testData/d2
+added QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc testData
 EOF
     test_cmp expected_add actual_add
   '
 
   test_expect_success "'ipfs ls --stream <three dir hashes>' succeeds" '
-    ipfs ls --stream QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream
+    ipfs ls --stream QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j >actual_ls_stream
   '
 
   test_expect_success "'ipfs ls --stream <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_stream &&
-QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss -         d1/
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy -         d2/
+QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc:
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j -         d1/
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW -         d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5         f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5         f2
 
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
-QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024      1024
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW:
+QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 1024      1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6         a
 QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8         bad\x7fname.txt
 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
-QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128       128
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j:
+QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN 128       128
 QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 6         a
 EOF
     test_cmp expected_ls_stream actual_ls_stream
   '
 
   test_expect_success "'ipfs ls --size=false --stream <three dir hashes>' succeeds" '
-    ipfs ls --size=false --stream QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream
+    ipfs ls --size=false --stream QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j >actual_ls_stream
   '
 
   test_expect_success "'ipfs ls --size=false --stream <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_stream &&
-QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss d1/
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy d2/
+QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc:
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j d1/
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M f2
 
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
-QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW:
+QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL a
 QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn bad\x7fname.txt
 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
-QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j:
+QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN 128
 QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN a
 EOF
     test_cmp expected_ls_stream actual_ls_stream
   '
 
   test_expect_success "'ipfs ls --stream --headers <three dir hashes>' succeeds" '
-    ipfs ls --stream --headers QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream_headers
+    ipfs ls --stream --headers QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j >actual_ls_stream_headers
   '
 
   test_expect_success "'ipfs ls --stream --headers  <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_stream_headers &&
-QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
+QmR5UuxvF2ALd2GRGMCNg1GDiuuvcAyEkQaCV9fNkevWuc:
 Hash                                           Size      Name
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss -         d1/
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy -         d2/
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j -         d1/
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW -         d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5         f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5         f2
 
-Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
+Qmapxr4zxxUjoUFzyggydRZDkcJknjbtahYFKokbBAVghW:
 Hash                                           Size      Name
-QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024      1024
+QmZHVTX2epinyx5baTFV2L2ap9VtgbmfeFdhgntAypT5N3 1024      1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6         a
 QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8         bad\x7fname.txt
 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
+QmWWEQhcLufF3qPmmbUjqH7WVWBT9JrGJwPiVTryCoBs2j:
 Hash                                           Size      Name
-QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128       128
+QmWUixdcx1VJtpuAgXAy4e3JPAbEoHE6VEDut5KcYcpuGN 128       128
 QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 6         a
 EOF
     test_cmp expected_ls_stream_headers actual_ls_stream_headers
@@ -244,19 +244,19 @@ test_ls_cmd_raw_leaves() {
 
 test_ls_object() {
   test_expect_success "ipfs add medium size file then 'ipfs ls --size=false' works as expected" '
-    random 500000 2 > somefile &&
+    random-data -size=500000 -seed=2 > somefile &&
     HASH=$(ipfs add somefile -q) &&
-    echo "QmPrM8S5T7Q3M8DQvQMS7m41m3Aq4jBjzAzvky5fH3xfr4 " > ls-expect &&
-    echo "QmdaAntAzQqqVMo4B8V69nkQd5d918YjHXUe2oF6hr72ri " >> ls-expect &&
+    echo "QmWJuiG6dhfwo3KXxCc9gkdizoMoXbLMCDiTTZgEhSmyyo " > ls-expect &&
+    echo "QmNPxtpjhoXMRVKm4oSwcJaS4fck5FR4LufPd5KJr4jYhm " >> ls-expect &&
     ipfs ls --size=false $HASH > ls-actual &&
     test_cmp ls-actual ls-expect
   '
 
   test_expect_success "ipfs add medium size file then 'ipfs ls' works as expected" '
-    random 500000 2 > somefile &&
+    random-data -size=500000 -seed=2 > somefile &&
     HASH=$(ipfs add somefile -q) &&
-    echo "QmPrM8S5T7Q3M8DQvQMS7m41m3Aq4jBjzAzvky5fH3xfr4 262144 " > ls-expect &&
-    echo "QmdaAntAzQqqVMo4B8V69nkQd5d918YjHXUe2oF6hr72ri 237856 " >> ls-expect &&
+    echo "QmWJuiG6dhfwo3KXxCc9gkdizoMoXbLMCDiTTZgEhSmyyo 262144 " > ls-expect &&
+    echo "QmNPxtpjhoXMRVKm4oSwcJaS4fck5FR4LufPd5KJr4jYhm 237856 " >> ls-expect &&
     ipfs ls $HASH > ls-actual &&
     test_cmp ls-actual ls-expect
   '
@@ -285,8 +285,8 @@ test_ls_object
 test_expect_success "'ipfs add -r' succeeds" '
   mkdir adir &&
   # note: not using a seed as the files need to have truly random content
-  random 1000 > adir/file1 &&
-  random 1000 > adir/file2 &&
+  random-data -size=1000 > adir/file1 &&
+  random-data -size=1000 > adir/file2 &&
   ipfs add --pin=false -q -r adir > adir-hashes
 '
 

--- a/test/sharness/t0046-id-hash.sh
+++ b/test/sharness/t0046-id-hash.sh
@@ -65,7 +65,7 @@ test_expect_success "ipfs add --inline --raw-leaves outputs the correct hash" '
 '
 
 test_expect_success "create 1000 bytes file and get its hash" '
-  random 1000 2 > 1000bytes &&
+  random-data -size=1000 -seed=2 > 1000bytes &&
   HASH0=$(ipfs add -q --raw-leaves --only-hash 1000bytes)
 '
 

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -49,7 +49,7 @@ test_expect_success "'ipfs pin rm' output looks good" '
 
 test_expect_success "ipfs repo gc fully reverse ipfs add (part 1)" '
   ipfs repo gc &&
-  random 100000 41 >gcfile &&
+  random-data -size=100000 -seed=41 >gcfile &&
   find "$IPFS_PATH/blocks" -type f -name "*.data" | sort -u > expected_blocks &&
   hash=$(ipfs add -q gcfile) &&
   ipfs pin rm -r $hash &&
@@ -142,7 +142,7 @@ test_expect_success "'ipfs refs local' no longer shows file" '
 '
 
 test_expect_success "adding multiblock random file succeeds" '
-  random 1000000 >multiblock &&
+  random-data -size=1000000 >multiblock &&
   MBLOCKHASH=`ipfs add -q multiblock`
 '
 

--- a/test/sharness/t0082-repo-gc-auto.sh
+++ b/test/sharness/t0082-repo-gc-auto.sh
@@ -17,10 +17,10 @@ check_ipfs_storage() {
 
 test_init_ipfs
 
-test_expect_success "generate 2 600 kB files and 2 MB file using go-random" '
-  random 600k 41 >600k1 &&
-  random 600k 42 >600k2 &&
-  random 2M 43 >2M
+test_expect_success "generate 2 600 kB files and 2 MB file using random-data" '
+  random-data -size=614400 -seed=41 >600k1 &&
+  random-data -size=614400 -seed=42 >600k2 &&
+  random-data -size=2097152 -seed=43 >2M
 '
 
 test_expect_success "set ipfs gc watermark, storage max, and gc timeout" '

--- a/test/sharness/t0087-repo-robust-gc.sh
+++ b/test/sharness/t0087-repo-robust-gc.sh
@@ -16,7 +16,7 @@ to_raw_cid() {
 test_gc_robust_part1() {
 
   test_expect_success "add a 1MB file with --raw-leaves" '
-    random 1048576 56 > afile &&
+    random-data -size=1048576 -seed=56 > afile &&
     HASH1=`ipfs add --raw-leaves -q --cid-version 1 afile` &&
     REFS=`ipfs refs -r $HASH1` &&
     read LEAF1 LEAF2 LEAF3 LEAF4 < <(echo $REFS)
@@ -96,20 +96,20 @@ test_gc_robust_part1() {
 test_gc_robust_part2() {
 
   test_expect_success "add 1MB file normally (i.e., without raw leaves)" '
-    random 1048576 56 > afile &&
+    random-data -size=1048576 -seed=56 > afile &&
     HASH2=`ipfs add -q afile`
   '
 
-  LEAF1=QmSijovevteoY63Uj1uC5b8pkpDU5Jgyk2dYBqz3sMJUPc
-  LEAF1FILE=.ipfs/blocks/ME/CIQECF2K344QITW5S6E6H6T4DOXDDB2XA2V7BBOCIMN2VVF4Q77SMEY.data
+  LEAF1=QmcNNR6JSCUhJ9nyoVQgBhABPgcgdsuYJgdSB1f2g6BF5c
+  LEAF1FILE=.ipfs/blocks/RA/CIQNA5C3BLRUX3LZ7X6UTOV3KSHLARNXVDK3W5KUO6GVHNRP4SGLRAY.data
 
-  LEAF2=QmTbPEyrA1JyGUHFvmtx1FNZVzdBreMv8Hc8jV9sBRWhNA
-  LEAF2FILE=.ipfs/blocks/WM/CIQE4EFIJN2SUTQYSKMKNG7VM75W3SXT6LWJCHJJ73UAWN73WCX3WMY.data
+  LEAF2=QmPvtiBLgwuwF2wyf9VL8PaYgSt1XwGJ2Yu4AscRGEQvqR
+  LEAF2FILE=.ipfs/blocks/RN/CIQBPIKEATBI7TIHVYRQJZAKEWF2H22PXW3A7LCEPB6MFFL7IA2CRNA.data
 
 
   test_expect_success "add some additional unpinned content" '
-    random 1000 3 > junk1 &&
-    random 1000 4 > junk2 &&
+    random-data -size=1000 -seed=3 > junk1 &&
+    random-data -size=1000 -seed=4 > junk2 &&
     JUNK1=`ipfs add --pin=false -q junk1` &&
     JUNK2=`ipfs add --pin=false -q junk2`
   '

--- a/test/sharness/t0131-multinode-client-routing.sh
+++ b/test/sharness/t0131-multinode-client-routing.sh
@@ -24,7 +24,7 @@ check_file_fetch() {
 
 run_single_file_test() {
   test_expect_success "add a file on node1" '
-    random 1000000 > filea &&
+    random-data -size=1000000 > filea &&
     FILEA_HASH=$(ipfsi 1 add -q filea)
   '
 
@@ -57,7 +57,7 @@ test_expect_success "connect up nodes" '
 '
 
 test_expect_success "add a file on a node in client mode" '
-  random 1000000 > filea &&
+  random-data -size=1000000 > filea &&
   FILE_HASH=$(ipfsi 8 add -q filea)
 '
 

--- a/test/sharness/t0181-private-network.sh
+++ b/test/sharness/t0181-private-network.sh
@@ -26,7 +26,7 @@ test_expect_success "daemon output includes info about the reason" '
 pnet_key() {
   echo '/key/swarm/psk/1.0.0/'
   echo '/bin/'
-  random 32
+  random-data -size=32
 }
 
 pnet_key > "${IPFS_PATH}/swarm.key"
@@ -101,7 +101,7 @@ run_single_file_test() {
   node2=$2
 
   test_expect_success "add a file on node$node1" '
-    random 1000000 > filea &&
+    random-data -size=1000000 > filea &&
     FILEA_HASH=$(ipfsi $node1 add -q filea)
   '
 

--- a/test/sharness/t0231-channel-streaming.sh
+++ b/test/sharness/t0231-channel-streaming.sh
@@ -16,7 +16,7 @@ get_api_port() {
 
 test_ls_cmd() {
   test_expect_success "make a file with multiple refs" '
-    HASH=$(random 1000000 | ipfs add -q)
+    HASH=$(random-data -size=1000000 | ipfs add -q)
   '
 
   test_expect_success "can get refs through curl" '

--- a/test/sharness/t0271-filestore-utils.sh
+++ b/test/sharness/t0271-filestore-utils.sh
@@ -24,9 +24,9 @@ test_init_dataset() {
   test_expect_success "create a dataset" '
     rm -r somedir
     mkdir somedir &&
-    random    1000  1 > somedir/file1 &&
-    random   10000  2 > somedir/file2 &&
-    random 1000000  3 > somedir/file3
+    random-data -size=1000     -seed=1 > somedir/file1 &&
+    random-data -size=10000    -seed=2 > somedir/file2 &&
+    random-data -size=1000000  -seed=3 > somedir/file3
   '
 }
 
@@ -35,30 +35,30 @@ test_init() {
   test_init_dataset
 }
 
-EXPHASH="QmRueCuPMYYvdxWz1vWncF7wzCScEx4qasZXo5aVBb1R4V"
+EXPHASH="QmXqfraAT3U8ct14PPPXcFkWyvmqUZazLdo29GXTKSHkP4"
 
 cat <<EOF > ls_expect_file_order
-bafkreicj3ezgtrh3euw2gyub6w3jydhnouqobxt7stbgtns3mv3iwv6bqq   1000 somedir/file1 0
-bafkreibxwxisv4cld6x76ybqbvf2uwbkoswjqt4hut46af6rps2twme7ey  10000 somedir/file2 0
-bafkreidntk6ciin24oez6yjz4b25fgwecncvi4ua4uhr2tdyenogpzpid4 262144 somedir/file3 0
-bafkreidwie26yauqbhpd2nhhhmod55irq3z372mh6gw4ikl2ifo34c5jra 262144 somedir/file3 262144
-bafkreib7piyesy3dr22sawmycdftrmpyt3z4tmhxrdig2zt5zdp7qwbuay 262144 somedir/file3 524288
-bafkreigxp5k3k6b3i5sldu4r3im74nfxmoptuuubcvq6rg632nfznskglu 213568 somedir/file3 786432
+bafkreidx7ivgllulfkzyoo4oa7dfrg4mjmudg2qgdivoooj4s7lh3m5nqu   1000 somedir/file1 0
+bafkreic2wqrsyr3y3qgzbvufen2w25r3p3zljckqyxkpcagsxz3zdcosd4  10000 somedir/file2 0
+bafkreiemzfmzws23c2po4m6deiueknqfty7r3voes3e3zujmobrooc2ngm 262144 somedir/file3 0
+bafkreihgm53yhxn427lnfdwhqgpawc62qejog7gega5kqb6uwbyhjm47hu 262144 somedir/file3 262144
+bafkreigl2pjptgxz6cexcnua56zc5dwsyrc4ph2eulmcb634oes6gzvmuy 262144 somedir/file3 524288
+bafkreifjcthslybjizk36xffcsb32fsbguxz3ptkl7723wz4u3qikttmam 213568 somedir/file3 786432
 EOF
 
 sort < ls_expect_file_order > ls_expect_key_order
 
-FILE1_HASH=bafkreicj3ezgtrh3euw2gyub6w3jydhnouqobxt7stbgtns3mv3iwv6bqq
-FILE2_HASH=bafkreibxwxisv4cld6x76ybqbvf2uwbkoswjqt4hut46af6rps2twme7ey
-FILE3_HASH=QmfE4SDQazxTD7u8VTYs9AJqQL8rrJPUAorLeJXKSZrVf9
+FILE1_HASH=bafkreidx7ivgllulfkzyoo4oa7dfrg4mjmudg2qgdivoooj4s7lh3m5nqu
+FILE2_HASH=bafkreic2wqrsyr3y3qgzbvufen2w25r3p3zljckqyxkpcagsxz3zdcosd4
+FILE3_HASH=QmYEZtRGGk8rgM8MetegLLRHMKskPCg7zWpmQQAo3cQiN5
 
 cat <<EOF > verify_expect_file_order
-ok      bafkreicj3ezgtrh3euw2gyub6w3jydhnouqobxt7stbgtns3mv3iwv6bqq   1000 somedir/file1 0
-ok      bafkreibxwxisv4cld6x76ybqbvf2uwbkoswjqt4hut46af6rps2twme7ey  10000 somedir/file2 0
-ok      bafkreidntk6ciin24oez6yjz4b25fgwecncvi4ua4uhr2tdyenogpzpid4 262144 somedir/file3 0
-ok      bafkreidwie26yauqbhpd2nhhhmod55irq3z372mh6gw4ikl2ifo34c5jra 262144 somedir/file3 262144
-ok      bafkreib7piyesy3dr22sawmycdftrmpyt3z4tmhxrdig2zt5zdp7qwbuay 262144 somedir/file3 524288
-ok      bafkreigxp5k3k6b3i5sldu4r3im74nfxmoptuuubcvq6rg632nfznskglu 213568 somedir/file3 786432
+ok      bafkreidx7ivgllulfkzyoo4oa7dfrg4mjmudg2qgdivoooj4s7lh3m5nqu   1000 somedir/file1 0
+ok      bafkreic2wqrsyr3y3qgzbvufen2w25r3p3zljckqyxkpcagsxz3zdcosd4  10000 somedir/file2 0
+ok      bafkreiemzfmzws23c2po4m6deiueknqfty7r3voes3e3zujmobrooc2ngm 262144 somedir/file3 0
+ok      bafkreihgm53yhxn427lnfdwhqgpawc62qejog7gega5kqb6uwbyhjm47hu 262144 somedir/file3 262144
+ok      bafkreigl2pjptgxz6cexcnua56zc5dwsyrc4ph2eulmcb634oes6gzvmuy 262144 somedir/file3 524288
+ok      bafkreifjcthslybjizk36xffcsb32fsbguxz3ptkl7723wz4u3qikttmam 213568 somedir/file3 786432
 EOF
 
 sort < verify_expect_file_order > verify_expect_key_order
@@ -201,30 +201,30 @@ test_kill_ipfs_daemon
 ## base32
 ##
 
-EXPHASH="bafybeibva2uh4qpwjo2yr5g7m7nd5kfq64atydq77qdlrikh5uejwqdcbi"
+EXPHASH="bafybeienfbjfbywu5y44i5qm4wxajblgy5a6xuc4eepjaw5fq223wwsy3m"
 
 cat <<EOF > ls_expect_file_order
-bafkreicj3ezgtrh3euw2gyub6w3jydhnouqobxt7stbgtns3mv3iwv6bqq   1000 somedir/file1 0
-bafkreibxwxisv4cld6x76ybqbvf2uwbkoswjqt4hut46af6rps2twme7ey  10000 somedir/file2 0
-bafkreidntk6ciin24oez6yjz4b25fgwecncvi4ua4uhr2tdyenogpzpid4 262144 somedir/file3 0
-bafkreidwie26yauqbhpd2nhhhmod55irq3z372mh6gw4ikl2ifo34c5jra 262144 somedir/file3 262144
-bafkreib7piyesy3dr22sawmycdftrmpyt3z4tmhxrdig2zt5zdp7qwbuay 262144 somedir/file3 524288
-bafkreigxp5k3k6b3i5sldu4r3im74nfxmoptuuubcvq6rg632nfznskglu 213568 somedir/file3 786432
+bafkreidx7ivgllulfkzyoo4oa7dfrg4mjmudg2qgdivoooj4s7lh3m5nqu   1000 somedir/file1 0
+bafkreic2wqrsyr3y3qgzbvufen2w25r3p3zljckqyxkpcagsxz3zdcosd4  10000 somedir/file2 0
+bafkreiemzfmzws23c2po4m6deiueknqfty7r3voes3e3zujmobrooc2ngm 262144 somedir/file3 0
+bafkreihgm53yhxn427lnfdwhqgpawc62qejog7gega5kqb6uwbyhjm47hu 262144 somedir/file3 262144
+bafkreigl2pjptgxz6cexcnua56zc5dwsyrc4ph2eulmcb634oes6gzvmuy 262144 somedir/file3 524288
+bafkreifjcthslybjizk36xffcsb32fsbguxz3ptkl7723wz4u3qikttmam 213568 somedir/file3 786432
 EOF
 
 sort < ls_expect_file_order > ls_expect_key_order
 
-FILE1_HASH=bafkreicj3ezgtrh3euw2gyub6w3jydhnouqobxt7stbgtns3mv3iwv6bqq
-FILE2_HASH=bafkreibxwxisv4cld6x76ybqbvf2uwbkoswjqt4hut46af6rps2twme7ey
-FILE3_HASH=bafybeih24zygzr2orr5q62mjnbgmjwgj6rx3tp74pwcqsqth44rloncllq
+FILE1_HASH=bafkreidx7ivgllulfkzyoo4oa7dfrg4mjmudg2qgdivoooj4s7lh3m5nqu
+FILE2_HASH=bafkreic2wqrsyr3y3qgzbvufen2w25r3p3zljckqyxkpcagsxz3zdcosd4
+FILE3_HASH=bafybeietaxxjghilcjhc2m4zcmicm7yjvkjdfkamc3ct2hq4gmsb3shqsi
 
 cat <<EOF > verify_expect_file_order
-ok      bafkreicj3ezgtrh3euw2gyub6w3jydhnouqobxt7stbgtns3mv3iwv6bqq   1000 somedir/file1 0
-ok      bafkreibxwxisv4cld6x76ybqbvf2uwbkoswjqt4hut46af6rps2twme7ey  10000 somedir/file2 0
-ok      bafkreidntk6ciin24oez6yjz4b25fgwecncvi4ua4uhr2tdyenogpzpid4 262144 somedir/file3 0
-ok      bafkreidwie26yauqbhpd2nhhhmod55irq3z372mh6gw4ikl2ifo34c5jra 262144 somedir/file3 262144
-ok      bafkreib7piyesy3dr22sawmycdftrmpyt3z4tmhxrdig2zt5zdp7qwbuay 262144 somedir/file3 524288
-ok      bafkreigxp5k3k6b3i5sldu4r3im74nfxmoptuuubcvq6rg632nfznskglu 213568 somedir/file3 786432
+ok      bafkreidx7ivgllulfkzyoo4oa7dfrg4mjmudg2qgdivoooj4s7lh3m5nqu   1000 somedir/file1 0
+ok      bafkreic2wqrsyr3y3qgzbvufen2w25r3p3zljckqyxkpcagsxz3zdcosd4  10000 somedir/file2 0
+ok      bafkreiemzfmzws23c2po4m6deiueknqfty7r3voes3e3zujmobrooc2ngm 262144 somedir/file3 0
+ok      bafkreihgm53yhxn427lnfdwhqgpawc62qejog7gega5kqb6uwbyhjm47hu 262144 somedir/file3 262144
+ok      bafkreigl2pjptgxz6cexcnua56zc5dwsyrc4ph2eulmcb634oes6gzvmuy 262144 somedir/file3 524288
+ok      bafkreifjcthslybjizk36xffcsb32fsbguxz3ptkl7723wz4u3qikttmam 213568 somedir/file3 786432
 EOF
 
 sort < verify_expect_file_order > verify_expect_key_order

--- a/test/sharness/t0272-urlstore.sh
+++ b/test/sharness/t0272-urlstore.sh
@@ -10,9 +10,9 @@ test_description="Test out the urlstore functionality"
 
 
 test_expect_success "create some random files" '
-  random 2222     7 > file1 &&
-  random 500000   7 > file2 &&
-  random 50000000 7 > file3
+  random-data -size=2222     -seed=7 > file1 &&
+  random-data -size=500000   -seed=7 > file2 &&
+  random-data -size=50000000 -seed=7 > file3
 '
 
 test_urlstore() {
@@ -69,9 +69,9 @@ test_urlstore() {
   '
 
   cat <<EOF | sort > ls_expect
-bafkreiafqvawjpukk4achpu7edu4d6x5dbzwgigl6nxunjif3ser6bnfpu 262144 http://127.0.0.1:$GWAY_PORT/ipfs/QmUow2T4P69nEsqTQDZCt8yg9CPS8GFmpuDAr5YtsPhTdM 0
-bafkreia46t3jwchosehfcq7kponx26shcjkatxek4m2tzzd67i6o3frpou 237856 http://127.0.0.1:$GWAY_PORT/ipfs/QmUow2T4P69nEsqTQDZCt8yg9CPS8GFmpuDAr5YtsPhTdM 262144
-bafkreiga7ukbxrxs26fiseijjd7zdd6gmlrmnxhalwfbagxwjv7ck4o34a   2222 http://127.0.0.1:$GWAY_PORT/ipfs/QmcHm3BL2cXuQ6rJdKQgPrmT9suqGkfy2KzH3MkXPEBXU6 0
+bafkreiconmdoujderxi757nf4wjpo4ukbhlo6mmxs6pg3yl53ln3ykldvi   2222 http://127.0.0.1:$GWAY_PORT/ipfs/QmUNEBSK2uPLSZU3Dj6XbSHjdGze4huWxESx2R4Ef1cKRW 0
+bafkreifybqsfcheqkxzlhuuvoi3u6wz42kic4yqohvkia2i5fg3mpkqt3i 262144 http://127.0.0.1:$GWAY_PORT/ipfs/QmTgZc5bhTHUcqGN8rRP9oTJBv1UeJVWufPMPiUfbP9Ghs 0
+bafkreigxuuyoickqhwxu4kjckmgfqb7ygd426qiakryvvstixy523imym4 237856 http://127.0.0.1:$GWAY_PORT/ipfs/QmTgZc5bhTHUcqGN8rRP9oTJBv1UeJVWufPMPiUfbP9Ghs 262144
 EOF
 
   test_expect_success "ipfs filestore ls works with urls" '
@@ -80,9 +80,9 @@ EOF
   '
 
   cat <<EOF | sort > verify_expect
-ok      bafkreiafqvawjpukk4achpu7edu4d6x5dbzwgigl6nxunjif3ser6bnfpu 262144 http://127.0.0.1:$GWAY_PORT/ipfs/QmUow2T4P69nEsqTQDZCt8yg9CPS8GFmpuDAr5YtsPhTdM 0
-ok      bafkreia46t3jwchosehfcq7kponx26shcjkatxek4m2tzzd67i6o3frpou 237856 http://127.0.0.1:$GWAY_PORT/ipfs/QmUow2T4P69nEsqTQDZCt8yg9CPS8GFmpuDAr5YtsPhTdM 262144
-ok      bafkreiga7ukbxrxs26fiseijjd7zdd6gmlrmnxhalwfbagxwjv7ck4o34a   2222 http://127.0.0.1:$GWAY_PORT/ipfs/QmcHm3BL2cXuQ6rJdKQgPrmT9suqGkfy2KzH3MkXPEBXU6 0
+ok      bafkreifybqsfcheqkxzlhuuvoi3u6wz42kic4yqohvkia2i5fg3mpkqt3i 262144 http://127.0.0.1:$GWAY_PORT/ipfs/QmTgZc5bhTHUcqGN8rRP9oTJBv1UeJVWufPMPiUfbP9Ghs 0
+ok      bafkreigxuuyoickqhwxu4kjckmgfqb7ygd426qiakryvvstixy523imym4 237856 http://127.0.0.1:$GWAY_PORT/ipfs/QmTgZc5bhTHUcqGN8rRP9oTJBv1UeJVWufPMPiUfbP9Ghs 262144
+ok      bafkreiconmdoujderxi757nf4wjpo4ukbhlo6mmxs6pg3yl53ln3ykldvi   2222 http://127.0.0.1:$GWAY_PORT/ipfs/QmUNEBSK2uPLSZU3Dj6XbSHjdGze4huWxESx2R4Ef1cKRW 0
 EOF
   
   test_expect_success "ipfs filestore verify works with urls" '
@@ -116,8 +116,8 @@ EOF
   '
 
   cat <<EOF | sort > verify_expect_2
-error   bafkreiafqvawjpukk4achpu7edu4d6x5dbzwgigl6nxunjif3ser6bnfpu 262144 http://127.0.0.1:$GWAY_PORT/ipfs/QmUow2T4P69nEsqTQDZCt8yg9CPS8GFmpuDAr5YtsPhTdM 0
-error   bafkreia46t3jwchosehfcq7kponx26shcjkatxek4m2tzzd67i6o3frpou 237856 http://127.0.0.1:$GWAY_PORT/ipfs/QmUow2T4P69nEsqTQDZCt8yg9CPS8GFmpuDAr5YtsPhTdM 262144
+error   bafkreifybqsfcheqkxzlhuuvoi3u6wz42kic4yqohvkia2i5fg3mpkqt3i 262144 http://127.0.0.1:$GWAY_PORT/ipfs/QmTgZc5bhTHUcqGN8rRP9oTJBv1UeJVWufPMPiUfbP9Ghs 0
+error   bafkreigxuuyoickqhwxu4kjckmgfqb7ygd426qiakryvvstixy523imym4 237856 http://127.0.0.1:$GWAY_PORT/ipfs/QmTgZc5bhTHUcqGN8rRP9oTJBv1UeJVWufPMPiUfbP9Ghs 262144
 EOF
   
   test_expect_success "ipfs filestore verify is correct" '

--- a/test/sharness/t0276-cidv0v1.sh
+++ b/test/sharness/t0276-cidv0v1.sh
@@ -15,8 +15,8 @@ test_init_ipfs
 #
 
 test_expect_success "create two small files" '
-  random 1000 7 > afile
-  random 1000 9 > bfile
+  random-data -size=1000 -seed=7 > afile
+  random-data -size=1000 -seed=9 > bfile
 '
 
 test_expect_success "add file using CIDv1 but don't pin" '

--- a/test/sharness/t0500-issues-and-regressions-offline.sh
+++ b/test/sharness/t0500-issues-and-regressions-offline.sh
@@ -22,7 +22,7 @@ test_expect_success "ipfs pin ls --help succeeds when input remains open" '
 '
 
 test_expect_success "ipfs add on 1MB from stdin woks" '
-  random 1048576 42 | ipfs add -q > 1MB.hash
+  random-data -size=1048576 -seed=42 | ipfs add -q > 1MB.hash
 '
 
 test_expect_success "'ipfs refs -r -e \$(cat 1MB.hash)' succeeds" '


### PR DESCRIPTION
Needed in prep for go1.24 due to change in `rand.Seed` behavior.