### PR TITLE
Bitswap: use a single ConnectEventManager.

### DIFF
--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -88,9 +88,14 @@ func Bitswap(serverEnabled, libp2pEnabled, httpEnabled bool) interface{} {
 		var bitswapNetworks, bitswapLibp2p network.BitSwapNetwork
 		var bitswapBlockstore blockstore.Blockstore = in.Bs
 
+		connEvtMgr := network.NewConnectEventManager()
+
 		libp2pEnabled := in.Cfg.Bitswap.Libp2pEnabled.WithDefault(config.DefaultBitswapLibp2pEnabled)
 		if libp2pEnabled {
-			bitswapLibp2p = bsnet.NewFromIpfsHost(in.Host)
+			bitswapLibp2p = bsnet.NewFromIpfsHost(
+				in.Host,
+				bsnet.WithConnectEventManager(connEvtMgr),
+			)
 		}
 
 		if httpEnabled {
@@ -112,6 +117,7 @@ func Bitswap(serverEnabled, libp2pEnabled, httpEnabled bool) interface{} {
 				httpnet.WithMaxBlockSize(int64(maxBlockSize)),
 				httpnet.WithUserAgent(version.GetUserAgentVersion()),
 				httpnet.WithMetricsLabelsForEndpoints(httpCfg.Allowlist),
+				httpnet.WithConnectEventManager(connEvtMgr),
 			)
 			bitswapNetworks = network.New(in.Host.Peerstore(), bitswapLibp2p, bitswapHTTP)
 		} else if libp2pEnabled {


### PR DESCRIPTION
After boxo v0.33.1, this is a recommended step to fix http retrieval bugs.

Having a single ConnectEventManager prevents misdirected operations in the network.Router to change the Connectedness state in a way that the counterpart (httpnet or bsnet) can later correct.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
