### PR TITLE
fix: disable telemetry in test profile

### DIFF
--- a/config/plugins.go
+++ b/config/plugins.go
@@ -7,5 +7,5 @@ type Plugins struct {
 
 type Plugin struct {
 	Disabled bool
-	Config   interface{}
+	Config   interface{} `json:",omitempty"`
 }

--- a/test/cli/harness/node.go
+++ b/test/cli/harness/node.go
@@ -245,6 +245,14 @@ func (n *Node) Init(ipfsArgs ...string) *Node {
 		cfg.Swarm.DisableNatPortMap = true
 		cfg.Discovery.MDNS.Enabled = n.EnableMDNS
 		cfg.Routing.LoopbackAddressesOnLanDHT = config.True
+		// Telemetry disabled by default in tests.
+		cfg.Plugins = config.Plugins{
+			Plugins: map[string]config.Plugin{
+				"telemetry": config.Plugin{
+					Disabled: true,
+				},
+			},
+		}
 	})
 	return n
 }

--- a/test/cli/telemetry_test.go
+++ b/test/cli/telemetry_test.go
@@ -25,6 +25,7 @@ func TestTelemetry(t *testing.T) {
 
 		// Create a new node
 		node := harness.NewT(t).NewNode().Init()
+		node.SetIPFSConfig("Plugins.Plugins.telemetry.Disabled", false)
 
 		// Set the opt-out environment variable
 		node.Runner.Env["IPFS_TELEMETRY"] = "off"
@@ -64,6 +65,7 @@ func TestTelemetry(t *testing.T) {
 
 		// Create a new node
 		node := harness.NewT(t).NewNode().Init()
+		node.SetIPFSConfig("Plugins.Plugins.telemetry.Disabled", false)
 
 		// Set opt-out via config
 		node.IPFS("config", "Plugins.Plugins.telemetry.Config.Mode", "off")
@@ -106,6 +108,7 @@ func TestTelemetry(t *testing.T) {
 
 		// Create a new node
 		node := harness.NewT(t).NewNode().Init()
+		node.SetIPFSConfig("Plugins.Plugins.telemetry.Disabled", false)
 
 		// Create a UUID file manually to simulate previous telemetry run
 		uuidPath := filepath.Join(node.Dir, "telemetry_uuid")
@@ -154,6 +157,7 @@ func TestTelemetry(t *testing.T) {
 
 		// Create a new node
 		node := harness.NewT(t).NewNode().Init()
+		node.SetIPFSConfig("Plugins.Plugins.telemetry.Disabled", false)
 
 		// Capture daemon output
 		stdout := &harness.Buffer{}
@@ -255,6 +259,7 @@ func TestTelemetry(t *testing.T) {
 
 		// Create a new node
 		node := harness.NewT(t).NewNode().Init()
+		node.SetIPFSConfig("Plugins.Plugins.telemetry.Disabled", false)
 
 		// Configure telemetry with a very short delay for testing
 		node.IPFS("config", "Plugins.Plugins.telemetry.Config.Delay", "100ms")

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -206,7 +206,7 @@ test_init_ipfs() {
   '
 
   test_expect_success "disable telemetry" '
-    test_config_set Plugins.Plugins.telemetry.Disabled "true"
+    test_config_set --bool Plugins.Plugins.telemetry.Disabled "true"
   '
 
   test_expect_success "prepare config -- mounting" '
@@ -232,7 +232,7 @@ test_init_ipfs_measure() {
   '
 
   test_expect_success "disable telemetry" '
-    test_config_set Plugins.Plugins.telemetry.Disabled "true"
+    test_config_set --bool Plugins.Plugins.telemetry.Disabled "true"
   '
 
   test_expect_success "prepare config -- mounting" '

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -207,6 +207,7 @@ test_init_ipfs() {
 
   test_expect_success "prepare config -- mounting" '
     mkdir mountdir ipfs ipns mfs &&
+    test_config_set Plugins.Plugins.telemetry.Disabled true &&
     test_config_set Mounts.IPFS "$(pwd)/ipfs" &&
     test_config_set Mounts.IPNS "$(pwd)/ipns" &&
     test_config_set Mounts.MFS "$(pwd)/mfs" ||

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -205,9 +205,12 @@ test_init_ipfs() {
     ipfs init "${args[@]}" --profile=test > /dev/null
   '
 
+  test_expect_success "disable telemetry" '
+    test_config_set Plugins.Plugins.telemetry.Disabled "true"
+  '
+
   test_expect_success "prepare config -- mounting" '
     mkdir mountdir ipfs ipns mfs &&
-    test_config_set Plugins.Plugins.telemetry.Disabled true &&
     test_config_set Mounts.IPFS "$(pwd)/ipfs" &&
     test_config_set Mounts.IPNS "$(pwd)/ipns" &&
     test_config_set Mounts.MFS "$(pwd)/mfs" ||
@@ -226,6 +229,10 @@ test_init_ipfs_measure() {
   test_expect_success "ipfs init succeeds" '
     export IPFS_PATH="$(pwd)/.ipfs" &&
     ipfs init "${args[@]}" --profile=test,flatfs-measure > /dev/null
+  '
+
+  test_expect_success "disable telemetry" '
+    test_config_set Plugins.Plugins.telemetry.Disabled "true"
   '
 
   test_expect_success "prepare config -- mounting" '


### PR DESCRIPTION
Disable the plugin in cli tests and sharness by default. Enable only in telemetry tests.

There are cases when tests get stuck or get killed and leave daemons hanging around. We don't want to be getting telemetry from those.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
