### PR TITLE
docs(fuse): use latest package name

### DIFF
--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -16,7 +16,7 @@ to your distribution manual to get things working.
 
 Install `fuse` with your favorite package manager:
 ```
-sudo apt-get install fuse
+sudo apt-get install fuse3
 ```
 
 On some older Linux distributions, you may need to add yourself to the `fuse` group.  


### PR DESCRIPTION
Installing `fuse` with `apt-get` on Debian Bookworm breaks dependencies. The latest package name (that should come preinstalled) is `fuse3`.

Update the docs example with the correct name.