### PR TITLE
core:constructor: add a log line about http retrieval

### DIFF
--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -99,6 +99,11 @@ func Bitswap(serverEnabled, libp2pEnabled, httpEnabled bool) interface{} {
 			if err != nil {
 				return nil, err
 			}
+			logger.Infof("HTTP Retrieval enabled: Allowlist: %t. Denylist: %t",
+				httpCfg.Allowlist != nil,
+				httpCfg.Denylist != nil,
+			)
+
 			bitswapHTTP := httpnet.New(in.Host,
 				httpnet.WithHTTPWorkers(int(httpCfg.NumWorkers.WithDefault(config.DefaultHTTPRetrievalNumWorkers))),
 				httpnet.WithAllowlist(httpCfg.Allowlist),


### PR DESCRIPTION
Similar to broadcast control. Useful for debugging/info purposes.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
