### PR TITLE
refactor: use slices.Sort to simplify code

### DIFF
--- a/core/commands/completion.go
+++ b/core/commands/completion.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"io"
+	"slices"
 	"sort"
 	"text/template"
 
@@ -68,18 +69,10 @@ func commandToCompletions(name string, fullName string, cmd *cmds.Command) *comp
 			parsed.Options = append(parsed.Options, flag)
 		}
 	}
-	sort.Slice(parsed.LongFlags, func(i, j int) bool {
-		return parsed.LongFlags[i] < parsed.LongFlags[j]
-	})
-	sort.Slice(parsed.ShortFlags, func(i, j int) bool {
-		return parsed.ShortFlags[i] < parsed.ShortFlags[j]
-	})
-	sort.Slice(parsed.LongOptions, func(i, j int) bool {
-		return parsed.LongOptions[i] < parsed.LongOptions[j]
-	})
-	sort.Slice(parsed.ShortOptions, func(i, j int) bool {
-		return parsed.ShortOptions[i] < parsed.ShortOptions[j]
-	})
+	slices.Sort(parsed.LongFlags)
+	slices.Sort(parsed.ShortFlags)
+	slices.Sort(parsed.LongOptions)
+	slices.Sort(parsed.ShortOptions)
 	return parsed
 }
 

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 
@@ -174,7 +175,7 @@ func printPeer(keyEnc ke.KeyEncoder, ps pstore.Peerstore, p peer.ID) (interface{
 
 	protocols, _ := ps.GetProtocols(p) // don't care about errors here.
 	info.Protocols = append(info.Protocols, protocols...)
-	sort.Slice(info.Protocols, func(i, j int) bool { return info.Protocols[i] < info.Protocols[j] })
+	slices.Sort(info.Protocols)
 
 	if v, err := ps.Get(p, "AgentVersion"); err == nil {
 		if vs, ok := v.(string); ok {
@@ -207,7 +208,7 @@ func printSelf(keyEnc ke.KeyEncoder, node *core.IpfsNode) (interface{}, error) {
 		}
 		sort.Strings(info.Addresses)
 		info.Protocols = node.PeerHost.Mux().Protocols()
-		sort.Slice(info.Protocols, func(i, j int) bool { return info.Protocols[i] < info.Protocols[j] })
+		slices.Sort(info.Protocols)
 	}
 	info.AgentVersion = version.GetUserAgentVersion()
 	return info, nil

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"slices"
 	"sort"
 	"strconv"
 	"sync"
@@ -488,7 +489,7 @@ func (ci *connInfo) identifyPeer(ps pstore.Peerstore, p peer.ID) (IdOutput, erro
 
 	if protocols, err := ps.GetProtocols(p); err == nil {
 		info.Protocols = append(info.Protocols, protocols...)
-		sort.Slice(info.Protocols, func(i, j int) bool { return info.Protocols[i] < info.Protocols[j] })
+		slices.Sort(info.Protocols)
 	}
 
 	if v, err := ps.Get(p, "AgentVersion"); err == nil {


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.