### PR TITLE
refactor(repo/fsrepo/migrations): use t.TempDir() instead of os.Mkdir…

### DIFF
--- a/repo/fsrepo/migrations/setup_test.go
+++ b/repo/fsrepo/migrations/setup_test.go
@@ -32,9 +32,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	t := &testing.T{}
 	// Setup test data
-	testDataDir := makeTestData()
-	defer os.RemoveAll(testDataDir)
+	testDataDir := makeTestData(t)
 
 	testCar := makeTestCar(testDataDir)
 	defer os.RemoveAll(testCar)
@@ -47,11 +47,8 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func makeTestData() string {
-	tempDir, err := os.MkdirTemp("", "kubo-migrations-test-*")
-	if err != nil {
-		panic(err)
-	}
+func makeTestData(t testing.TB) string {
+	tempDir := t.TempDir()
 
 	versions := []string{"v1.0.0", "v1.1.0", "v1.1.2", "v2.0.0-rc1", "2.0.0", "v2.0.1"}
 	packages := []string{"kubo", "go-ipfs", "fs-repo-migrations", "fs-repo-1-to-2", "fs-repo-2-to-3", "fs-repo-9-to-10", "fs-repo-10-to-11"}


### PR DESCRIPTION
…Temp

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


 `TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.