### PR TITLE
feat(add): add support for naming pinned CIDs

### DIFF
--- a/client/rpc/unixfs.go
+++ b/client/rpc/unixfs.go
@@ -49,6 +49,7 @@ func (api *UnixfsAPI) Add(ctx context.Context, f files.Node, opts ...caopts.Unix
 		Option("nocopy", options.NoCopy).
 		Option("only-hash", options.OnlyHash).
 		Option("pin", options.Pin).
+		Option("pin-name", options.PinName).
 		Option("silent", options.Silent).
 		Option("progress", options.Progress)
 

--- a/cmd/ipfs/kubo/add_migrations.go
+++ b/cmd/ipfs/kubo/add_migrations.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipfs/boxo/files"
 	"github.com/ipfs/boxo/path"
+	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/core/coreapi"
 	coreiface "github.com/ipfs/kubo/core/coreiface"
@@ -86,7 +87,7 @@ func addMigrationFiles(ctx context.Context, node *core.IpfsNode, paths []string,
 			return err
 		}
 
-		ipfsPath, err := ufs.Add(ctx, files.NewReaderStatFile(f, fi), options.Unixfs.Pin(pin))
+		ipfsPath, err := ufs.Add(ctx, files.NewReaderStatFile(f, fi), options.Unixfs.Pin(pin, config.DefaultPinName))
 		if err != nil {
 			return err
 		}

--- a/config/import.go
+++ b/config/import.go
@@ -22,6 +22,7 @@ const (
 	// BatchMaxnodes and BatchMaxSize.
 	DefaultBatchMaxSize = 100 << 20 // 20MiB
 
+	DefaultPinName = "default" // Default name for the pin when using the 'ipfs add' command with --pin option
 )
 
 var (

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -37,6 +37,7 @@ type AddEvent struct {
 }
 
 const (
+	pinNameOptionName           = "pin-name"
 	quietOptionName             = "quiet"
 	quieterOptionName           = "quieter"
 	silentOptionName            = "silent"
@@ -184,6 +185,7 @@ See 'dag export' and 'dag import' for more information.
 		cmds.BoolOption(inlineOptionName, "Inline small blocks into CIDs. (experimental)"),
 		cmds.IntOption(inlineLimitOptionName, "Maximum block size to inline. (experimental)").WithDefault(32),
 		cmds.BoolOption(pinOptionName, "Pin locally to protect added files from garbage collection.").WithDefault(true),
+		cmds.StringOption(pinNameOptionName, "Name to use for the pin in the remote pinning service. If not set, the file name will be used.").WithDefault(config.DefaultPinName),
 		cmds.StringOption(toFilesOptionName, "Add reference to Files API (MFS) at the provided path."),
 		cmds.BoolOption(preserveModeOptionName, "Apply existing POSIX permissions to created UnixFS entries. Disables raw-leaves. (experimental)"),
 		cmds.BoolOption(preserveMtimeOptionName, "Apply existing POSIX modification time to created UnixFS entries. Disables raw-leaves. (experimental)"),
@@ -230,6 +232,7 @@ See 'dag export' and 'dag import' for more information.
 		silent, _ := req.Options[silentOptionName].(bool)
 		chunker, _ := req.Options[chunkerOptionName].(string)
 		dopin, _ := req.Options[pinOptionName].(bool)
+		pinName, _ := req.Options[pinNameOptionName].(string)
 		rawblks, rbset := req.Options[rawLeavesOptionName].(bool)
 		maxFileLinks, maxFileLinksSet := req.Options[maxFileLinksOptionName].(int)
 		maxDirectoryLinks, maxDirectoryLinksSet := req.Options[maxDirectoryLinksOptionName].(int)
@@ -326,7 +329,7 @@ See 'dag export' and 'dag import' for more information.
 
 			options.Unixfs.Chunker(chunker),
 
-			options.Unixfs.Pin(dopin),
+			options.Unixfs.Pin(dopin, pinName),
 			options.Unixfs.HashOnly(onlyHash),
 			options.Unixfs.FsCache(fscache),
 			options.Unixfs.Nocopy(nocopy),

--- a/core/coreapi/test/path_test.go
+++ b/core/coreapi/test/path_test.go
@@ -39,7 +39,7 @@ func TestPathUnixFSHAMTPartial(t *testing.T) {
 		dir[strconv.Itoa(i)] = files.NewBytesFile([]byte(strconv.Itoa(i)))
 	}
 
-	r, err := a.Unixfs().Add(ctx, files.NewMapDirectory(dir), options.Unixfs.Pin(false))
+	r, err := a.Unixfs().Add(ctx, files.NewMapDirectory(dir), options.Unixfs.Pin(false, ""))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -58,6 +58,7 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 		attribute.Bool("maxhamtfanoutset", settings.MaxHAMTFanoutSet),
 		attribute.Int("layout", int(settings.Layout)),
 		attribute.Bool("pin", settings.Pin),
+		attribute.String("pin-name", settings.PinName),
 		attribute.Bool("onlyhash", settings.OnlyHash),
 		attribute.Bool("fscache", settings.FsCache),
 		attribute.Bool("nocopy", settings.NoCopy),
@@ -136,6 +137,9 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 		fileAdder.Progress = settings.Progress
 	}
 	fileAdder.Pin = settings.Pin && !settings.OnlyHash
+	if settings.Pin {
+		fileAdder.PinName = settings.PinName
+	}
 	fileAdder.Silent = settings.Silent
 	fileAdder.RawLeaves = settings.RawLeaves
 	if settings.MaxFileLinksSet {

--- a/core/coreiface/options/unixfs.go
+++ b/core/coreiface/options/unixfs.go
@@ -39,6 +39,7 @@ type UnixfsAddSettings struct {
 	Layout  Layout
 
 	Pin      bool
+	PinName  string
 	OnlyHash bool
 	FsCache  bool
 	NoCopy   bool
@@ -83,6 +84,7 @@ func UnixfsAddOptions(opts ...UnixfsAddOption) (*UnixfsAddSettings, cid.Prefix, 
 		Layout:  BalancedLayout,
 
 		Pin:      false,
+		PinName:  "",
 		OnlyHash: false,
 		FsCache:  false,
 		NoCopy:   false,
@@ -280,9 +282,12 @@ func (unixfsOpts) Layout(layout Layout) UnixfsAddOption {
 }
 
 // Pin tells the adder to pin the file root recursively after adding
-func (unixfsOpts) Pin(pin bool) UnixfsAddOption {
+func (unixfsOpts) Pin(pin bool, pinName string) UnixfsAddOption {
 	return func(settings *UnixfsAddSettings) error {
 		settings.Pin = pin
+		if pin {
+			settings.PinName = pinName
+		}
 		return nil
 	}
 }

--- a/core/coreiface/tests/unixfs.go
+++ b/core/coreiface/tests/unixfs.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/boxo/path"
+	"github.com/ipfs/kubo/config"
 	coreiface "github.com/ipfs/kubo/core/coreiface"
 	"github.com/ipfs/kubo/core/coreiface/options"
 
@@ -539,7 +540,7 @@ func (tp *TestSuite) TestAddPinned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = api.Unixfs().Add(ctx, strFile(helloStr)(), options.Unixfs.Pin(true))
+	_, err = api.Unixfs().Add(ctx, strFile(helloStr)(), options.Unixfs.Pin(true, config.DefaultPinName))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds support for assigning a human-readable name to a pinned CID. Named pins enhance usability by allowing users to refer to content symbolically instead of using raw multihashes.


###  Changes

* Introduces the `--pin-name` flag to `ipfs add`

###  Example Usage

```bash
$ ipfs add test.go --pin --pin-name testname
added QmdZwVeTRV1m4YKNXUEd2tBjxkag7JY4Lwf2zmcVJbXKfi test.go

$ ipfs pin ls --names
QmesP6bmy8z4fMn2UzuaXpxur8Drm4VcWApqgPeEg47r3g recursive testname
```

Fixes #10341 