### PR TITLE
Feat: http retrieval as experimental feature

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -458,6 +458,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 			cfg.Identity.PeerID,
 			cfg.Addresses,
 			cfg.Identity.PrivKey,
+			cfg.Experimental.HTTPRetrieval.Enabled,
 		)
 	default:
 		return fmt.Errorf("unrecognized routing option: %s", routingOption)

--- a/config/experiments.go
+++ b/config/experiments.go
@@ -1,5 +1,12 @@
 package config
 
+type HTTPRetrieval struct {
+	Enabled    bool             `json:",omitempty"`
+	NumWorkers *OptionalInteger `json:",omitempty"`
+	Allowlist  []string         `json:",omitempty"`
+	Denylist   []string         `json:",omitempty"`
+}
+
 type Experiments struct {
 	FilestoreEnabled              bool
 	UrlstoreEnabled               bool
@@ -10,6 +17,8 @@ type Experiments struct {
 	OptimisticProvide             bool
 	OptimisticProvideJobsPoolSize int
 	GatewayOverLibp2p             bool `json:",omitempty"`
+
+	HTTPRetrieval HTTPRetrieval
 
 	GraphsyncEnabled     graphsyncEnabled                 `json:",omitempty"`
 	AcceleratedDHTClient experimentalAcceleratedDHTClient `json:",omitempty"`

--- a/config/routing.go
+++ b/config/routing.go
@@ -24,8 +24,9 @@ var (
 	// Default filter-protocols to pass along with delegated routing requests (as defined in IPIP-484)
 	// and also filter out locally
 	DefaultHTTPRoutersFilterProtocols = getEnvOrDefault("IPFS_HTTP_ROUTERS_FILTER_PROTOCOLS", []string{
-		"unknown", // allow results without protocol list, we can do libp2p identify to test them
+		//"unknown", // allow results without protocol list, we can do libp2p identify to test them
 		"transport-bitswap",
+		"transport-ipfs-gateway-http",
 		// TODO: add 'transport-ipfs-gateway-http' once https://github.com/ipfs/rainbow/issues/125 is addressed
 	})
 )

--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/ipfs/boxo/bitswap"
 	"github.com/ipfs/boxo/bitswap/client"
+	"github.com/ipfs/boxo/bitswap/network"
 	bsnet "github.com/ipfs/boxo/bitswap/network/bsnet"
+	"github.com/ipfs/boxo/bitswap/network/httpnet"
 	blockstore "github.com/ipfs/boxo/blockstore"
 	exchange "github.com/ipfs/boxo/exchange"
 	"github.com/ipfs/boxo/exchange/providing"
@@ -75,13 +77,25 @@ type bitswapIn struct {
 // group.
 func Bitswap(provide bool) interface{} {
 	return func(in bitswapIn, lc fx.Lifecycle) (*bitswap.Bitswap, error) {
+		var ntwk network.BitSwapNetwork
 		bitswapNetwork := bsnet.NewFromIpfsHost(in.Host)
+
+		if httpCfg := in.Cfg.Experimental.HTTPRetrieval; httpCfg.Enabled {
+			htnet := httpnet.New(in.Host,
+				httpnet.WithHTTPWorkers(int(httpCfg.NumWorkers.WithDefault(16))),
+				httpnet.WithAllowlist(httpCfg.Allowlist),
+				httpnet.WithDenylist(httpCfg.Denylist),
+			)
+			ntwk = network.New(in.Host.Peerstore(), bitswapNetwork, htnet)
+		} else {
+			ntwk = bitswapNetwork
+		}
 
 		var provider routing.ContentDiscovery
 		if provide {
 			// We need to hardcode the default because it is an
 			// internal setting in boxo.
-			pqm, err := rpqm.New(bitswapNetwork,
+			pqm, err := rpqm.New(ntwk,
 				in.Rt,
 				rpqm.WithMaxProviders(10),
 				rpqm.WithIgnoreProviders(in.Cfg.Routing.IgnoreProviders...),
@@ -93,7 +107,7 @@ func Bitswap(provide bool) interface{} {
 			provider = pqm
 
 		}
-		bs := bitswap.New(helpers.LifecycleCtx(in.Mctx, lc), bitswapNetwork, provider, in.Bs, in.BitswapOpts...)
+		bs := bitswap.New(helpers.LifecycleCtx(in.Mctx, lc), ntwk, provider, in.Bs, in.BitswapOpts...)
 
 		lc.Append(fx.Hook{
 			OnStop: func(ctx context.Context) error {

--- a/core/node/libp2p/routingopt.go
+++ b/core/node/libp2p/routingopt.go
@@ -33,7 +33,7 @@ func constructDefaultHTTPRouters(cfg *config.Config) ([]*routinghelpers.Parallel
 	var routers []*routinghelpers.ParallelRouter
 	// Append HTTP routers for additional speed
 	for _, endpoint := range config.DefaultHTTPRouters {
-		httpRouter, err := irouting.ConstructHTTPRouter(endpoint, cfg.Identity.PeerID, httpAddrsFromConfig(cfg.Addresses), cfg.Identity.PrivKey)
+		httpRouter, err := irouting.ConstructHTTPRouter(endpoint, cfg.Identity.PeerID, httpAddrsFromConfig(cfg.Addresses), cfg.Identity.PrivKey, cfg.Experimental.HTTPRetrieval.Enabled)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +119,7 @@ func constructDHTRouting(mode dht.ModeOpt) RoutingOption {
 }
 
 // ConstructDelegatedRouting is used when Routing.Type = "custom"
-func ConstructDelegatedRouting(routers config.Routers, methods config.Methods, peerID string, addrs config.Addresses, privKey string) RoutingOption {
+func ConstructDelegatedRouting(routers config.Routers, methods config.Methods, peerID string, addrs config.Addresses, privKey string, httpRetrieval bool) RoutingOption {
 	return func(args RoutingOptionArgs) (routing.Routing, error) {
 		return irouting.Parse(routers, methods,
 			&irouting.ExtraDHTParams{
@@ -130,9 +130,10 @@ func ConstructDelegatedRouting(routers config.Routers, methods config.Methods, p
 				Context:        args.Ctx,
 			},
 			&irouting.ExtraHTTPParams{
-				PeerID:     peerID,
-				Addrs:      httpAddrsFromConfig(addrs),
-				PrivKeyB64: privKey,
+				PeerID:        peerID,
+				Addrs:         httpAddrsFromConfig(addrs),
+				PrivKeyB64:    privKey,
+				HTTPRetrieval: httpRetrieval,
 			},
 		)
 	}

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.24
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.29.1
+	github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.41.1
 	github.com/multiformats/go-multiaddr v0.15.0

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -298,8 +298,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.29.1 h1:z61ZT4YDfTHLjXTsu/+3wvJ8aJlExthDSOCpx6Nh8xc=
-github.com/ipfs/boxo v0.29.1/go.mod h1:MkDJStXiJS9U99cbAijHdcmwNfVn5DKYBmQCOgjY2NU=
+github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b h1:JVmBJtkQPbpuobkHqJLwYZhTSSndZoraLrf3eIS0z5A=
+github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b/go.mod h1:omQZmLS7LegSpBy3m4CrAB9/SO7Fq3pfv+5y1FOd+gI=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.29.1
+	github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.5.0
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.29.1 h1:z61ZT4YDfTHLjXTsu/+3wvJ8aJlExthDSOCpx6Nh8xc=
-github.com/ipfs/boxo v0.29.1/go.mod h1:MkDJStXiJS9U99cbAijHdcmwNfVn5DKYBmQCOgjY2NU=
+github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b h1:JVmBJtkQPbpuobkHqJLwYZhTSSndZoraLrf3eIS0z5A=
+github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b/go.mod h1:omQZmLS7LegSpBy3m4CrAB9/SO7Fq3pfv+5y1FOd+gI=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/routing/delegated.go
+++ b/routing/delegated.go
@@ -149,12 +149,13 @@ func parse(visited map[string]bool,
 }
 
 type ExtraHTTPParams struct {
-	PeerID     string
-	Addrs      []string
-	PrivKeyB64 string
+	PeerID        string
+	Addrs         []string
+	PrivKeyB64    string
+	HTTPRetrieval bool
 }
 
-func ConstructHTTPRouter(endpoint string, peerID string, addrs []string, privKey string) (routing.Routing, error) {
+func ConstructHTTPRouter(endpoint string, peerID string, addrs []string, privKey string, httpRetrieval bool) (routing.Routing, error) {
 	return httpRoutingFromConfig(
 		config.Router{
 			Type: "http",
@@ -163,9 +164,10 @@ func ConstructHTTPRouter(endpoint string, peerID string, addrs []string, privKey
 			},
 		},
 		&ExtraHTTPParams{
-			PeerID:     peerID,
-			Addrs:      addrs,
-			PrivKeyB64: privKey,
+			PeerID:        peerID,
+			Addrs:         addrs,
+			PrivKeyB64:    privKey,
+			HTTPRetrieval: httpRetrieval,
 		},
 	)
 }
@@ -200,13 +202,18 @@ func httpRoutingFromConfig(conf config.Router, extraHTTP *ExtraHTTPParams) (rout
 		return nil, err
 	}
 
+	protocols := config.DefaultHTTPRoutersFilterProtocols
+	if extraHTTP.HTTPRetrieval {
+		protocols = append(protocols, "transport-ipfs-gateway-http")
+	}
+
 	cli, err := drclient.New(
 		params.Endpoint,
 		drclient.WithHTTPClient(delegateHTTPClient),
 		drclient.WithIdentity(key),
 		drclient.WithProviderInfo(addrInfo.ID, addrInfo.Addrs),
 		drclient.WithUserAgent(version.GetUserAgentVersion()),
-		drclient.WithProtocolFilter(config.DefaultHTTPRoutersFilterProtocols),
+		drclient.WithProtocolFilter(protocols),
 		drclient.WithStreamResultsRequired(),       // https://specs.ipfs.tech/routing/http-routing-v1/#streaming
 		drclient.WithDisabledLocalFiltering(false), // force local filtering in case remote server does not support IPIP-484
 	)

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.29.1 // indirect
+	github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect
 	github.com/ipfs/go-datastore v0.8.2 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -294,8 +294,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.29.1 h1:z61ZT4YDfTHLjXTsu/+3wvJ8aJlExthDSOCpx6Nh8xc=
-github.com/ipfs/boxo v0.29.1/go.mod h1:MkDJStXiJS9U99cbAijHdcmwNfVn5DKYBmQCOgjY2NU=
+github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b h1:JVmBJtkQPbpuobkHqJLwYZhTSSndZoraLrf3eIS0z5A=
+github.com/ipfs/boxo v0.29.2-0.20250401090827-fcc26de2640b/go.mod h1:omQZmLS7LegSpBy3m4CrAB9/SO7Fq3pfv+5y1FOd+gI=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=
 github.com/ipfs/go-block-format v0.2.0/go.mod h1:+jpL11nFx5A/SPpsoBn6Bzkra/zaArfSmsknbPMYgzM=
 github.com/ipfs/go-cid v0.5.0 h1:goEKKhaGm0ul11IHA7I6p1GmKz8kEYniqFopaB5Otwg=


### PR DESCRIPTION
This introduces the http-retrieval capability as an experimental feature.

It can be enabled in the configuration `Experimental.HTTPRetrieval.Enabled = true`.

Documentation and changelog to be added later.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
