### PR TITLE
wrap user-facing mfs.Lookup error

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -724,7 +724,7 @@ Examples:
 
 		fsn, err := mfs.Lookup(nd.FilesRoot, path)
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %w", path, err)
 		}
 
 		fi, ok := fsn.(*mfs.File)


### PR DESCRIPTION
To avoid the blank Error: file does not exist and specify which file we failed to find.

Error before: `Error: file does not exist`

Error after: `Error: /my-cat-pic.jpg: file does not exist`

Closes #8671
