### PR TITLE
fix: Add IPFS & IPNS path details to error (re. #10762) [skip changelog]

### DIFF
--- a/fuse/node/mount_unix.go
+++ b/fuse/node/mount_unix.go
@@ -89,11 +89,11 @@ func doMount(node *core.IpfsNode, fsdir, nsdir string) error {
 	wg.Wait()
 
 	if err1 != nil {
-		log.Errorf("error mounting: %s", err1)
+		log.Errorf("error mounting IPFS %s: %s", fsdir, err1)
 	}
 
 	if err2 != nil {
-		log.Errorf("error mounting: %s", err2)
+		log.Errorf("error mounting IPNS %s for IPFS %s: %s", nsdir, fsdir, err2)
 	}
 
 	if err1 != nil || err2 != nil {


### PR DESCRIPTION
Add IPFS & IPNS path details to error.

This can make debugging issues such as #10762 more straightforward.