### PR TITLE
Support WithIgnoreProviders() in provider query manager

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -48,9 +48,10 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		},
 
 		Routing: Routing{
-			Type:    nil,
-			Methods: nil,
-			Routers: nil,
+			Type:            nil,
+			Methods:         nil,
+			Routers:         nil,
+			IgnoreProviders: []peer.ID{},
 		},
 
 		// setup the node mount points.

--- a/config/routing.go
+++ b/config/routing.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	peer "github.com/libp2p/go-libp2p/core/peer"
 )
 
 const (
@@ -40,6 +42,8 @@ type Routing struct {
 	AcceleratedDHTClient Flag `json:",omitempty"`
 
 	LoopbackAddressesOnLanDHT Flag `json:",omitempty"`
+
+	IgnoreProviders []peer.ID
 
 	Routers Routers
 

--- a/docs/changelogs/v0.35.md
+++ b/docs/changelogs/v0.35.md
@@ -18,6 +18,13 @@ This release  was brought to you by the [Shipyard](http://ipshipyard.com/) team.
 
 ### 🔦 Highlights
 
+##### `Routing.IgnoreProviders`
+
+This new option allows ignoring specific peer IDs when returned by the content
+routing system as providers of content. See the
+[documentation](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingignoreproviders)
+for for information.
+
 #### 📦️ Important dependency updates
 
 ### 📝 Changelog

--- a/docs/config.md
+++ b/docs/config.md
@@ -119,6 +119,7 @@ config file at runtime.
     - [`Routing.Type`](#routingtype)
     - [`Routing.AcceleratedDHTClient`](#routingaccelerateddhtclient)
     - [`Routing.LoopbackAddressesOnLanDHT`](#routingloopbackaddressesonlandht)
+	- [`Routing.IgnoreProviders`](#routingignoreproviders)
     - [`Routing.Routers`](#routingrouters)
       - [`Routing.Routers: Type`](#routingrouters-type)
       - [`Routing.Routers: Parameters`](#routingrouters-parameters)
@@ -1717,6 +1718,19 @@ Most users do not need this setting. It can be useful during testing, when multi
 Default: `false`
 
 Type: `bool` (missing means `false`)
+
+### `Routing.IgnoreProviders`
+
+An array of peerIDs. Any provider record associated to one of these peer IDs is ignored.
+
+Apart from ignoring specific providers for reasons like misbehaviour etc. this
+setting is useful to ignore providers as a way to indicate preference, when the same provider
+is found under different peerIDs (i.e. one for HTTP and one for Bitswap retrieval).
+
+Default: `[]`
+
+Type: `array[peerID]`
+
 
 ### `Routing.Routers`
 


### PR DESCRIPTION
Adds `Routing.IgnoreProviders`.

This requires initializing a custom providerQueryManager and using it instead of the default created internally in Bitswap. Since the default is created with some internal default configuration options (MaxProviders), this hardcodes it.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
