### PR TITLE
docs:added GOLOG_LOG_LEVEL to debug-guide for logging more info

### DIFF
--- a/docs/debug-guide.md
+++ b/docs/debug-guide.md
@@ -15,6 +15,8 @@ This is a document for helping debug Kubo. Please add to it if you can!
 
 ### Beginning
 
+> **Note:**  Enable more logs by setting `GOLOG_LOG_LEVEL` env variable when troubleshooting. See [go-log documentation](https://github.com/ipfs/go-log#golog_log_level) for configuration options and available log levels.
+
 When you see ipfs doing something (using lots of CPU, memory, or otherwise
 being weird), the first thing you want to do is gather all the relevant
 profiling information.


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Closes https://github.com/ipfs/kubo/issues/10409

@SgtPooki, could you take a look and let me know if adding a note, makes it easy to find the “enable more logs” instructions?