### PR TITLE
fix(gateway): gateway-conformance v0.8

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.7
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.8
         with:
           output: fixtures
 
@@ -94,7 +94,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.7
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.8
         with:
           gateway-url: http://127.0.0.1:8080
           subdomain-url: http://localhost:8080
@@ -128,7 +128,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.7
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.8
         with:
           output: fixtures
 
@@ -201,7 +201,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.7
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.8
         with:
           gateway-url: http://127.0.0.1:8092
           args: --specs "trustless-gateway,-trustless-ipns-gateway" -skip 'TestGatewayCar/GET_response_for_application/vnd.ipld.car/Header_Content-Length'

--- a/docs/changelogs/v0.36.md
+++ b/docs/changelogs/v0.36.md
@@ -32,6 +32,7 @@ go-log v2 has been out for quite a while now and it is time to deprecate v1.
 
 - update `go-libp2p-kad-dht` to [v0.33.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.33.0)
 - update `boxo` to [v0.31.0](https://github.com/ipfs/boxo/releases/tag/v0.31.0)
+- update `gateway-conformance` to [v0.8](https://github.com/ipfs/gateway-conformance/releases/tag/v0.8.0)
 
 ### 📝 Changelog
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.24
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.31.0
+	github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.41.1
 	github.com/multiformats/go-multiaddr v0.15.0

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -308,8 +308,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.31.0 h1:h+zE4Pcf2rzlctQtLxhltPvflpojyLflXVWQfVR0pz0=
-github.com/ipfs/boxo v0.31.0/go.mod h1:gEkUkBiZWtEjHd1AiUxaWEYaQApPtbeGF45fdfCwLX0=
+github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c h1:0jAFJxC74Gy0VwDG6WwYJq0yZdXOFIIeCwUXXln0w6A=
+github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c/go.mod h1:gEkUkBiZWtEjHd1AiUxaWEYaQApPtbeGF45fdfCwLX0=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.31.0
+	github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c
 	github.com/ipfs/go-block-format v0.2.1
 	github.com/ipfs/go-cid v0.5.0
 	github.com/ipfs/go-cidutil v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.31.0 h1:h+zE4Pcf2rzlctQtLxhltPvflpojyLflXVWQfVR0pz0=
-github.com/ipfs/boxo v0.31.0/go.mod h1:gEkUkBiZWtEjHd1AiUxaWEYaQApPtbeGF45fdfCwLX0=
+github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c h1:0jAFJxC74Gy0VwDG6WwYJq0yZdXOFIIeCwUXXln0w6A=
+github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c/go.mod h1:gEkUkBiZWtEjHd1AiUxaWEYaQApPtbeGF45fdfCwLX0=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-bitswap v0.11.0 h1:j1WVvhDX1yhG32NTC9xfxnqycqYIlhzEzLXG/cU1HyQ=

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
-	github.com/ipfs/boxo v0.31.0 // indirect
+	github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.1 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -330,8 +330,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.31.0 h1:h+zE4Pcf2rzlctQtLxhltPvflpojyLflXVWQfVR0pz0=
-github.com/ipfs/boxo v0.31.0/go.mod h1:gEkUkBiZWtEjHd1AiUxaWEYaQApPtbeGF45fdfCwLX0=
+github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c h1:0jAFJxC74Gy0VwDG6WwYJq0yZdXOFIIeCwUXXln0w6A=
+github.com/ipfs/boxo v0.31.1-0.20250528182950-f87feb50c39c/go.mod h1:gEkUkBiZWtEjHd1AiUxaWEYaQApPtbeGF45fdfCwLX0=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.1 h1:96kW71XGNNa+mZw/MTzJrCpMhBWCrd9kBLoKm9Iip/Q=


### PR DESCRIPTION
- Closes https://github.com/ipfs/kubo/issues/10808
- RN: https://github.com/ipfs/gateway-conformance/releases/tag/v0.8.0

## TODO

- [x] switch to boxo release with https://github.com/ipfs/boxo/pull/922
- [x] switch to conformance release with https://github.com/ipfs/gateway-conformance/pull/213



<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
