### PR TITLE
Fix failing FUSE test

### DIFF
--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -187,7 +187,7 @@ func TestIpfsStressRead(t *testing.T) {
 			defer wg.Done()
 
 			for i := 0; i < 2000; i++ {
-				item, err := path.NewPath(paths[rand.Intn(len(paths))])
+				item, err := path.NewPath("/ipfs/" + paths[rand.Intn(len(paths))])
 				if err != nil {
 					errs <- err
 					continue


### PR DESCRIPTION
Test was failing becuase path passed to `path.NewPath` (from boxo) did not include a required namespace. Prepending the namespace to the path with "/ipfs/" fixes this.
