### PR TITLE
core: Add a ContentDiscovery field

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -98,6 +98,7 @@ type IpfsNode struct {
 	Filters                   *ma.Filters                `optional:"true"`
 	Bootstrapper              io.Closer                  `optional:"true"` // the periodic bootstrapper
 	Routing                   irouting.ProvideManyRouter `optional:"true"` // the routing system. recommend ipfs-dht
+	ContentDiscovery          routing.ContentDiscovery   `optional:"true"` // the discovery part of the routing system
 	DNSResolver               *madns.Resolver            // the DNS resolver
 	IPLDPathResolver          pathresolver.Resolver      `name:"ipldPathResolver"`          // The IPLD path resolver
 	UnixFSPathResolver        pathresolver.Resolver      `name:"unixFSPathResolver"`        // The UnixFS path resolver

--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -21,9 +21,9 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 	version "github.com/ipfs/kubo"
 	"github.com/ipfs/kubo/config"
-	irouting "github.com/ipfs/kubo/routing"
 	"github.com/libp2p/go-libp2p/core/host"
 	peer "github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/routing"
 	"go.uber.org/fx"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -75,7 +75,7 @@ type bitswapIn struct {
 	Mctx        helpers.MetricsCtx
 	Cfg         *config.Config
 	Host        host.Host
-	Rt          irouting.ProvideManyRouter
+	Discovery   routing.ContentDiscovery
 	Bs          blockstore.GCBlockstore
 	BitswapOpts []bitswap.Option `group:"bitswap-options"`
 }
@@ -178,7 +178,7 @@ func Bitswap(serverEnabled, libp2pEnabled, httpEnabled bool) interface{} {
 			ignoredPeerIDs = append(ignoredPeerIDs, pid)
 		}
 		providerQueryMgr, err := rpqm.New(bitswapNetworks,
-			in.Rt,
+			in.Discovery,
 			rpqm.WithMaxProviders(maxProviders),
 			rpqm.WithIgnoreProviders(ignoredPeerIDs...),
 		)

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -216,6 +216,7 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 
 		fx.Provide(libp2p.Routing),
 		fx.Provide(libp2p.ContentRouting),
+		fx.Provide(libp2p.ContentDiscovery),
 
 		fx.Provide(libp2p.BaseRouting(cfg)),
 		maybeProvide(libp2p.PubsubRouter, bcfg.getOpt("ipnsps")),
@@ -380,6 +381,7 @@ func Offline(cfg *config.Config) fx.Option {
 		fx.Provide(libp2p.Routing),
 		fx.Provide(libp2p.ContentRouting),
 		fx.Provide(libp2p.OfflineRouting),
+		fx.Provide(libp2p.ContentDiscovery),
 		OfflineProviders(),
 	)
 }

--- a/core/node/libp2p/routing.go
+++ b/core/node/libp2p/routing.go
@@ -177,6 +177,12 @@ func ContentRouting(in p2pOnlineContentRoutingIn) routing.ContentRouting {
 	}
 }
 
+// ContentDiscovery narrows down the given content routing facility so that it
+// only does discovery.
+func ContentDiscovery(in irouting.ProvideManyRouter) routing.ContentDiscovery {
+	return in
+}
+
 type p2pOnlineRoutingIn struct {
 	fx.In
 
@@ -185,7 +191,7 @@ type p2pOnlineRoutingIn struct {
 }
 
 // Routing will get all routers obtained from different methods (delegated
-// routers, pub-sub, and so on) and add them all together using a TieredRouter.
+// routers, pub-sub, and so on) and add them all together using a ParallelRouter.
 func Routing(in p2pOnlineRoutingIn) irouting.ProvideManyRouter {
 	routers := in.Routers
 


### PR DESCRIPTION
No behaviour changes.

Currently we are using ProvideManyRouter for Bitswap, which is only meant to use ContentDiscovery. This makes things more clear in that there is a designated ContentDiscovery instance.

To discuss: we have a TieredRouting and a ParallelRouting. We are using Tiered only for service discovery, and ParallelRouting for everything else.

This means Bitswap will trigger parallel lookups to all routers (DHT + cid.contact by default I guess). Is my understanding correct? I thought we were delaying triggering DHT lookups by a second or so?