### PR TITLE
fix(coreapi): add nil check for node in ResolvePath to prevent panic

### DIFF
--- a/core/coreapi/path.go
+++ b/core/coreapi/path.go
@@ -68,6 +68,9 @@ func (api *CoreAPI) ResolvePath(ctx context.Context, p path.Path) (path.Immutabl
 	if err != nil {
 		return path.ImmutablePath{}, nil, err
 	}
+	if node == nil {
+		return path.ImmutablePath{}, nil, fmt.Errorf("failed to resolve path: no valid node found")
+	}
 
 	segments := []string{p.Namespace(), node.String()}
 	segments = append(segments, remainder...)


### PR DESCRIPTION
Fixes potential panic when resolver returns nil node without error. This commonly occurs with filtered content, offline mode, or corrupted DAG structures.