### PR TITLE
refactor: support percent-encoded /unix paths

### DIFF
--- a/client/rpc/api.go
+++ b/client/rpc/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-cid"
 	legacy "github.com/ipfs/go-ipld-legacy"
 	ipfs "github.com/ipfs/kubo"
+	daemon "github.com/ipfs/kubo/cmd/ipfs/kubo"
 	iface "github.com/ipfs/kubo/core/coreiface"
 	caopts "github.com/ipfs/kubo/core/coreiface/options"
 	"github.com/ipfs/kubo/misc/fsutil"
@@ -109,6 +110,7 @@ func NewApi(a ma.Multiaddr) (*HttpApi, error) {
 		return nil, err
 	}
 	if network == "unix" {
+		address = daemon.NormalizeUnixMultiaddr(address)
 		transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
 			return net.Dial("unix", address)
 		}

--- a/docs/config.md
+++ b/docs/config.md
@@ -249,7 +249,7 @@ the local [Kubo RPC API](https://docs.ipfs.tech/reference/kubo/rpc/) (`/api/v0`)
 Supported Transports:
 
 * tcp/ip{4,6} - `/ipN/.../tcp/...`
-* unix - `/unix/path/to/socket`
+* unix - `/unix/path/to/socket` or `/unix/path%2Fto%2Fsocket`
 
 > [!CAUTION]
 > **NEVER EXPOSE UNPROTECTED ADMIN RPC TO LAN OR THE PUBLIC INTERNET**
@@ -276,7 +276,7 @@ the local [HTTP gateway](https://specs.ipfs.tech/http-gateways/) (`/ipfs`, `/ipn
 Supported Transports:
 
 * tcp/ip{4,6} - `/ipN/.../tcp/...`
-* unix - `/unix/path/to/socket`
+* unix - `/unix/path/to/socket` or `/unix/path%2Fto%2Fsocket`
 
 Default: `/ip4/127.0.0.1/tcp/8080`
 

--- a/test/cli/rpc_unixsocket_test.go
+++ b/test/cli/rpc_unixsocket_test.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"context"
+	"net/url"
 	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	rpcapi "github.com/ipfs/kubo/client/rpc"
@@ -13,39 +16,72 @@ import (
 )
 
 func TestRPCUnixSocket(t *testing.T) {
-	node := harness.NewT(t).NewNode().Init()
+	t.Parallel()
 
-	sockDir := node.Dir
-	sockAddr := path.Join("/unix", sockDir, "sock")
-
-	node.UpdateConfig(func(cfg *config.Config) {
-		//cfg.Addresses.API = append(cfg.Addresses.API, sockPath)
-		cfg.Addresses.API = []string{sockAddr}
-	})
-	t.Log("Starting daemon with unix socket:", sockAddr)
-	node.StartDaemon()
-
-	unixMaddr, err := multiaddr.NewMultiaddr(sockAddr)
-	require.NoError(t, err)
-
-	apiClient, err := rpcapi.NewApi(unixMaddr)
-	require.NoError(t, err)
-
-	var ver struct {
-		Version string
+	testCases := []struct {
+		name             string
+		getSockMultiaddr func(sockPath string) (unixMultiaddr string)
+	}{
+		{
+			name: "Legacy /unix: unescaped socket path",
+			getSockMultiaddr: func(sockDir string) string {
+				return path.Join("/unix", sockDir, "sock")
+			},
+		},
+		{
+			name: "Spec-compliant /unix: percent-encoded socket path without leading slash",
+			getSockMultiaddr: func(sockDir string) string {
+				sockPath := path.Join(sockDir, "sock")
+				pathWithoutLeadingSlash := strings.TrimPrefix(sockPath, string(filepath.Separator))
+				escapedPath := url.PathEscape(pathWithoutLeadingSlash)
+				return path.Join("/unix", escapedPath)
+			},
+		},
+		{
+			name: "Spec-compliant /unix: percent-encoded socket path with leading slash",
+			getSockMultiaddr: func(sockDir string) string {
+				sockPath := path.Join(sockDir, "sock")
+				escapedPath := url.PathEscape(sockPath)
+				return path.Join("/unix", escapedPath)
+			},
+		},
 	}
-	err = apiClient.Request("version").Exec(context.Background(), &ver)
-	require.NoError(t, err)
-	require.NotEmpty(t, ver)
-	t.Log("Got version:", ver.Version)
 
-	var res struct {
-		ID string
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := harness.NewT(t).NewNode().Init()
+			sockDir := node.Dir
+			sockAddr := tc.getSockMultiaddr(sockDir)
+			node.UpdateConfig(func(cfg *config.Config) {
+				//cfg.Addresses.API = append(cfg.Addresses.API, sockPath)
+				cfg.Addresses.API = []string{sockAddr}
+			})
+			t.Log("Starting daemon with unix socket:", sockAddr)
+			node.StartDaemon()
+
+			unixMaddr, err := multiaddr.NewMultiaddr(sockAddr)
+			require.NoError(t, err)
+
+			apiClient, err := rpcapi.NewApi(unixMaddr)
+			require.NoError(t, err)
+
+			var ver struct {
+				Version string
+			}
+			err = apiClient.Request("version").Exec(context.Background(), &ver)
+			require.NoError(t, err)
+			require.NotEmpty(t, ver)
+			t.Log("Got version:", ver.Version)
+
+			var res struct {
+				ID string
+			}
+			err = apiClient.Request("id").Exec(context.Background(), &res)
+			require.NoError(t, err)
+			require.NotEmpty(t, res)
+			t.Log("Got ID:", res.ID)
+
+			node.StopDaemon()
+		})
 	}
-	err = apiClient.Request("id").Exec(context.Background(), &res)
-	require.NoError(t, err)
-	require.NotEmpty(t, res)
-	t.Log("Got ID:", res.ID)
-
-	node.StopDaemon()
 }


### PR DESCRIPTION
## Why

- https://github.com/multiformats/multiaddr/pull/174

 is breaking spec change that is incompatible with existing feature in Kubo, where users were able to provide old notation of `/unix` multiaddrs in both [Addresses.API](https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesapi) and [Addresses.Gateway](https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesgateway).


## How 

This is a PoC that aims to support
https://github.com/multiformats/multiaddr/pull/174 while not breaking existing Kubo users.


## TODO 

- [ ] resolve TODO in daemon.go – decide if we want to move normalization to https://github.com/multiformats/go-multiaddr

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
