### PR TITLE
fix: update webui to v4.9.1

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -12,7 +12,7 @@ import (
 )
 
 // WebUI version confirmed to work with this Kubo version
-const WebUIPath = "/ipfs/bafybeietkqxghs3hm56e3w64s4papqlvvzqzjigs4eyuy24plkpz652fee" // v4.9.0
+const WebUIPath = "/ipfs/bafybeicg7e6o2eszkfdzxg5233gmuip2a7kfzoloh7voyvt2r6ivdet54u" // v4.9.1
 
 // WebUIPaths is a list of all past webUI paths.
 var WebUIPaths = []string{


### PR DESCRIPTION
- https://github.com/ipfs/ipfs-webui/releases/tag/v4.9.1

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
