### PR TITLE
rpc: retreive pin names when Detailed option provided

### DIFF
--- a/client/rpc/pin.go
+++ b/client/rpc/pin.go
@@ -72,6 +72,7 @@ func (api *PinAPI) Ls(ctx context.Context, pins chan<- iface.Pin, opts ...caopts
 
 	res, err := api.core().Request("pin/ls").
 		Option("type", options.Type).
+		Option("names", options.Detailed).
 		Option("stream", true).
 		Send(ctx)
 	if err != nil {


### PR DESCRIPTION
Closes: #10965

1) This prevents holding on to fields between iterations that don't get overwritten; so that things like `Name` don't stick.
2) This adds in the detailed option to the API request. The data and option constructor for this already existed, but seemingly wasn't used anywhere? Or I missed the references. In any case, this adds it to the request whether its `true` or `false`, as configurable via `coreoptions.Pin.Ls.Detailed()`
This seems to match the documentation:
>// Detailed is an option for [Pin.Ls] which sets whether or not to return
// detailed information, such as pin names and modes.

This should be a small bugfix, but if anyone thinks it belongs in the changelog, let me know and either I can add it or someone else can just push it themselves.