### PR TITLE
config/swarm/connmgr: expose silence period

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -95,6 +95,9 @@ const DefaultConnMgrLowWater = 32
 // grace period.
 const DefaultConnMgrGracePeriod = time.Second * 20
 
+// DefaultConnMgrSilencePeriod controls how often the connection manager enforces the limits.
+const DefaultConnMgrSilencePeriod = time.Second * 10
+
 // DefaultConnMgrType is the default value for the connection managers
 // type.
 const DefaultConnMgrType = "basic"

--- a/config/swarm.go
+++ b/config/swarm.go
@@ -104,10 +104,11 @@ type Transports struct {
 
 // ConnMgr defines configuration options for the libp2p connection manager.
 type ConnMgr struct {
-	Type        *OptionalString   `json:",omitempty"`
-	LowWater    *OptionalInteger  `json:",omitempty"`
-	HighWater   *OptionalInteger  `json:",omitempty"`
-	GracePeriod *OptionalDuration `json:",omitempty"`
+	Type          *OptionalString   `json:",omitempty"`
+	LowWater      *OptionalInteger  `json:",omitempty"`
+	HighWater     *OptionalInteger  `json:",omitempty"`
+	GracePeriod   *OptionalDuration `json:",omitempty"`
+	SilencePeriod *OptionalDuration `json:",omitempty"`
 }
 
 // ResourceMgr defines configuration options for the libp2p Network Resource Manager

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -49,7 +49,9 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 		grace := cfg.Swarm.ConnMgr.GracePeriod.WithDefault(config.DefaultConnMgrGracePeriod)
 		low := int(cfg.Swarm.ConnMgr.LowWater.WithDefault(config.DefaultConnMgrLowWater))
 		high := int(cfg.Swarm.ConnMgr.HighWater.WithDefault(config.DefaultConnMgrHighWater))
-		connmgr = fx.Provide(libp2p.ConnectionManager(low, high, grace))
+		silence := cfg.Swarm.ConnMgr.SilencePeriod.WithDefault(config.DefaultConnMgrSilencePeriod)
+		connmgr = fx.Provide(libp2p.ConnectionManager(low, high, grace, silence))
+
 	default:
 		return fx.Error(fmt.Errorf("unrecognized Swarm.ConnMgr.Type: %q", connMgrType))
 	}

--- a/core/node/libp2p/libp2p.go
+++ b/core/node/libp2p/libp2p.go
@@ -25,9 +25,12 @@ type Libp2pOpts struct {
 	Opts []libp2p.Option `group:"libp2p"`
 }
 
-func ConnectionManager(low, high int, grace time.Duration) func() (opts Libp2pOpts, err error) {
+func ConnectionManager(low, high int, grace, silence time.Duration) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
-		cm, err := connmgr.NewConnManager(low, high, connmgr.WithGracePeriod(grace))
+		cm, err := connmgr.NewConnManager(low, high,
+			connmgr.WithGracePeriod(grace),
+			connmgr.WithSilencePeriod(silence),
+		)
 		if err != nil {
 			return opts, err
 		}

--- a/docs/changelogs/v0.36.md
+++ b/docs/changelogs/v0.36.md
@@ -38,6 +38,10 @@ The `ipfs files cp` command has a `--force` option to allow it to overwrite exis
 
 The `filestore` command has a new option, `--remove-bad-blocks`, to verify objects in the filestore and remove those that fail verification.
 
+#### ConnMgr.SilencePeriod configuration setting exposed
+
+This connection manager option controls how often connections are swept and potentially terminated. See the [ConnMgr documentation](../config.md#swarmconnmgrsilenceperiod).
+
 #### 📦️ Important dependency updates
 
 - update `go-libp2p-kad-dht` to [v0.33.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.33.0)

--- a/docs/changelogs/v0.36.md
+++ b/docs/changelogs/v0.36.md
@@ -40,7 +40,7 @@ The `filestore` command has a new option, `--remove-bad-blocks`, to verify objec
 
 #### ConnMgr.SilencePeriod configuration setting exposed
 
-This connection manager option controls how often connections are swept and potentially terminated. See the [ConnMgr documentation](../config.md#swarmconnmgrsilenceperiod).
+This connection manager option controls how often connections are swept and potentially terminated. See the [ConnMgr documentation](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmconnmgrsilenceperiod).
 
 #### 📦️ Important dependency updates
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -164,6 +164,7 @@ config file at runtime.
         - [`Swarm.ConnMgr.LowWater`](#swarmconnmgrlowwater)
         - [`Swarm.ConnMgr.HighWater`](#swarmconnmgrhighwater)
         - [`Swarm.ConnMgr.GracePeriod`](#swarmconnmgrgraceperiod)
+        - [`Swarm.ConnMgr.SilencePeriod`](#swarmconnmgrsilenceperiod)
     - [`Swarm.ResourceMgr`](#swarmresourcemgr)
       - [`Swarm.ResourceMgr.Enabled`](#swarmresourcemgrenabled)
       - [`Swarm.ResourceMgr.MaxMemory`](#swarmresourcemgrmaxmemory)
@@ -2294,8 +2295,9 @@ Type: `optionalString` (default when unset or empty)
 
 The basic connection manager uses a "high water", a "low water", and internal
 scoring to periodically close connections to free up resources. When a node
-using the basic connection manager reaches `HighWater` idle connections, it will
-close the least useful ones until it reaches `LowWater` idle connections.
+using the basic connection manager reaches `HighWater` idle connections, it
+will close the least useful ones until it reaches `LowWater` idle
+connections. The process of closing connections happens every `SilencePeriod`.
 
 The connection manager considers a connection idle if:
 
@@ -2314,7 +2316,8 @@ The connection manager considers a connection idle if:
       "Type": "basic",
       "LowWater": 100,
       "HighWater": 200,
-      "GracePeriod": "30s"
+      "GracePeriod": "30s",
+      "SilencePeriod": "10s"
     }
   }
 }
@@ -2345,6 +2348,14 @@ GracePeriod is a time duration that new connections are immune from being closed
 by the connection manager.
 
 Default: `"20s"`
+
+Type: `optionalDuration`
+
+##### `Swarm.ConnMgr.SilencePeriod`
+
+SilencePeriod is the time duration between connection manager runs, when connections that are idle are closed.
+
+Default: `"10s"`
 
 Type: `optionalDuration`
 


### PR DESCRIPTION
Allows users to set the connmgr silence period.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
