### PR TITLE
fix(ci):  cleanup zombie daemons on panics

### DIFF
--- a/test/cli/autoconf/swarm_connect_test.go
+++ b/test/cli/autoconf/swarm_connect_test.go
@@ -2,7 +2,6 @@ package autoconf
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ipfs/kubo/test/cli/harness"
 	"github.com/stretchr/testify/assert"
@@ -21,10 +20,12 @@ func TestSwarmConnectWithAutoConf(t *testing.T) {
 	t.Parallel()
 
 	t.Run("AutoConf disabled - should work", func(t *testing.T) {
+		// Don't run subtests in parallel to avoid daemon startup conflicts
 		testSwarmConnectWithAutoConfSetting(t, false, true) // expect success
 	})
 
 	t.Run("AutoConf enabled - should work", func(t *testing.T) {
+		// Don't run subtests in parallel to avoid daemon startup conflicts
 		testSwarmConnectWithAutoConfSetting(t, true, true) // expect success (fix the bug!)
 	})
 }
@@ -44,17 +45,10 @@ func testSwarmConnectWithAutoConfSetting(t *testing.T, autoConfEnabled bool, exp
 		"/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
 	})
 
-	// CRITICAL: Start the daemon first - this is the key requirement
-	// The daemon must be running and working properly
+	// Start the daemon
 	node.StartDaemon()
 	defer node.StopDaemon()
 
-	// Give daemon time to start up completely
-	time.Sleep(3 * time.Second)
-
-	// Verify daemon is responsive
-	result := node.RunIPFS("id")
-	require.Equal(t, 0, result.ExitCode(), "Daemon should be responsive before testing swarm connect")
 	t.Logf("Daemon is running and responsive. AutoConf enabled: %v", autoConfEnabled)
 
 	// Now test swarm connect to a bootstrap peer
@@ -62,7 +56,7 @@ func testSwarmConnectWithAutoConfSetting(t *testing.T, autoConfEnabled bool, exp
 	// 1. The daemon is running
 	// 2. The CLI should connect to the daemon via API
 	// 3. The daemon should handle the swarm connect request
-	result = node.RunIPFS("swarm", "connect", "/dnsaddr/bootstrap.libp2p.io")
+	result := node.RunIPFS("swarm", "connect", "/dnsaddr/bootstrap.libp2p.io")
 
 	// swarm connect should work regardless of AutoConf setting
 	assert.Equal(t, 0, result.ExitCode(),

--- a/test/cli/harness/harness.go
+++ b/test/cli/harness/harness.go
@@ -36,22 +36,23 @@ func EnableDebugLogging() {
 func NewT(t *testing.T, options ...func(h *Harness)) *Harness {
 	h := New(options...)
 
-	// Register cleanup with panic recovery to ensure daemons are killed
+	// Single consolidated cleanup with proper panic recovery
 	t.Cleanup(func() {
 		defer func() {
-			// Always kill any remaining daemon processes, even if cleanup panics
+			// Always force-kill daemon processes on panic
 			if r := recover(); r != nil {
 				log.Debugf("panic during cleanup: %v, forcing daemon cleanup", r)
 				CleanupDaemonProcesses()
 				panic(r) // re-panic after cleanup
 			}
 		}()
-		h.Cleanup()
-	})
 
-	// Also register a separate cleanup for daemon processes
-	// This ensures they're killed even if h.Cleanup() fails
-	t.Cleanup(CleanupDaemonProcesses)
+		// Run full cleanup which includes daemon cleanup
+		h.Cleanup()
+
+		// Final safety check for any remaining processes
+		CleanupDaemonProcesses()
+	})
 
 	return h
 }
@@ -198,11 +199,9 @@ func (h *Harness) Sh(expr string) *RunResult {
 }
 
 func (h *Harness) Cleanup() {
-	// Use defer to ensure we always try to clean up, even if something fails
 	defer func() {
 		if r := recover(); r != nil {
-			log.Debugf("panic during harness cleanup: %v", r)
-			// Force cleanup of daemons before re-panicking
+			log.Debugf("panic during harness cleanup: %v, forcing daemon cleanup", r)
 			CleanupDaemonProcesses()
 			panic(r)
 		}
@@ -210,7 +209,7 @@ func (h *Harness) Cleanup() {
 
 	log.Debugf("cleaning up cluster")
 
-	// Try to stop daemons gracefully first
+	// Try graceful daemon shutdown with panic protection
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -223,10 +222,9 @@ func (h *Harness) Cleanup() {
 	// Force cleanup any remaining daemon processes
 	CleanupDaemonProcesses()
 
-	// TODO: don't do this if test fails, not sure how?
+	// Clean up temp directory
 	log.Debugf("removing harness dir")
-	err := os.RemoveAll(h.Dir)
-	if err != nil {
+	if err := os.RemoveAll(h.Dir); err != nil {
 		log.Panicf("removing temp dir %s: %s", h.Dir, err)
 	}
 }

--- a/test/cli/harness/harness.go
+++ b/test/cli/harness/harness.go
@@ -35,7 +35,7 @@ func EnableDebugLogging() {
 // NewT constructs a harness that cleans up after the given test is done.
 func NewT(t *testing.T, options ...func(h *Harness)) *Harness {
 	h := New(options...)
-	
+
 	// Register cleanup with panic recovery to ensure daemons are killed
 	t.Cleanup(func() {
 		defer func() {
@@ -48,11 +48,11 @@ func NewT(t *testing.T, options ...func(h *Harness)) *Harness {
 		}()
 		h.Cleanup()
 	})
-	
+
 	// Also register a separate cleanup for daemon processes
 	// This ensures they're killed even if h.Cleanup() fails
 	t.Cleanup(CleanupDaemonProcesses)
-	
+
 	return h
 }
 
@@ -207,9 +207,9 @@ func (h *Harness) Cleanup() {
 			panic(r)
 		}
 	}()
-	
+
 	log.Debugf("cleaning up cluster")
-	
+
 	// Try to stop daemons gracefully first
 	func() {
 		defer func() {
@@ -219,10 +219,10 @@ func (h *Harness) Cleanup() {
 		}()
 		h.Nodes.StopDaemons()
 	}()
-	
+
 	// Force cleanup any remaining daemon processes
 	CleanupDaemonProcesses()
-	
+
 	// TODO: don't do this if test fails, not sure how?
 	log.Debugf("removing harness dir")
 	err := os.RemoveAll(h.Dir)

--- a/test/cli/harness/node.go
+++ b/test/cli/harness/node.go
@@ -274,7 +274,7 @@ func (n *Node) StartDaemonWithReq(req RunRequest, authorization string) *Node {
 	res := n.Runner.MustRun(newReq)
 
 	n.Daemon = res
-	
+
 	// Register the daemon process for cleanup tracking
 	if res.Cmd != nil && res.Cmd.Process != nil {
 		globalProcessTracker.RegisterProcess(res.Cmd.Process)
@@ -322,10 +322,10 @@ func (n *Node) StopDaemon() *Node {
 		log.Debugf("didn't stop node %d since no daemon present", n.ID)
 		return n
 	}
-	
+
 	// Store PID for cleanup tracking
 	pid := n.Daemon.Cmd.Process.Pid
-	
+
 	watch := make(chan struct{}, 1)
 	go func() {
 		_, _ = n.Daemon.Cmd.Process.Wait()

--- a/test/cli/harness/node.go
+++ b/test/cli/harness/node.go
@@ -296,7 +296,7 @@ func (n *Node) StartDaemonWithReq(req RunRequest, authorization string) *Node {
 
 			// Register the daemon process for cleanup tracking
 			if res.Cmd != nil && res.Cmd.Process != nil {
-				globalProcessTracker.RegisterProcess(res.Cmd.Process)
+				globalProcessTracker.registerProcess(res.Cmd.Process)
 			}
 
 			log.Debugf("node %d started, checking API", n.ID)
@@ -386,7 +386,7 @@ func (n *Node) StopDaemon() *Node {
 	// os.Interrupt does not support interrupts on Windows https://github.com/golang/go/issues/46345
 	if runtime.GOOS == "windows" {
 		if n.signalAndWait(watch, syscall.SIGKILL, 5*time.Second) {
-			globalProcessTracker.UnregisterProcess(pid)
+			globalProcessTracker.unregisterProcess(pid)
 			return n
 		}
 		log.Panicf("timed out stopping node %d with peer ID %s", n.ID, n.PeerID())
@@ -394,22 +394,22 @@ func (n *Node) StopDaemon() *Node {
 
 	log.Debugf("signaling node %d with SIGTERM", n.ID)
 	if n.signalAndWait(watch, syscall.SIGTERM, 1*time.Second) {
-		globalProcessTracker.UnregisterProcess(pid)
+		globalProcessTracker.unregisterProcess(pid)
 		return n
 	}
 	log.Debugf("signaling node %d with SIGTERM", n.ID)
 	if n.signalAndWait(watch, syscall.SIGTERM, 2*time.Second) {
-		globalProcessTracker.UnregisterProcess(pid)
+		globalProcessTracker.unregisterProcess(pid)
 		return n
 	}
 	log.Debugf("signaling node %d with SIGQUIT", n.ID)
 	if n.signalAndWait(watch, syscall.SIGQUIT, 5*time.Second) {
-		globalProcessTracker.UnregisterProcess(pid)
+		globalProcessTracker.unregisterProcess(pid)
 		return n
 	}
 	log.Debugf("signaling node %d with SIGKILL", n.ID)
 	if n.signalAndWait(watch, syscall.SIGKILL, 5*time.Second) {
-		globalProcessTracker.UnregisterProcess(pid)
+		globalProcessTracker.unregisterProcess(pid)
 		return n
 	}
 	log.Panicf("timed out stopping node %d with peer ID %s", n.ID, n.PeerID())

--- a/test/cli/harness/nodes.go
+++ b/test/cli/harness/nodes.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -32,46 +33,91 @@ func (n Nodes) ForEachPar(f func(*Node)) {
 	}
 }
 
+// Connect establishes connections between all nodes in the collection
 func (n Nodes) Connect() Nodes {
-	wg := sync.WaitGroup{}
+	// Use a 10 second timeout - more generous than the original 1 second,
+	// but reasonable for test environments
+	const timeout = 10 * time.Second
+	if len(n) < 2 {
+		return n // Nothing to connect
+	}
+
+	// Use errgroup for better concurrent error handling
+	group := &errgroup.Group{}
+
+	// Track connection errors
+	type connError struct {
+		from, to int
+		err      error
+	}
+	var mu sync.Mutex
+	var errors []connError
+
+	// Establish all connections concurrently
 	for i, node := range n {
 		for j, otherNode := range n {
 			if i == j {
 				continue
 			}
-			node := node
-			otherNode := otherNode
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				node.Connect(otherNode)
-			}()
+			// Capture loop variables
+			fromNode, toNode := node, otherNode
+			fromIdx, toIdx := i, j
+
+			group.Go(func() error {
+				// Use ConnectAndWait for robust connection with timeout
+				if err := fromNode.ConnectAndWait(toNode, timeout); err != nil {
+					mu.Lock()
+					errors = append(errors, connError{from: fromIdx, to: toIdx, err: err})
+					mu.Unlock()
+					// Don't return error - collect all failures first
+				}
+				return nil
+			})
 		}
 	}
-	wg.Wait()
-	// Verify connections were established
+
+	// Wait for all connection attempts
+	_ = group.Wait() // We handle errors separately
+
+	// Report any connection failures
+	if len(errors) > 0 {
+		errMsg := fmt.Sprintf("failed to establish %d connections:\n", len(errors))
+		for _, e := range errors {
+			errMsg += fmt.Sprintf("  - node %d -> node %d: %v\n", e.from, e.to, e.err)
+		}
+		log.Panicf(errMsg)
+	}
+
+	// Verify all nodes have expected connections
+	if err := n.verifyAllConnected(); err != nil {
+		log.Panicf("connection verification failed: %v", err)
+	}
+
+	return n
+}
+
+// verifyAllConnected checks that all nodes are properly connected
+func (n Nodes) verifyAllConnected() error {
+	expectedPeers := len(n) - 1
+
 	for _, node := range n {
 		peers := node.Peers()
-		if len(peers) == 0 {
-			// Connection may still be establishing, retry a few times
-			for retry := 0; retry < 10; retry++ {
-				time.Sleep(100 * time.Millisecond)
-				peers = node.Peers()
-				if len(peers) > 0 {
-					break
-				}
-			}
-			if len(peers) == 0 {
-				log.Panicf("node %d with peer ID %s has no peers after connection attempts", node.ID, node.PeerID())
-			}
+
+		if len(peers) < expectedPeers {
+			return fmt.Errorf("node %d (peer %s) has only %d peers, expected at least %d",
+				node.ID, node.PeerID(), len(peers), expectedPeers)
 		}
-		// Validate first peer has proper protocol
-		firstPeer := peers[0]
-		if _, err := firstPeer.ValueForProtocol(multiaddr.P_P2P); err != nil {
-			log.Panicf("unexpected state for node %d with peer ID %s: %s", node.ID, node.PeerID(), err)
+
+		// Verify each peer has valid P2P protocol
+		for i, peer := range peers {
+			if _, err := peer.ValueForProtocol(multiaddr.P_P2P); err != nil {
+				return fmt.Errorf("node %d peer %d has invalid protocol: %v",
+					node.ID, i, err)
+			}
 		}
 	}
-	return n
+
+	return nil
 }
 
 func (n Nodes) StartDaemons(args ...string) Nodes {

--- a/test/cli/harness/process_tracker.go
+++ b/test/cli/harness/process_tracker.go
@@ -47,7 +47,7 @@ func (pt *processTracker) KillAll() {
 		
 		// Try SIGTERM first
 		if err := proc.Signal(syscall.SIGTERM); err != nil {
-			if !os.IsProcessDone(err) {
+			if !IsProcessDone(err) {
 				log.Debugf("error sending SIGTERM to PID %d: %v", pid, err)
 			}
 		}
@@ -57,7 +57,7 @@ func (pt *processTracker) KillAll() {
 		
 		// Force kill if still running
 		if err := proc.Kill(); err != nil {
-			if !os.IsProcessDone(err) {
+			if !IsProcessDone(err) {
 				log.Debugf("error killing PID %d: %v", pid, err)
 			}
 		}

--- a/test/cli/harness/process_tracker.go
+++ b/test/cli/harness/process_tracker.go
@@ -81,3 +81,11 @@ func isProcessDone(err error) bool {
 func CleanupDaemonProcesses() {
 	globalProcessTracker.killAll()
 }
+
+// RegisterBackgroundProcess registers an external process for cleanup tracking
+// This is useful for tests that start processes outside of the harness Runner
+func RegisterBackgroundProcess(proc *os.Process) {
+	if proc != nil {
+		globalProcessTracker.registerProcess(proc)
+	}
+}

--- a/test/cli/harness/process_tracker.go
+++ b/test/cli/harness/process_tracker.go
@@ -41,31 +41,31 @@ func (pt *processTracker) UnregisterProcess(pid int) {
 func (pt *processTracker) KillAll() {
 	pt.mu.Lock()
 	defer pt.mu.Unlock()
-	
+
 	for pid, proc := range pt.processes {
 		log.Debugf("force killing daemon process PID %d", pid)
-		
+
 		// Try SIGTERM first
 		if err := proc.Signal(syscall.SIGTERM); err != nil {
 			if !IsProcessDone(err) {
 				log.Debugf("error sending SIGTERM to PID %d: %v", pid, err)
 			}
 		}
-		
+
 		// Give it a moment to terminate
 		time.Sleep(100 * time.Millisecond)
-		
+
 		// Force kill if still running
 		if err := proc.Kill(); err != nil {
 			if !IsProcessDone(err) {
 				log.Debugf("error killing PID %d: %v", pid, err)
 			}
 		}
-		
+
 		// Clean up entry
 		delete(pt.processes, pid)
 	}
-	
+
 	if len(pt.processes) > 0 {
 		log.Debugf("cleaned up %d daemon processes", len(pt.processes))
 	}
@@ -81,3 +81,4 @@ func IsProcessDone(err error) bool {
 func CleanupDaemonProcesses() {
 	globalProcessTracker.KillAll()
 }
+

--- a/test/cli/harness/process_tracker.go
+++ b/test/cli/harness/process_tracker.go
@@ -1,0 +1,83 @@
+package harness
+
+import (
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// processTracker keeps track of all daemon processes started during tests
+type processTracker struct {
+	mu        sync.Mutex
+	processes map[int]*os.Process
+}
+
+// globalProcessTracker is a package-level tracker for all spawned daemons
+var globalProcessTracker = &processTracker{
+	processes: make(map[int]*os.Process),
+}
+
+// RegisterProcess adds a process to the tracker
+func (pt *processTracker) RegisterProcess(proc *os.Process) {
+	if proc == nil {
+		return
+	}
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	pt.processes[proc.Pid] = proc
+	log.Debugf("registered daemon process PID %d", proc.Pid)
+}
+
+// UnregisterProcess removes a process from the tracker
+func (pt *processTracker) UnregisterProcess(pid int) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	delete(pt.processes, pid)
+	log.Debugf("unregistered daemon process PID %d", pid)
+}
+
+// KillAll forcefully terminates all tracked processes
+func (pt *processTracker) KillAll() {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	
+	for pid, proc := range pt.processes {
+		log.Debugf("force killing daemon process PID %d", pid)
+		
+		// Try SIGTERM first
+		if err := proc.Signal(syscall.SIGTERM); err != nil {
+			if !os.IsProcessDone(err) {
+				log.Debugf("error sending SIGTERM to PID %d: %v", pid, err)
+			}
+		}
+		
+		// Give it a moment to terminate
+		time.Sleep(100 * time.Millisecond)
+		
+		// Force kill if still running
+		if err := proc.Kill(); err != nil {
+			if !os.IsProcessDone(err) {
+				log.Debugf("error killing PID %d: %v", pid, err)
+			}
+		}
+		
+		// Clean up entry
+		delete(pt.processes, pid)
+	}
+	
+	if len(pt.processes) > 0 {
+		log.Debugf("cleaned up %d daemon processes", len(pt.processes))
+	}
+}
+
+// IsProcessDone checks if an error indicates the process has already exited
+func IsProcessDone(err error) bool {
+	return err == os.ErrProcessDone
+}
+
+// CleanupDaemonProcesses kills all tracked daemon processes
+// This should be called in test cleanup or panic recovery
+func CleanupDaemonProcesses() {
+	globalProcessTracker.KillAll()
+}

--- a/test/cli/harness/run.go
+++ b/test/cli/harness/run.go
@@ -109,6 +109,14 @@ func (r *Runner) Run(req RunRequest) *RunResult {
 		Err:    err,
 	}
 
+	// Track background processes automatically
+	// If the process is still running after RunFunc returns, it's a background process
+	if err == nil && cmd.Process != nil && cmd.ProcessState == nil {
+		// Process was started but not waited for (background process)
+		globalProcessTracker.registerProcess(cmd.Process)
+		log.Debugf("auto-tracked background process PID %d: %v", cmd.Process.Pid, cmd.Args)
+	}
+
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		result.ExitErr = exitErr
 	}

--- a/test/cli/migrations/migration_16_to_17_test.go
+++ b/test/cli/migrations/migration_16_to_17_test.go
@@ -600,6 +600,9 @@ func runDaemonWithMigrationMonitoring(t *testing.T, node *harness.Node, migratio
 	err = cmd.Start()
 	require.NoError(t, err)
 
+	// Register for cleanup in case of test failure
+	harness.RegisterBackgroundProcess(cmd.Process)
+
 	var allOutput strings.Builder
 	var migrationDetected, migrationSucceeded, daemonReady bool
 

--- a/test/cli/migrations/migration_legacy_15_to_17_test.go
+++ b/test/cli/migrations/migration_legacy_15_to_17_test.go
@@ -215,6 +215,9 @@ func runDaemonWithMigrationMonitoringCustomEnv(t *testing.T, node *harness.Node,
 	// Start the daemon
 	require.NoError(t, cmd.Start())
 
+	// Register for cleanup in case of test failure
+	harness.RegisterBackgroundProcess(cmd.Process)
+
 	// Monitor output from both streams
 	var outputBuffer strings.Builder
 	done := make(chan bool)


### PR DESCRIPTION
> [!WARNING]
> Do not merge, using this PR as a sandbox for now, to see what fails on CI but rarely locally.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


This PR is exploration into making test/cli/harness more robust when things go bad with spawned processes and we run on self-hosted runners.

- Process tracking: new system tracks all spawned processes and force-kills them on test end/panic
- Connection fixes: validate peers array before access, use serial connections to avoid TLS issues
- Daemon reliability: add retry logic for transient startup failures, verify daemon readiness
  - :point_right:  unsure if this is the right thing to do -- i'm ok with removing this from this PR (important part is tracking dameons and ensuring we kill them). 
- Auto-cleanup: background processes started via harness are automatically registered for cleanup


Impact:
- No more zombie ipfs daemon processes left after test panics
- More reliable test execution in CI
- Cleaner test harness code with better error handling