### PR TITLE
fix(config): wire up `Provider.Enabled` flag

### DIFF
--- a/config/experiments.go
+++ b/config/experiments.go
@@ -6,7 +6,7 @@ type Experiments struct {
 	ShardingEnabled               bool `json:",omitempty"` // deprecated by autosharding: https://github.com/ipfs/kubo/pull/8527
 	Libp2pStreamMounting          bool
 	P2pHttpProxy                  bool //nolint
-	StrategicProviding            bool
+	StrategicProviding            bool `json:",omitempty"` // removed, use Provider.Enabled instead
 	OptimisticProvide             bool
 	OptimisticProvideJobsPoolSize int
 	GatewayOverLibp2p             bool `json:",omitempty"`

--- a/config/profile.go
+++ b/config/profile.go
@@ -270,7 +270,7 @@ fetching may be degraded.
 		},
 	},
 	"announce-off": {
-		Description: `Disables Reprovide system (and announcing to Amino DHT).
+		Description: `Disables Provide and Reprovide systems (announcing to Amino DHT).
 
 		USE WITH CAUTION:
 		The main use case for this is setups with manual Peering.Peers config.
@@ -279,16 +279,16 @@ fetching may be degraded.
 		one hosting it, and other peers are not already connected to it.
 `,
 		Transform: func(c *Config) error {
+			c.Provider.Enabled = False
 			c.Reprovider.Interval = NewOptionalDuration(0) // 0 disables periodic reprovide
-			c.Experimental.StrategicProviding = true       // this is not a typo (the name is counter-intuitive)
 			return nil
 		},
 	},
 	"announce-on": {
-		Description: `Re-enables Reprovide system (reverts announce-off profile).`,
+		Description: `Re-enables Provide and Reprovide systems (reverts announce-off profile).`,
 		Transform: func(c *Config) error {
+			c.Provider.Enabled = True
 			c.Reprovider.Interval = NewOptionalDuration(DefaultReproviderInterval) // have to apply explicit default because nil would be ignored
-			c.Experimental.StrategicProviding = false                              // this is not a typo (the name is counter-intuitive)
 			return nil
 		},
 	},

--- a/config/provider.go
+++ b/config/provider.go
@@ -1,9 +1,8 @@
 package config
 
 const (
-	DefaultProviderEnabled                   = true
-	DefaultProviderWorkerCount               = 16
-	DefaultProviderWorkerCountAcceleratedDHT = 64
+	DefaultProviderEnabled     = true
+	DefaultProviderWorkerCount = 16
 )
 
 // Provider configuration describes how NEW CIDs are announced the moment they are created.

--- a/config/provider.go
+++ b/config/provider.go
@@ -1,12 +1,15 @@
 package config
 
 const (
-	DefaultProviderWorkerCount = 64
+	DefaultProviderEnabled                   = true
+	DefaultProviderWorkerCount               = 16
+	DefaultProviderWorkerCountAcceleratedDHT = 64
 )
 
 // Provider configuration describes how NEW CIDs are announced the moment they are created.
 // For periodical reprovide configuration, see Reprovider.*
 type Provider struct {
+	Enabled     Flag             `json:",omitempty"`
 	Strategy    *OptionalString  `json:",omitempty"` // Unused, you are likely looking for Reprovider.Strategy instead
 	WorkerCount *OptionalInteger `json:",omitempty"` // Number of concurrent provides allowed, 0 means unlimited
 }

--- a/config/routing.go
+++ b/config/routing.go
@@ -48,10 +48,11 @@ type Routing struct {
 
 	IgnoreProviders []string `json:",omitempty"`
 
+	// Simplified configuration used by default when Routing.Type=auto|autoclient
 	DelegatedRouters []string `json:",omitempty"`
 
+	// Advanced configuration used when Routing.Type=custom
 	Routers Routers `json:",omitempty"`
-
 	Methods Methods `json:",omitempty"`
 }
 

--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -83,7 +83,7 @@ type bitswapIn struct {
 // Bitswap creates the BitSwap server/client instance.
 // If Bitswap.ServerEnabled is false, the node will act only as a client
 // using an empty blockstore to prevent serving blocks to other peers.
-func Bitswap(serverEnabled bool) interface{} {
+func Bitswap(serverEnabled, libp2pEnabled, httpEnabled bool) interface{} {
 	return func(in bitswapIn, lc fx.Lifecycle) (*bitswap.Bitswap, error) {
 		var bitswapNetworks, bitswapLibp2p network.BitSwapNetwork
 		var bitswapBlockstore blockstore.Blockstore = in.Bs
@@ -93,7 +93,8 @@ func Bitswap(serverEnabled bool) interface{} {
 			bitswapLibp2p = bsnet.NewFromIpfsHost(in.Host)
 		}
 
-		if httpCfg := in.Cfg.HTTPRetrieval; httpCfg.Enabled.WithDefault(config.DefaultHTTPRetrievalEnabled) {
+		if httpEnabled {
+			httpCfg := in.Cfg.HTTPRetrieval
 			maxBlockSize, err := humanize.ParseBytes(httpCfg.MaxBlockSize.WithDefault(config.DefaultHTTPRetrievalMaxBlockSize))
 			if err != nil {
 				return nil, err
@@ -136,7 +137,7 @@ func Bitswap(serverEnabled bool) interface{} {
 			return nil, err
 		}
 
-		// Explicitly enable/disable server to ensure desired provide mode
+		// Explicitly enable/disable server
 		in.BitswapOpts = append(in.BitswapOpts, bitswap.WithServerEnabled(serverEnabled))
 
 		bs := bitswap.New(helpers.LifecycleCtx(in.Mctx, lc), bitswapNetworks, providerQueryMgr, bitswapBlockstore, in.BitswapOpts...)

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -343,14 +343,6 @@ func Online(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 	// and vice versa: Provider.Enabled=false will disable both Provider of new CIDs and the Reprovider of old ones.
 	isProviderEnabled := cfg.Provider.Enabled.WithDefault(config.DefaultProviderEnabled) && cfg.Reprovider.Interval.WithDefault(config.DefaultReproviderInterval) != 0
 
-	isAcceleratedDHTClient := cfg.Routing.AcceleratedDHTClient.WithDefault(config.DefaultAcceleratedDHTClient)
-
-	// Accelerated DHT client has routing table cached, this able to handle bigger worker pool
-	defaultProviderWorkerCount := int64(config.DefaultProviderWorkerCount)
-	if isAcceleratedDHTClient {
-		defaultProviderWorkerCount = config.DefaultProviderWorkerCountAcceleratedDHT
-	}
-
 	return fx.Options(
 		fx.Provide(BitswapOptions(cfg)),
 		fx.Provide(Bitswap(isBitswapServerEnabled, isBitswapLibp2pEnabled, isHTTPRetrievalEnabled)),
@@ -371,8 +363,8 @@ func Online(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 			isProviderEnabled,
 			cfg.Reprovider.Strategy.WithDefault(config.DefaultReproviderStrategy),
 			cfg.Reprovider.Interval.WithDefault(config.DefaultReproviderInterval),
-			isAcceleratedDHTClient,
-			int(cfg.Provider.WorkerCount.WithDefault(defaultProviderWorkerCount)),
+			cfg.Routing.AcceleratedDHTClient.WithDefault(config.DefaultAcceleratedDHTClient),
+			int(cfg.Provider.WorkerCount.WithDefault(config.DefaultProviderWorkerCount)),
 		),
 	)
 }

--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -132,8 +132,8 @@ https://github.com/ipfs/kubo/blob/master/docs/config.md#routingaccelerateddhtcli
 // ONLINE/OFFLINE
 
 // OnlineProviders groups units managing provider routing records online
-func OnlineProviders(useStrategicProviding bool, reprovideStrategy string, reprovideInterval time.Duration, acceleratedDHTClient bool, provideWorkerCount int) fx.Option {
-	if useStrategicProviding {
+func OnlineProviders(provide bool, reprovideStrategy string, reprovideInterval time.Duration, acceleratedDHTClient bool, provideWorkerCount int) fx.Option {
+	if !provide {
 		return OfflineProviders()
 	}
 

--- a/docs/changelogs/v0.35.md
+++ b/docs/changelogs/v0.35.md
@@ -181,12 +181,16 @@ to delays in initial advertisements (provides).
 Provides and Reprovides now have separate queues, allowing for immediate
 provide of new CIDs and optimised batching of reprovides.
 
-This change introduces a new configuration option for limiting the number of
-concurrent provide operations:
-[`Provider.WorkerCount`](https://github.com/ipfs/kubo/blob/master/docs/config.md#providerworkercount).
+###### New `Provider` configuration options
+
+This change introduces a new configuration options:
+
+- [`Provider.Enabled`](https://github.com/ipfs/kubo/blob/master/docs/config.md#providerenabled) is a global flag for disabling both [Provider](https://github.com/ipfs/kubo/blob/master/docs/config.md#provider) and [Reprovider](https://github.com/ipfs/kubo/blob/master/docs/config.md#reprovider) systems (announcing new/old CIDs to amino DHT).
+- [`Provider.WorkerCount`](https://github.com/ipfs/kubo/blob/master/docs/config.md#providerworkercount) for limiting the number of concurrent provide operations, allows for fine-tuning the trade-off between announcement speed and system load when announcing new CIDs.
+- Removed `Experimental.StrategicProviding`. Superseded by `Provider.Enabled`, `Reprovider.Interval` and [`Reprovider.Strategy`](https://github.com/ipfs/kubo/blob/master/docs/config.md#reproviderstrategy).
 
 > [!TIP]
-> Users who need to provide large volumes of content immediately should consider removing the cap on concurrent provide operations and also set `Routing.AcceleratedDHTClient` to `true`.
+> Users who need to provide large volumes of content immediately should consider setting `Routing.AcceleratedDHTClient` to `true`. If that is not enough, consider adjusting `Provider.WorkerCount` to a higher value.
 
 ###### Deprecated `ipfs stats provider`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -110,6 +110,7 @@ config file at runtime.
           - [`Pinning.RemoteServices: Policies.MFS.PinName`](#pinningremoteservices-policiesmfspinname)
           - [`Pinning.RemoteServices: Policies.MFS.RepinInterval`](#pinningremoteservices-policiesmfsrepininterval)
   - [`Provider`](#provider)
+    - [`Provider.Enabled`](#providerenabled)
     - [`Provider.Strategy`](#providerstrategy)
     - [`Provider.WorkerCount`](#providerworkercount)
   - [`Pubsub`](#pubsub)
@@ -962,7 +963,7 @@ We are working on developing a modern replacement. To support our efforts, pleas
 on specified hostnames that point at your Kubo instance.
 
 It is useful when you want to run [Path gateway](https://specs.ipfs.tech/http-gateways/path-gateway/) on `example.com/ipfs/cid`,
-and [Subdomain gateway](https://specs.ipfs.tech/http-gateways/subdomain-gateway/) on `cid.ipfs.example.org`, 
+and [Subdomain gateway](https://specs.ipfs.tech/http-gateways/subdomain-gateway/) on `cid.ipfs.example.org`,
 or limit `verifiable.example.net` to response types defined in [Trustless Gateway](https://specs.ipfs.tech/http-gateways/trustless-gateway/) specification.
 
 > [!CAUTION]
@@ -1000,7 +1001,7 @@ Type: `array[string]`
 #### `Gateway.PublicGateways: UseSubdomains`
 
 A boolean to configure whether the gateway at the hostname should be
-a [Subdomain Gateway](https://specs.ipfs.tech/http-gateways/subdomain-gateway/) 
+a [Subdomain Gateway](https://specs.ipfs.tech/http-gateways/subdomain-gateway/)
 and provide [Origin isolation](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)
 between content roots.
 
@@ -1503,15 +1504,28 @@ commands.
 
 For periodical DHT reprovide settings, see [`Reprovide.*`](#reprovider).
 
+### `Provider.Enabled`
+
+Controls whether Kubo provider and reprovide systems are enabled.
+
+> [!CAUTION]
+> Disabling this, will disable BOTH `Provider` system for new CIDs
+> and the periodical reprovide ([`Reprovider.Interval`](#reprovider)) of old CIDs.
+
+Default: `true`
+
+Type: `flag`
+
 ### `Provider.Strategy`
 
 Legacy, not used at the moment, see [`Reprovider.Strategy`](#reproviderstrategy) instead.
 
 ### `Provider.WorkerCount`
 
-Sets the maximum number of _concurrent_ DHT provide operations. DHT reprovides
-operations do **not** count against that limit. A value of `0` allows an
-unlimited number of provide workers.
+Sets the maximum number of _concurrent_ DHT provide operations (announcement of new CIDs).
+
+[`Reprovider`](#reprovider) operations do **not** count against this limit.
+A value of `0` allows an unlimited number of provide workers.
 
 If the [accelerated DHT client](#routingaccelerateddhtclient) is enabled, each
 provide operation opens ~20 connections in parallel. With the standard DHT
@@ -1524,7 +1538,11 @@ For nodes without strict connection limits that need to provide large volumes
 of content immediately, we recommend enabling the `Routing.AcceleratedDHTClient` and
 setting `Provider.WorkerCount` to `0` (unlimited).
 
-Default: `64`
+> [!CAUTION]
+> Raising this value too high may lead to increased load.
+> Proceed with caution.
+
+Default: `16` (`64` if `Routing.AcceleratedDHTClient=true`)
 
 Type: `integer` (non-negative; `0` means unlimited number of workers)
 
@@ -1705,6 +1723,10 @@ Note: disabling content reproviding will result in other nodes on the network
 not being able to discover that you have the objects that you have. If you want
 to have this disabled and keep the network aware of what you have, you must
 manually announce your content periodically.
+
+> [!CAUTION]
+> Setting `Reprovider.Interval=0` will only disable the periodic reprovides.
+> New CIDs will stil lbe announced. To disable both, set [`Provider.Enabled=false`](#providerenabled) as well.
 
 Default: `22h` (`DefaultReproviderInterval`)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1890,12 +1890,13 @@ Type: `array[string]`
 
 ### `Routing.DelegatedRouters`
 
-This is an array of URL hostnames that support the [Delegated Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/) which are used alongside the DHT when [`Routing.Type`](#routingtype) is set to `auto` or `autoclient`.
+An array of URL hostnames for delegated routers to be queried in addition to the Amino DHT when `Routing.Type` is set to `auto` (default) or `autoclient`.
+These endpoints must support the [Delegated Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/).
 
 > [!TIP]
 > Delegated routing allows IPFS implementations to offload tasks like content routing, peer routing, and naming to a separate process or server while also benefiting from HTTP caching.
 >
-> One can run their own delegated router either by implementing the [Delegated Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/) themselves, or by using [Someguy](https://github.com/ipfs/someguy), a turn-key implementation that proxies requests to the Amino DHT and other delegated routing servers, such as the Network Indexer at `cid.contact`. Public utility instance of Someguy is hosted at [`https://delegated-ipfs.dev`](https://docs.ipfs.tech/concepts/public-utilities/#delegated-routing).
+> One can run their own delegated router either by implementing the [Delegated Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/) themselves, or by using [Someguy](https://github.com/ipfs/someguy), a turn-key implementation that proxies requests to other routing systems. A public utility instance of Someguy is hosted at [`https://delegated-ipfs.dev`](https://docs.ipfs.tech/concepts/public-utilities/#delegated-routing).
 
 Default: `["https://cid.contact"]` (empty or `nil` will also use this default; to disable delegated routing, set `Routing.Type` to `dht` or `dhtclient`)
 
@@ -1903,11 +1904,14 @@ Type: `array[string]`
 
 ### `Routing.Routers`
 
-**EXPERIMENTAL: `Routing.Routers` configuration may change in future release**
+Alternative configuration used when `Routing.Type=custom`.
 
-Map of additional Routers.
+> [!WARNING]
+> **EXPERIMENTAL: `Routing.Routers` configuration may change in future release**
+>
+> Consider this advanced low-level config: Most users can simply use `Routing.Type=auto` or `autoclient` and set up basic config in user-friendly [`Routing.DelegatedRouters`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingdelegatedrouters).
 
-Allows for extending the default routing (Amino DHT) with alternative Router
+Allows for replacing the default routing (Amino DHT) with alternative Router
 implementations.
 
 The map key is a name of a Router, and the value is its configuration.
@@ -1967,7 +1971,14 @@ Type: `object[string->string]`
 
 ### `Routing: Methods`
 
-`Methods:map` will define which routers will be executed per method. The key will be the name of the method: `"provide"`, `"find-providers"`, `"find-peers"`, `"put-ipns"`, `"get-ipns"`. All methods must be added to the list.
+`Methods:map` will define which routers will be executed per method used when `Routing.Type=custom`.
+
+> [!WARNING]
+> **EXPERIMENTAL: `Routing.Routers` configuration may change in future release**
+>
+> Consider this advanced low-level config: Most users can simply use `Routing.Type=auto` or `autoclient` and set up basic config in user-friendly [`Routing.DelegatedRouters`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingdelegatedrouters).
+
+The key will be the name of the method: `"provide"`, `"find-providers"`, `"find-peers"`, `"put-ipns"`, `"get-ipns"`. All methods must be added to the list.
 
 The value will contain:
 - `RouterName:string`: Name of the router. It should be one of the previously added to `Routing.Routers` list.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1111,7 +1111,7 @@ $ ipfs config --json Gateway.PublicGateways '{"localhost": null }'
 
 ### `Gateway` recipes
 
-Below is a list of the most common public gateway setups.
+Below is a list of the most common gateway setups.
 
 * Public [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://{cid}.ipfs.dweb.link` (each content root gets its own Origin)
    ```console
@@ -1122,6 +1122,7 @@ Below is a list of the most common public gateway setups.
        }
      }'
    ```
+   - **Performance:** consider running with `Routing.AcceleratedDHTClient=true` and either `Provider.Enabled=false` (avoid providing newly retrieved blocks) or `Provider.WorkerCount=0` (provide as fast as possible, at the cost of increased load)
    - **Backward-compatible:** this feature enables automatic redirects from content paths to subdomains:
 
      `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.dweb.link`
@@ -1146,6 +1147,7 @@ Below is a list of the most common public gateway setups.
        }
      }'
    ```
+   - **Performance:** when running an open, recursive gateway consider running with `Routing.AcceleratedDHTClient=true` and either `Provider.Enabled=false` (avoid providing newly retrieved blocks) or `Provider.WorkerCount=0` (provide as fast as possible, at the cost of increased load)
 
 * Public [DNSLink](https://dnslink.io/) gateway resolving every hostname passed in `Host` header.
   ```console
@@ -1534,17 +1536,17 @@ connections, with at most 10 active at once. Provides complete more quickly
 when using the accelerated client. Be mindful of how many simultaneous
 connections this setting can generate.
 
-For nodes without strict connection limits that need to provide large volumes
-of content immediately, we recommend enabling the `Routing.AcceleratedDHTClient` and
-setting `Provider.WorkerCount` to `0` (unlimited).
-
 > [!CAUTION]
-> Raising this value too high may lead to increased load.
-> Proceed with caution.
+> For nodes without strict connection limits that need to provide large volumes
+> of content immediately, we recommend enabling the `Routing.AcceleratedDHTClient` and
+> setting `Provider.WorkerCount` to `0` (unlimited).
+>
+> At the same time, mind that raising this value too high may lead to increased load.
+> Proceed with caution, ensure proper hardware and networking are in place.
 
-Default: `16` (`64` if `Routing.AcceleratedDHTClient=true`)
+Default: `16`
 
-Type: `integer` (non-negative; `0` means unlimited number of workers)
+Type: `optionalInteger` (non-negative; `0` means unlimited number of workers)
 
 ## `Pubsub`
 
@@ -1722,11 +1724,11 @@ system.
 Note: disabling content reproviding will result in other nodes on the network
 not being able to discover that you have the objects that you have. If you want
 to have this disabled and keep the network aware of what you have, you must
-manually announce your content periodically.
+manually announce your content periodically or run your own routing system
+and convince users to add it to [`Routing.DelegatedRouters`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingdelegatedrouters).
 
 > [!CAUTION]
-> Setting `Reprovider.Interval=0` will only disable the periodic reprovides.
-> New CIDs will stil lbe announced. To disable both, set [`Provider.Enabled=false`](#providerenabled) as well.
+> To maintain backward-compatibility, setting `Reprovider.Interval=0` will also disable Provider system (equivalent of `Provider.Enabled=false`)
 
 Default: `22h` (`DefaultReproviderInterval`)
 

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -537,27 +537,9 @@ ipfs config --json Swarm.RelayClient.Enabled true
 
 ### State
 
-Experimental, disabled by default.
+`Experimental.StrategicProviding` was removed in Kubo v0.35.
 
-Replaces the existing provide mechanism with a robust, strategic provider system. Currently enabling this option will provide nothing.
-
-### How to enable
-
-Modify your ipfs config:
-
-```
-ipfs config --json Experimental.StrategicProviding true
-```
-
-### Road to being a real feature
-
-- [ ] needs real-world testing
-- [ ] needs adoption
-- [ ] needs to support all provider subsystem features
-    - [X] provide nothing
-    - [ ] provide roots
-    - [ ] provide all
-    - [ ] provide strategic
+Replaced by [`Provide.Enabled`](https://github.com/ipfs/kubo/blob/master/docs/config.md#providerenabled) and [`Reprovider.Strategy`](https://github.com/ipfs/kubo/blob/master/docs/config.md#reproviderstrategy).
 
 ## GraphSync
 

--- a/test/cli/provider_test.go
+++ b/test/cli/provider_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipfs/kubo/test/cli/harness"
 	"github.com/ipfs/kubo/test/cli/testutils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +34,7 @@ func TestProvider(t *testing.T) {
 		}
 	}
 
-	t.Run("Provider.Enabled=true", func(t *testing.T) {
+	t.Run("Provider.Enabled=true announces new CIDs created by ipfs add", func(t *testing.T) {
 		t.Parallel()
 
 		nodes := initNodes(t, 2, func(n *harness.Node) {
@@ -48,7 +49,7 @@ func TestProvider(t *testing.T) {
 		expectProviders(t, cid, nodes[0].PeerID().String(), nodes[1:]...)
 	})
 
-	t.Run("Provider.Enabled=false", func(t *testing.T) {
+	t.Run("Provider.Enabled=false disables announcement of new CID from ipfs add", func(t *testing.T) {
 		t.Parallel()
 
 		nodes := initNodes(t, 2, func(n *harness.Node) {
@@ -57,6 +58,75 @@ func TestProvider(t *testing.T) {
 		defer nodes.StopDaemons()
 
 		cid := nodes[0].IPFSAddStr(time.Now().String())
+		expectNoProviders(t, cid, nodes[1:]...)
+	})
+
+	t.Run("Provider.Enabled=false disables manual announcement via RPC command", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := initNodes(t, 2, func(n *harness.Node) {
+			n.SetIPFSConfig("Provider.Enabled", false)
+		})
+		defer nodes.StopDaemons()
+
+		cid := nodes[0].IPFSAddStr(time.Now().String())
+		res := nodes[0].RunIPFS("routing", "provide", cid)
+		assert.Contains(t, res.Stderr.Trimmed(), "invalid configuration: Provider.Enabled is set to 'false'")
+		assert.Equal(t, 1, res.ExitCode())
+
+		expectNoProviders(t, cid, nodes[1:]...)
+	})
+
+	// Right now Provide and Reprovide are tied together
+	t.Run("Reprovide.Interval=0 disables announcement of new CID too", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := initNodes(t, 2, func(n *harness.Node) {
+			n.SetIPFSConfig("Reprovider.Interval", "0")
+		})
+		defer nodes.StopDaemons()
+
+		cid := nodes[0].IPFSAddStr(time.Now().String())
+		expectNoProviders(t, cid, nodes[1:]...)
+	})
+
+	// It is a lesser evil - forces users to fix their config and have some sort of interval
+	t.Run("Manual Reprovider trigger does not work when periodic Reprovider is disabled", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := initNodes(t, 2, func(n *harness.Node) {
+			n.SetIPFSConfig("Reprovider.Interval", "0")
+		})
+		defer nodes.StopDaemons()
+
+		cid := nodes[0].IPFSAddStr(time.Now().String(), "--offline")
+
+		expectNoProviders(t, cid, nodes[1:]...)
+
+		res := nodes[0].RunIPFS("routing", "reprovide")
+		assert.Contains(t, res.Stderr.Trimmed(), "invalid configuration: Reprovider.Interval is set to '0'")
+		assert.Equal(t, 1, res.ExitCode())
+
+		expectNoProviders(t, cid, nodes[1:]...)
+	})
+
+	// It is a lesser evil - forces users to fix their config and have some sort of interval
+	t.Run("Manual Reprovider trigger does not work when Provider system is disabled", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := initNodes(t, 2, func(n *harness.Node) {
+			n.SetIPFSConfig("Provider.Enabled", false)
+		})
+		defer nodes.StopDaemons()
+
+		cid := nodes[0].IPFSAddStr(time.Now().String(), "--offline")
+
+		expectNoProviders(t, cid, nodes[1:]...)
+
+		res := nodes[0].RunIPFS("routing", "reprovide")
+		assert.Contains(t, res.Stderr.Trimmed(), "invalid configuration: Provider.Enabled is set to 'false'")
+		assert.Equal(t, 1, res.ExitCode())
+
 		expectNoProviders(t, cid, nodes[1:]...)
 	})
 
@@ -149,20 +219,4 @@ func TestProvider(t *testing.T) {
 		expectProviders(t, cidBarDir, nodes[0].PeerID().String(), nodes[1:]...)
 	})
 
-	t.Run("Providing works without ticking", func(t *testing.T) {
-		t.Parallel()
-
-		nodes := initNodes(t, 2, func(n *harness.Node) {
-			n.SetIPFSConfig("Reprovider.Interval", "0")
-		})
-		defer nodes.StopDaemons()
-
-		cid := nodes[0].IPFSAddStr(time.Now().String(), "--offline")
-
-		expectNoProviders(t, cid, nodes[1:]...)
-
-		nodes[0].IPFS("routing", "reprovide")
-
-		expectProviders(t, cid, nodes[0].PeerID().String(), nodes[1:]...)
-	})
 }

--- a/test/cli/provider_test.go
+++ b/test/cli/provider_test.go
@@ -33,11 +33,11 @@ func TestProvider(t *testing.T) {
 		}
 	}
 
-	t.Run("Basic Providing", func(t *testing.T) {
+	t.Run("Provider.Enabled=true", func(t *testing.T) {
 		t.Parallel()
 
 		nodes := initNodes(t, 2, func(n *harness.Node) {
-			n.SetIPFSConfig("Experimental.StrategicProviding", false)
+			n.SetIPFSConfig("Provider.Enabled", true)
 		})
 		defer nodes.StopDaemons()
 
@@ -48,11 +48,11 @@ func TestProvider(t *testing.T) {
 		expectProviders(t, cid, nodes[0].PeerID().String(), nodes[1:]...)
 	})
 
-	t.Run("Basic Strategic Providing", func(t *testing.T) {
+	t.Run("Provider.Enabled=false", func(t *testing.T) {
 		t.Parallel()
 
 		nodes := initNodes(t, 2, func(n *harness.Node) {
-			n.SetIPFSConfig("Experimental.StrategicProviding", true)
+			n.SetIPFSConfig("Provider.Enabled", false)
 		})
 		defer nodes.StopDaemons()
 


### PR DESCRIPTION
Kubo 0.35.0-rc1 had issues on Staging environment due too OOMs ([internal notes](https://www.notion.so/Kubo-0-34-1-vs-0-35-0-1ed1def342878037b7c1f8b67d7c986b?pvs=4#1ed1def342878070ba3ec1e526d86761)).

@guillaumemichel and @gammazero  suggested that the problem is related to provides, which should be disabled on that box.  This PR aims to implement ability to fully disable provides (and reprovides) as noted in #10803 and unblock Kubo 0.35 (https://github.com/ipfs/kubo/issues/10760)

### TODO

- [x] Add [`Provider.Enabled`](https://github.com/ipfs/kubo/blob/master/docs/config.md#providerenabled) is a global flag for disabling both [Provider](https://github.com/ipfs/kubo/blob/master/docs/config.md#provider) and [Reprovider](https://github.com/ipfs/kubo/blob/master/docs/config.md#reprovider) systems (announcing new/old CIDs to amino DHT).
- [x] Remove `Experimental.StrategicProviding`. Superseded by `Provider.Enabled`, `Reprovider.Interval` and [`Reprovider.Strategy`](https://github.com/ipfs/kubo/blob/master/docs/config.md#reproviderstrategy).
  - [x] update tests
- [x] Lower default for `Provider.WorkerCount` when no Accelerated DHT client
- [x] Add/Update CLI tests of `routing [re]provide` commands, ensure global flags are respected
- [x] CI green
- [x] Deploy to staging and see if OOM is still present: https://github.com/ipshipyard/waterworks-infra/pull/604
  - [x] [OOMd right after it started](https://grafana.ipshipyard.dev/d/c3b61616-3e32-47e2-850b-04d48e0daaf0/ipfs-rainbow-gateway?orgId=1&from=2025-05-13T21:30:00.000Z&to=2025-05-13T22:17:34.651Z&timezone=utc&var-instance=kubo-staging-us-east-01&var-instance=kubo-staging-us-east-02&refresh=1m&viewPanel=panel-5), but then looked stable. I'm going to let it [run for a longer time](https://grafana.ipshipyard.dev/d/c3b61616-3e32-47e2-850b-04d48e0daaf0/ipfs-rainbow-gateway?orgId=1&from=2025-05-13T21:30:00.000Z&to=now&timezone=utc&var-instance=kubo-staging-us-east-01&var-instance=kubo-staging-us-east-02&refresh=1m&viewPanel=panel-5) to see if it occurs as often as in 0.34.1 
- [x] (optional) make extra test where we re-enable [re]provider and see behavior with lowered `Provider.WorkerCount` 
  - [x] done ([internal notes](https://www.notion.so/Kubo-0-34-1-vs-0-35-0-1ed1def342878037b7c1f8b67d7c986b?pvs=4#1f41def34287804db785f093aa9385d4)) – updated docs in https://github.com/ipfs/kubo/pull/10804/commits/e8ec3fde17c14a192866dbc9637c18c27e0c734c 
- [x] Merge if staging OOMs are gone

