### PR TITLE
fix: harness tests random panic

### DIFF
--- a/test/cli/harness/nodes.go
+++ b/test/cli/harness/nodes.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/ipfs/kubo/test/cli/testutils"
 	"github.com/multiformats/go-multiaddr"
-	"golang.org/x/sync/errgroup"
 )
 
 // Nodes is a collection of Kubo nodes along with operations on groups of nodes.
@@ -17,37 +16,28 @@ func (n Nodes) Init(args ...string) Nodes {
 }
 
 func (n Nodes) ForEachPar(f func(*Node)) {
-	group := &errgroup.Group{}
+	var wg sync.WaitGroup
 	for _, node := range n {
+		wg.Add(1)
 		node := node
-		group.Go(func() error {
+		go func() {
+			defer wg.Done()
 			f(node)
-			return nil
-		})
+		}()
 	}
-	err := group.Wait()
-	if err != nil {
-		panic(err)
-	}
+	wg.Wait()
 }
 
 func (n Nodes) Connect() Nodes {
-	wg := sync.WaitGroup{}
 	for i, node := range n {
 		for j, otherNode := range n {
 			if i == j {
 				continue
 			}
-			node := node
-			otherNode := otherNode
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				node.Connect(otherNode)
-			}()
+			// Do not connect in paralled, because that can cause TLS handshake problems on some platforms.
+			node.Connect(otherNode)
 		}
 	}
-	wg.Wait()
 	for _, node := range n {
 		firstPeer := node.Peers()[0]
 		if _, err := firstPeer.ValueForProtocol(multiaddr.P_P2P); err != nil {

--- a/test/cli/harness/nodes.go
+++ b/test/cli/harness/nodes.go
@@ -34,7 +34,7 @@ func (n Nodes) Connect() Nodes {
 			if i == j {
 				continue
 			}
-			// Do not connect in paralled, because that can cause TLS handshake problems on some platforms.
+			// Do not connect in parallel, because that can cause TLS handshake problems on some platforms.
 			node.Connect(otherNode)
 		}
 	}


### PR DESCRIPTION
Connecting nodes in parallel can cause TLS handshake failures. For each node, connect to the other nodes serially. It is not necessary to connect in parallel as it does not save any significant time.

Closes #10932
