### PR TITLE
fix: correct typo 'fo' to 'of' in content blocking test comment

### DIFF
--- a/test/cli/content_blocking_test.go
+++ b/test/cli/content_blocking_test.go
@@ -308,7 +308,7 @@ func TestContentBlocking(t *testing.T) {
 	// trustless gateway exposed over libp2p
 	// when Experimental.GatewayOverLibp2p=true
 	// (https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md#http-gateway-over-libp2p)
-	// NOTE: this type fo gateway is hardcoded to be NoFetch: it does not fetch
+	// NOTE: this type of gateway is hardcoded to be NoFetch: it does not fetch
 	// data that is not in local store, so we only need to run it once: a
 	// simple smoke-test for allowed CID and blockedCID.
 	t.Run("GatewayOverLibp2p", func(t *testing.T) {


### PR DESCRIPTION
## Fix typo in content blocking test comment

### Description
This PR fixes a simple typo in the comment on line 311 of `test/cli/content_blocking_test.go`.

### Changes
- Fixed typo: "this type fo gateway" → "this type of gateway"

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation improvement

### Testing
- No functional changes, only comment correction
- All existing tests should continue to pass

### Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Changes are minimal and focused