### PR TITLE
fix(ci): docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24 AS builder
 
 ARG TARGETOS TARGETARCH
 
-ENV SRC_DIR /kubo
+ENV SRC_DIR=/kubo
 
 # Download packages first so they can be cached.
 COPY go.mod go.sum $SRC_DIR/
@@ -47,7 +47,7 @@ RUN set -eux; \
 FROM busybox:stable-glibc
 
 # Get the ipfs binary, entrypoint script, and TLS CAs from the build container.
-ENV SRC_DIR /kubo
+ENV SRC_DIR=/kubo
 COPY --from=utilities /usr/sbin/gosu /sbin/gosu
 COPY --from=utilities /usr/bin/tini /sbin/tini
 COPY --from=utilities /bin/fusermount /usr/local/bin/fusermount
@@ -74,7 +74,7 @@ EXPOSE 8080
 EXPOSE 8081
 
 # Create the fs-repo directory and switch to a non-privileged user.
-ENV IPFS_PATH /data/ipfs
+ENV IPFS_PATH=/data/ipfs
 RUN mkdir -p $IPFS_PATH \
   && adduser -D -h $IPFS_PATH -u 1000 -G users ipfs \
   && chown ipfs:users $IPFS_PATH
@@ -93,7 +93,7 @@ RUN mkdir /container-init.d \
 VOLUME $IPFS_PATH
 
 # The default logging level
-ENV GOLOG_LOG_LEVEL ""
+ENV GOLOG_LOG_LEVEL=""
 
 # This just makes sure that:
 # 1. There's an fs-repo, and initializes one if there isn't.

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -26,10 +26,10 @@ TEST_GO :=
 TEST_GO_BUILD :=
 CHECK_GO :=
 
-go-pkg-name=$(shell $(GOCC) list $(go-tags) github.com/ipfs/kubo/$(1))
+go-pkg-name=$(shell GOFLAGS=-buildvcs=false $(GOCC) list $(go-tags) github.com/ipfs/kubo/$(1))
 go-main-name=$(notdir $(call go-pkg-name,$(1)))$(?exe)
 go-curr-pkg-tgt=$(d)/$(call go-main-name,$(d))
-go-pkgs=$(shell $(GOCC) list github.com/ipfs/kubo/...)
+go-pkgs=$(shell GOFLAGS=-buildvcs=false $(GOCC) list github.com/ipfs/kubo/...)
 
 go-tags=$(if $(GOTAGS), -tags="$(call join-with,$(space),$(GOTAGS))")
 go-flags-with-tags=$(GOFLAGS)$(go-tags)


### PR DESCRIPTION
Docker started failing in master and PRs – see https://github.com/ipfs/kubo/pull/10905#issuecomment-3186036451

Looked into this and I am more confused than I was before. `GOFLAGS=-buildvcs=false` IS in the `Dockerfile`. The problem is that the `Makefile`'s `$(shell ...)` commands don't inherit this environment variable.

This isn't a regression from a Go 1.25 update, image/ci uses 1.24. I suspect the issue has likely always existed but may have been masked or only recently become apparent due to (guessing):

1. Changes in how Docker caches layers
2. Changes in GitHub Actions environment
3. The specific conditions in the PR build environment

The root cause is that `$(shell ...)` in Make creates a new shell that doesn't inherit the parent's environment variables unless explicitly passed. My fix addresses this by hardcoding `-buildvcs=false` for the `go list` commands that are used to determine package names.

While at it, updated ENV to use modern notation.

cc @ipfs/kubo-maintainers  for visibility. 