### PR TITLE
fix(telemetry): improve vm/container detection

### DIFF
--- a/plugin/plugins/telemetry/telemetry.go
+++ b/plugin/plugins/telemetry/telemetry.go
@@ -511,7 +511,7 @@ func detectContainer() bool {
 	// Check if our process is running inside a container cgroup
 	// Look for container-specific patterns in the cgroup path after "::/"
 	if content, err := os.ReadFile("/proc/self/cgroup"); err == nil {
-		for _, line := range strings.Split(string(content), "\n") {
+		for line := range strings.Lines(string(content)) {
 			// cgroup lines format: "ID:subsystem:/path"
 			// We want to check the path part after the last ":"
 			parts := strings.SplitN(line, ":", 3)


### PR DESCRIPTION
Current VM detection is not very accurate and systemd-detect-virt does exactly what's needed under a miriad of virtualization platforms.

The downside is that we are running a system command which is uglier and might perhaps flip anti-viruses or something.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
