### PR TITLE
refactor: use slices.Sort where appropriate

### DIFF
--- a/core/commands/active.go
+++ b/core/commands/active.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"text/tabwriter"
 	"time"
 
@@ -60,7 +60,7 @@ Lists running and recently run commands.
 					for k := range req.Options {
 						keys = append(keys, k)
 					}
-					sort.Strings(keys)
+					slices.Sort(keys)
 
 					for _, k := range keys {
 						fmt.Fprintf(tw, "%s=%v,", k, req.Options[k])

--- a/core/commands/bootstrap.go
+++ b/core/commands/bootstrap.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
-
-	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
-	repo "github.com/ipfs/kubo/repo"
-	fsrepo "github.com/ipfs/kubo/repo/fsrepo"
+	"slices"
+	"strings"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	config "github.com/ipfs/kubo/config"
+	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
+	repo "github.com/ipfs/kubo/repo"
+	fsrepo "github.com/ipfs/kubo/repo/fsrepo"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -284,7 +284,9 @@ var bootstrapListCmd = &cmds.Command{
 }
 
 func bootstrapWritePeers(w io.Writer, prefix string, peers []string) error {
-	sort.Stable(sort.StringSlice(peers))
+	slices.SortStableFunc(peers, func(a, b string) int {
+		return strings.Compare(a, b)
+	})
 	for _, peer := range peers {
 		_, err := w.Write([]byte(prefix + peer + "\n"))
 		if err != nil {

--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -1,10 +1,11 @@
 package commands
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -287,7 +288,7 @@ var basesCmd = &cmds.Command{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, val []CodeAndName) error {
 			prefixes, _ := req.Options[prefixOptionName].(bool)
 			numeric, _ := req.Options[numericOptionName].(bool)
-			sort.Sort(multibaseSorter{val})
+			multibaseSorter{val}.Sort()
 			for _, v := range val {
 				code := v.Code
 				if code < 32 || code >= 127 {
@@ -357,7 +358,7 @@ var codecsCmd = &cmds.Command{
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, val []CodeAndName) error {
 			numeric, _ := req.Options[codecsNumericOptionName].(bool)
-			sort.Sort(codeAndNameSorter{val})
+			codeAndNameSorter{val}.Sort()
 			for _, v := range val {
 				if numeric {
 					fmt.Fprintf(w, "%5d  %s\n", v.Code, v.Name)
@@ -398,23 +399,22 @@ type multibaseSorter struct {
 	data []CodeAndName
 }
 
-func (s multibaseSorter) Len() int      { return len(s.data) }
-func (s multibaseSorter) Swap(i, j int) { s.data[i], s.data[j] = s.data[j], s.data[i] }
-
-func (s multibaseSorter) Less(i, j int) bool {
-	a := unicode.ToLower(rune(s.data[i].Code))
-	b := unicode.ToLower(rune(s.data[j].Code))
-	if a != b {
-		return a < b
-	}
-	// lowecase letters should come before uppercase
-	return s.data[i].Code > s.data[j].Code
+func (s multibaseSorter) Sort() {
+	slices.SortFunc(s.data, func(a, b CodeAndName) int {
+		if n := cmp.Compare(unicode.ToLower(rune(a.Code)), unicode.ToLower(rune(b.Code))); n != 0 {
+			return n
+		}
+		// lowecase letters should come before uppercase
+		return cmp.Compare(b.Code, a.Code)
+	})
 }
 
 type codeAndNameSorter struct {
 	data []CodeAndName
 }
 
-func (s codeAndNameSorter) Len() int           { return len(s.data) }
-func (s codeAndNameSorter) Swap(i, j int)      { s.data[i], s.data[j] = s.data[j], s.data[i] }
-func (s codeAndNameSorter) Less(i, j int) bool { return s.data[i].Code < s.data[j].Code }
+func (s codeAndNameSorter) Sort() {
+	slices.SortFunc(s.data, func(a, b CodeAndName) int {
+		return cmp.Compare(a.Code, b.Code)
+	})
+}

--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -131,7 +131,7 @@ func cmdPathStrings(cmd *Command, showOptions bool) []string {
 	}
 
 	recurse("", cmd)
-	sort.Strings(cmds)
+	slices.Sort(cmds)
 	return cmds
 }
 

--- a/core/commands/completion.go
+++ b/core/commands/completion.go
@@ -2,7 +2,8 @@ package commands
 
 import (
 	"io"
-	"sort"
+	"slices"
+	"strings"
 	"text/template"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -39,8 +40,8 @@ func commandToCompletions(name string, fullName string, cmd *cmds.Command) *comp
 		parsed.Subcommands = append(parsed.Subcommands,
 			commandToCompletions(name, fullName+" "+name, subCmd))
 	}
-	sort.Slice(parsed.Subcommands, func(i, j int) bool {
-		return parsed.Subcommands[i].Name < parsed.Subcommands[j].Name
+	slices.SortFunc(parsed.Subcommands, func(a, b *completionCommand) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	for _, opt := range cmd.Options {
@@ -68,18 +69,10 @@ func commandToCompletions(name string, fullName string, cmd *cmds.Command) *comp
 			parsed.Options = append(parsed.Options, flag)
 		}
 	}
-	sort.Slice(parsed.LongFlags, func(i, j int) bool {
-		return parsed.LongFlags[i] < parsed.LongFlags[j]
-	})
-	sort.Slice(parsed.ShortFlags, func(i, j int) bool {
-		return parsed.ShortFlags[i] < parsed.ShortFlags[j]
-	})
-	sort.Slice(parsed.LongOptions, func(i, j int) bool {
-		return parsed.LongOptions[i] < parsed.LongOptions[j]
-	})
-	sort.Slice(parsed.ShortOptions, func(i, j int) bool {
-		return parsed.ShortOptions[i] < parsed.ShortOptions[j]
-	})
+	slices.Sort(parsed.LongFlags)
+	slices.Sort(parsed.ShortFlags)
+	slices.Sort(parsed.LongOptions)
+	slices.Sort(parsed.ShortOptions)
 	return parsed
 }
 

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 	gopath "path"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -698,8 +698,8 @@ Examples:
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *filesLsOutput) error {
 			noSort, _ := req.Options[dontSortOptionName].(bool)
 			if !noSort {
-				sort.Slice(out.Entries, func(i, j int) bool {
-					return strings.Compare(out.Entries[i].Name, out.Entries[j].Name) < 0
+				slices.SortFunc(out.Entries, func(a, b mfs.NodeListing) int {
+					return strings.Compare(a.Name, b.Name)
 				})
 			}
 

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strings"
 
 	version "github.com/ipfs/kubo"
@@ -170,11 +170,11 @@ func printPeer(keyEnc ke.KeyEncoder, ps pstore.Peerstore, p peer.ID) (interface{
 	for _, a := range addrs {
 		info.Addresses = append(info.Addresses, a.String())
 	}
-	sort.Strings(info.Addresses)
+	slices.Sort(info.Addresses)
 
 	protocols, _ := ps.GetProtocols(p) // don't care about errors here.
 	info.Protocols = append(info.Protocols, protocols...)
-	sort.Slice(info.Protocols, func(i, j int) bool { return info.Protocols[i] < info.Protocols[j] })
+	slices.Sort(info.Protocols)
 
 	if v, err := ps.Get(p, "AgentVersion"); err == nil {
 		if vs, ok := v.(string); ok {
@@ -205,9 +205,9 @@ func printSelf(keyEnc ke.KeyEncoder, node *core.IpfsNode) (interface{}, error) {
 		for _, a := range addrs {
 			info.Addresses = append(info.Addresses, a.String())
 		}
-		sort.Strings(info.Addresses)
+		slices.Sort(info.Addresses)
 		info.Protocols = node.PeerHost.Mux().Protocols()
-		sort.Slice(info.Protocols, func(i, j int) bool { return info.Protocols[i] < info.Protocols[j] })
+		slices.Sort(info.Protocols)
 	}
 	info.AgentVersion = version.GetUserAgentVersion()
 	return info, nil

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
+	"slices"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -118,8 +119,8 @@ The JSON output contains type information.
 						return nil
 					}, func(i int) {
 						// after each dir
-						sort.Slice(outputLinks, func(i, j int) bool {
-							return outputLinks[i].Name < outputLinks[j].Name
+						slices.SortFunc(outputLinks, func(a, b LsLink) int {
+							return strings.Compare(a.Name, b.Name)
 						})
 
 						output[i] = LsObject{

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"slices"
 
 	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
 	mbase "github.com/multiformats/go-multibase"
@@ -325,7 +325,7 @@ TOPIC AND DATA ENCODING
 		for _, peer := range peers {
 			list.Strings = append(list.Strings, peer.String())
 		}
-		sort.Strings(list.Strings)
+		slices.Sort(list.Strings)
 		return cmds.EmitOnce(res, list)
 	},
 	Type: stringList{},


### PR DESCRIPTION
Replace older sort functions with `slices.Sort` to simplify code and possible enhance performance.

Replaces #10854