### PR TITLE
fix: SweepingProvider shouldn't error when missing DHT

### DIFF
--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -397,6 +397,11 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 		KeyProvider provider.KeyChanFunc
 	}
 	initKeyStore := fx.Invoke(func(lc fx.Lifecycle, in keystoreInput) {
+		// Skip keystore initialization for NoopProvider
+		if _, ok := in.Provider.(*NoopProvider); ok {
+			return
+		}
+
 		var (
 			cancel context.CancelFunc
 			done   = make(chan struct{})

--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -353,7 +353,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 			}
 		}
 		if impl == nil {
-			return &NoopProvider{}, nil, errors.New("provider: no valid DHT available for providing")
+			return &NoopProvider{}, nil, nil
 		}
 
 		var selfAddrsFunc func() []ma.Multiaddr


### PR DESCRIPTION
If Sweeping Provider is enabled, but no DHT is supplied, `SweepingProviderOpt()` shouldn't return an error.

We want to transition Sweeping Provider to being the default provide mode, and it should be OK for a kubo node not to use a DHT. DHT provides will not happen, but fx shouldn't fail.

IIRC this was included in https://github.com/ipfs/kubo/pull/10834 but probably overwritten due to conflicts in https://github.com/ipfs/kubo/pull/10951/