### PR TITLE
feat(daemon): accelerated client startup note

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -653,9 +653,9 @@ take effect.
 		if cfg.Routing.AcceleratedDHTClient.WithDefault(config.DefaultAcceleratedDHTClient) {
 			fmt.Print(`
 
-⚠️ Routing.AcceleratedDHTClient is enabled for faster content discovery
-⚠️ and DHT reprovides. Routing table is initializing. IPFS is ready to use,
-⚠️ but performance will improve in a few minutes as more peers are discovered
+ℹ️ Routing.AcceleratedDHTClient is enabled for faster content discovery
+ℹ️ and DHT provides. Routing table is initializing. IPFS is ready to use,
+ℹ️ but performance will improve over time as more peers are discovered
 
 `)
 		}

--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -649,6 +649,17 @@ take effect.
 `)
 		}
 
+		// Inform user about Routing.AcceleratedDHTClient when enabled
+		if cfg.Routing.AcceleratedDHTClient.WithDefault(config.DefaultAcceleratedDHTClient) {
+			fmt.Print(`
+
+⚠️ Routing.AcceleratedDHTClient is enabled for faster content discovery
+⚠️ and DHT reprovides. Routing table is initializing. IPFS is ready to use,
+⚠️ but performance will improve in a few minutes as more peers are discovered
+
+`)
+		}
+
 		// Give the user heads up if daemon running in online mode has no peers after 1 minute
 		time.AfterFunc(1*time.Minute, func() {
 			cfg, err := cctx.GetConfig()


### PR DESCRIPTION
This PR adds a note on `ipfs daemon` startup when accelerated DHT client is enabled, informing user that it may take a few minutes for performance to improve.

(original idea by @mishmosh in https://github.com/probe-lab/website/issues/176#issuecomment-3014345222)

cc may help with bringing clarity to users experiencing things like #10891