### PR TITLE
feat(config): expose ProviderSearchMaxResults

### DIFF
--- a/config/internal.go
+++ b/config/internal.go
@@ -14,5 +14,6 @@ type InternalBitswap struct {
 	EngineTaskWorkerCount       OptionalInteger
 	MaxOutstandingBytesPerPeer  OptionalInteger
 	ProviderSearchDelay         OptionalDuration
+	ProviderSearchMaxResults    OptionalInteger
 	WantHaveReplaceSize         OptionalInteger
 }

--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -28,6 +28,7 @@ const (
 	DefaultEngineTaskWorkerCount       = 8
 	DefaultMaxOutstandingBytesPerPeer  = 1 << 20
 	DefaultProviderSearchDelay         = 1000 * time.Millisecond
+	DefaultMaxProviders                = 10 // matching BitswapClientDefaultMaxProviders from https://github.com/ipfs/boxo/blob/v0.29.1/bitswap/internal/defaults/defaults.go#L15
 	DefaultWantHaveReplaceSize         = 1024
 )
 
@@ -79,11 +80,13 @@ func Bitswap(provide bool) interface{} {
 
 		var provider routing.ContentDiscovery
 		if provide {
-			// We need to hardcode the default because it is an
-			// internal setting in boxo.
+			var maxProviders int = DefaultMaxProviders
+			if in.Cfg.Internal.Bitswap != nil {
+				maxProviders = int(in.Cfg.Internal.Bitswap.ProviderSearchMaxResults.WithDefault(DefaultMaxProviders))
+			}
 			pqm, err := rpqm.New(bitswapNetwork,
 				in.Rt,
-				rpqm.WithMaxProviders(10),
+				rpqm.WithMaxProviders(maxProviders),
 				rpqm.WithIgnoreProviders(in.Cfg.Routing.IgnoreProviders...),
 			)
 			if err != nil {

--- a/docs/changelogs/v0.35.md
+++ b/docs/changelogs/v0.35.md
@@ -11,7 +11,7 @@ This release  was brought to you by the [Shipyard](http://ipshipyard.com/) team.
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [Dedicated `Reprovider.Strategy` for MFS](#dedicated-reproviderstrategy-for-mfs)
-  - [`Routing.IgnoreProviders`](#routingignoreproviders)
+  - [Additional new configuration options](#additional-new-configuration-options)
   - [Grid view in WebUI](#grid-view-in-webui)
   - [📦️ Important dependency updates](#-important-dependency-updates)
 - [📝 Changelog](#-changelog)
@@ -31,12 +31,10 @@ Users relying on the `pinned` strategy can switch to `pinned+mfs` and use MFS al
 
 See [`Reprovider.Strategy`](https://github.com/ipfs/kubo/blob/master/docs/config.md#reproviderstrategy) for more details.
 
-#### `Routing.IgnoreProviders`
+#### Additional new configuration options
 
-This new option allows ignoring specific peer IDs when returned by the content
-routing system as providers of content. See the
-[documentation](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingignoreproviders)
-for for information.
+- [`Internal.Bitswap.ProviderSearchMaxResults`](https://github.com/ipfs/kubo/blob/master/docs/config.md##internalbitswapprovidersearchmaxresults) for adjusting the maximum number of providers bitswap client should aim at before it stops searching for new ones.
+- [`Routing.IgnoreProviders`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingignoreproviders) allows ignoring specific peer IDs when returned by the content routing system as providers of content.
 
 #### Grid view in WebUI
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -79,7 +79,8 @@ config file at runtime.
       - [`Internal.Bitswap.EngineBlockstoreWorkerCount`](#internalbitswapengineblockstoreworkercount)
       - [`Internal.Bitswap.EngineTaskWorkerCount`](#internalbitswapenginetaskworkercount)
       - [`Internal.Bitswap.MaxOutstandingBytesPerPeer`](#internalbitswapmaxoutstandingbytesperpeer)
-    - [`Internal.Bitswap.ProviderSearchDelay`](#internalbitswapprovidersearchdelay)
+      - [`Internal.Bitswap.ProviderSearchDelay`](#internalbitswapprovidersearchdelay)
+      - [`Internal.Bitswap.ProviderSearchMaxResults`](#internalbitswapprovidersearchmaxresults)
     - [`Internal.UnixFSShardingSizeThreshold`](#internalunixfsshardingsizethreshold)
   - [`Ipns`](#ipns)
     - [`Ipns.RepublishPeriod`](#ipnsrepublishperiod)
@@ -119,7 +120,7 @@ config file at runtime.
     - [`Routing.Type`](#routingtype)
     - [`Routing.AcceleratedDHTClient`](#routingaccelerateddhtclient)
     - [`Routing.LoopbackAddressesOnLanDHT`](#routingloopbackaddressesonlandht)
-	- [`Routing.IgnoreProviders`](#routingignoreproviders)
+    - [`Routing.IgnoreProviders`](#routingignoreproviders)
     - [`Routing.Routers`](#routingrouters)
       - [`Routing.Routers: Type`](#routingrouters-type)
       - [`Routing.Routers: Parameters`](#routingrouters-parameters)
@@ -1181,13 +1182,20 @@ deteriorate the quality provided to less aggressively-wanting peers.
 
 Type: `optionalInteger` (byte count, `null` means default which is 1MB)
 
-### `Internal.Bitswap.ProviderSearchDelay`
+#### `Internal.Bitswap.ProviderSearchDelay`
 
 This parameter determines how long to wait before looking for providers outside of bitswap.
 Other routing systems like the Amino DHT are able to provide results in less than a second, so lowering
 this number will allow faster peers lookups in some cases.
 
 Type: `optionalDuration` (`null` means default which is 1s)
+
+#### `Internal.Bitswap.ProviderSearchMaxResults`
+
+Maximum number of providers bitswap client should aim at before it stops searching for new ones.
+Setting to 0 means unlimited.
+
+Type: `optionalInteger` (`null` means default which is 10)
 
 ### `Internal.UnixFSShardingSizeThreshold`
 


### PR DESCRIPTION
This PR is replacing hardcoded integer from https://github.com/ipfs/kubo/pull/10765 with named default and expose config option for adjusting it, like we do in Rainbow.