### PR TITLE
refator: using maps.Clone [skip changelog]

### DIFF
--- a/repo/common/common.go
+++ b/repo/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 )
 
@@ -65,9 +66,9 @@ func MapSetKV(v map[string]interface{}, key string, value interface{}) error {
 // child maps until a non-map value is found.
 func MapMergeDeep(left, right map[string]interface{}) map[string]interface{} {
 	// We want to alter a copy of the map, not the original
-	result := make(map[string]interface{})
-	for k, v := range left {
-		result[k] = v
+	var result map[string]interface{}
+	if result = maps.Clone(left); result == nil {
+		result = make(map[string]interface{})
 	}
 
 	for key, rightVal := range right {


### PR DESCRIPTION
here is the benchmark:
```
package main

import (
	"maps"
	"strconv"
	"testing"
)

var sink interface{}

func makeTestMap(size int) map[string]interface{} {
	m := make(map[string]interface{}, size)
	for i := 0; i < size; i++ {
		m["key"+strconv.Itoa(i)] = i
	}
	return m
}

func benchmarkClone(b *testing.B, size int) {
	m := makeTestMap(size)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		sink = maps.Clone(m)
	}
}

func benchmarkForLoop(b *testing.B, size int) {
	m := makeTestMap(size)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		m2 := make(map[string]interface{})
		for k, v := range m {
			m2[k] = v
		}
		sink = m2
	}
}

func BenchmarkClone_10(b *testing.B)   { benchmarkClone(b, 10) }
func BenchmarkForLoop_10(b *testing.B) { benchmarkForLoop(b, 10) }

func BenchmarkClone_100(b *testing.B)   { benchmarkClone(b, 100) }
func BenchmarkForLoop_100(b *testing.B) { benchmarkForLoop(b, 100) }

func BenchmarkClone_1k(b *testing.B)   { benchmarkClone(b, 1000) }
func BenchmarkForLoop_1k(b *testing.B) { benchmarkForLoop(b, 1000) }

func BenchmarkClone_10k(b *testing.B)   { benchmarkClone(b, 10000) }
func BenchmarkForLoop_10k(b *testing.B) { benchmarkForLoop(b, 10000) }

func BenchmarkClone_100k(b *testing.B)   { benchmarkClone(b, 100000) }
func BenchmarkForLoop_100k(b *testing.B) { benchmarkForLoop(b, 100000) }

func BenchmarkClone_1000k(b *testing.B)   { benchmarkClone(b, 1000000) }
func BenchmarkForLoop_1000k(b *testing.B) { benchmarkForLoop(b, 1000000) }

```
result is:
```
goos: darwin
goarch: arm64
pkg: github.com/cuiweixie/mylabs/tests/maps_clone_vs_for_k_v_clone
cpu: Apple M1 Pro
BenchmarkClone_10-10             3228483               368.1 ns/op           664 B/op          4 allocs/op
BenchmarkForLoop_10-10           2517056               486.0 ns/op           952 B/op          5 allocs/op
BenchmarkClone_100-10             415302              2916 ns/op            4952 B/op          4 allocs/op
BenchmarkForLoop_100-10           232340              5060 ns/op            9368 B/op         11 allocs/op
BenchmarkClone_1k-10               36474             32950 ns/op           82048 B/op          6 allocs/op
BenchmarkForLoop_1k-10             16503             71562 ns/op          160328 B/op         22 allocs/op
BenchmarkClone_10k-10               2629            447135 ns/op          656053 B/op         34 allocs/op
BenchmarkForLoop_10k-10             1274            926968 ns/op         1308331 B/op         81 allocs/op
BenchmarkClone_100k-10               254           5762323 ns/op         5248180 B/op        258 allocs/op
BenchmarkForLoop_100k-10             123           8988190 ns/op        10493188 B/op        532 allocs/op
BenchmarkClone_1000k-10                9         122134931 ns/op        83970096 B/op       4098 allocs/op
BenchmarkForLoop_1000k-10              6         187265181 ns/op        167458568 B/op      8192 allocs/op
PASS
ok      github.com/cuiweixie/mylabs/tests/maps_clone_vs_for_k_v_clone   20.194s
```