### PR TITLE
docs: Fix typo in v0.34 changelog [skip changelog]

### DIFF
--- a/docs/changelogs/v0.34.md
+++ b/docs/changelogs/v0.34.md
@@ -148,7 +148,7 @@ Use [`Reprovider.Strategy`](https://github.com/ipfs/kubo/blob/master/docs/config
   - fix: switch away from IPFS_LOG_LEVEL (#10694) ([ipfs/kubo#10694](https://github.com/ipfs/kubo/pull/10694))
   - Merge release v0.33.2 ([ipfs/kubo#10713](https://github.com/ipfs/kubo/pull/10713))
   - Remove unused TimeParts struct (#10708) ([ipfs/kubo#10708](https://github.com/ipfs/kubo/pull/10708))
-  - fix(rpc): restore and reprecate `bitswap reprovide` (#10699) ([ipfs/kubo#10699](https://github.com/ipfs/kubo/pull/10699))
+  - fix(rpc): restore and deprecate `bitswap reprovide` (#10699) ([ipfs/kubo#10699](https://github.com/ipfs/kubo/pull/10699))
   - docs(release): update RELEASE_CHECKLIST.md after v0.33.1 (#10697) ([ipfs/kubo#10697](https://github.com/ipfs/kubo/pull/10697))
   - docs: update min requirements (#10687) ([ipfs/kubo#10687](https://github.com/ipfs/kubo/pull/10687))
   - Merge release v0.33.1 ([ipfs/kubo#10698](https://github.com/ipfs/kubo/pull/10698))


### PR DESCRIPTION
I've stumbled upon this because it was shown on https://github.com/ipfs/kubo/pull/10770/files as:

> Unchanged files with check annotations (Preview)
