### PR TITLE
core/commands/dag/stat: improve output

### DIFF
--- a/core/commands/dag/stat.go
+++ b/core/commands/dag/stat.go
@@ -52,6 +52,11 @@ func dagStat(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) 
 			Order: traverse.DFSPre,
 			Func: func(current traverse.State) error {
 				currentNodeSize := uint64(len(current.Node.RawData()))
+				curDagstats := &DagStat{
+					Cid:       current.Node.Cid(),
+					Size:      currentNodeSize,
+					NumBlocks: -1,
+				}
 				dagstats.Size += currentNodeSize
 				dagstats.NumBlocks++
 				if !cidSet.Has(current.Node.Cid()) {
@@ -60,7 +65,8 @@ func dagStat(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) 
 				dagStatSummary.incrementRedundantSize(currentNodeSize)
 				cidSet.Add(current.Node.Cid())
 				if progressive {
-					if err := res.Emit(dagStatSummary); err != nil {
+					curSummary := &DagStatSummary{DagStatsArray: []*DagStat{curDagstats}}
+					if err := res.Emit(curSummary); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
`ipfs dag stat -h` says:

```
USAGE
  ipfs dag stat <root>... - Gets stats for a DAG.

  ipfs dag stat [--progress=false] [--] <root>...
```

but `--progress` defaults to `true`.

So by default it prints this :

```
ipfs dag stat -progress=true QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ
CID: QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ, Size: 95, NumBlocks: 1
CID: QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ, Size: 202, NumBlocks: 2
CID: QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ, Size: 8912, NumBlocks: 3
CID: QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ, Size: 271056, NumBlocks: 4
CID: QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ, Size: 533200, NumBlocks: 5
...

<actual dag stat summary>.
```

I find this confusing. Is this intended? This PR switches to:

```
ipfs dag stat QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ
CID: QmUWfSKRTZGTHuYhV4kBTrS8fJEV2GPzeXcdhxUGPuYTnJ, Size: 95, NumBlocks: -1
CID: QmaCxzMg6FZRkDi61q4ymWcCvoj6GkuBo5mVszi5DHBpb1, Size: 107, NumBlocks: -1
CID: QmUf2ynPG2wCJe3zLaASNJrQKN3BkboD2VRAKcwteDAUQB, Size: 8710, NumBlocks: -1
CID: bafkreibspggfqizukzodgaivbqusjz2xugesiaf3cutlf5rayzkfawhyry, Size: 262144, NumBlocks: -1
CID: bafkreicagz2co2ryds5auotj5kgwbqt7mvfzua4o54fv24rbycodytnmuu, Size: 262144, NumBlocks: -1
...

<actual summary>
```

which means it lists the nodes that are traversed as it makes progress traversing the DAG.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
