### PR TITLE
feat: add docker stub for deprecated ipfs/go-ipfs name

### DIFF
--- a/.github/legacy/Dockerfile.goipfs-stub
+++ b/.github/legacy/Dockerfile.goipfs-stub
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+# Stub Dockerfile for the deprecated 'ipfs/go-ipfs' image name.
+# This image redirects users to the new 'ipfs/kubo' name.
+FROM busybox:stable-glibc
+
+# Copy stub entrypoint that displays deprecation message
+COPY .github/legacy/goipfs_stub.sh /usr/local/bin/ipfs
+
+# Make it executable
+RUN chmod +x /usr/local/bin/ipfs
+
+# Use the same ports as the real image for compatibility
+EXPOSE 4001 4001/udp 5001 8080 8081
+
+# Create ipfs user for consistency
+ENV IPFS_PATH=/data/ipfs
+RUN mkdir -p $IPFS_PATH \
+  && adduser -D -h $IPFS_PATH -u 1000 -G users ipfs \
+  && chown ipfs:users $IPFS_PATH
+
+# Run as ipfs user
+USER ipfs
+
+# The stub script will run and exit with an error message
+ENTRYPOINT ["/usr/local/bin/ipfs"]
+CMD ["daemon"]

--- a/.github/legacy/goipfs_stub.sh
+++ b/.github/legacy/goipfs_stub.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Stub script for the deprecated 'ipfs/go-ipfs' Docker image.
+# This informs users to switch to 'ipfs/kubo'.
+
+cat >&2 <<'EOF'
+ERROR: The name 'go-ipfs' is no longer used.
+
+Please update your Docker scripts to use 'ipfs/kubo' instead of 'ipfs/go-ipfs'.
+
+For example:
+  docker pull ipfs/kubo:release
+
+More information:
+  - https://github.com/ipfs/kubo#docker
+  - https://hub.docker.com/r/ipfs/kubo
+  - https://docs.ipfs.tech/install/run-ipfs-inside-docker/
+
+EOF
+
+exit 1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,7 +39,8 @@ jobs:
     timeout-minutes: 15
     env:
       IMAGE_NAME: ipfs/kubo
-      LEGACY_IMAGE_NAME: ipfs/go-ipfs
+    outputs:
+      tags: ${{ steps.tags.outputs.value }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5
@@ -140,3 +141,52 @@ jobs:
           cache-to: |
             type=gha,mode=max
             type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+  # Build and push stub image to the legacy ipfs/go-ipfs name
+  # This redirects users to use ipfs/kubo instead
+  legacy-name:
+    needs: docker-hub
+    if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
+    name: Push stub to legacy ipfs/go-ipfs name
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      LEGACY_IMAGE_NAME: ipfs/go-ipfs
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Convert tags to legacy image name
+        id: legacy_tags
+        run: |
+          TAGS="${{ github.event.inputs.tags || needs.docker-hub.outputs.tags }}"
+          if ! echo "$TAGS" | grep -q "kubo"; then
+            echo "ERROR: Tags must contain kubo image name"
+            exit 1
+          fi
+          echo "value<<EOF" >> $GITHUB_OUTPUT
+          echo "$TAGS" | sed "s|ipfs/kubo|$LEGACY_IMAGE_NAME|g" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - if: github.event_name != 'workflow_dispatch' || github.event.inputs.push == 'true'
+        name: Build and push legacy stub image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          context: .
+          push: true
+          file: ./.github/legacy/Dockerfile.goipfs-stub
+          tags: ${{ steps.legacy_tags.outputs.value }}

--- a/bin/get-docker-tags.sh
+++ b/bin/get-docker-tags.sh
@@ -29,12 +29,10 @@ GIT_BRANCH=${3:-$(git symbolic-ref -q --short HEAD || echo "unknown")}
 GIT_TAG=${4:-$(git describe --tags --exact-match 2> /dev/null || echo "")}
 
 IMAGE_NAME=${IMAGE_NAME:-ipfs/kubo}
-LEGACY_IMAGE_NAME=${LEGACY_IMAGE_NAME:-ipfs/go-ipfs}
 
 echoImageName () {
   local IMAGE_TAG=$1
   echo "$IMAGE_NAME:$IMAGE_TAG"
-  echo "$LEGACY_IMAGE_NAME:$IMAGE_TAG"
 }
 
 if [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc ]]; then

--- a/docs/changelogs/v0.39.md
+++ b/docs/changelogs/v0.39.md
@@ -18,6 +18,16 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 
 ### 🔦 Highlights
 
+#### 🪦 Deprecated `go-ipfs` name no longer published
+
+The `go-ipfs` name was deprecated in 2022 and renamed to `kubo`. Starting with this release, we have stopped publishing Docker images and distribution binaries under the old `go-ipfs` name.
+
+Existing users should switch to:
+- Docker: `ipfs/kubo` image (instead of `ipfs/go-ipfs`)
+- Binaries: download from https://dist.ipfs.tech/kubo/ or https://github.com/ipfs/kubo/releases
+
+For Docker users, the legacy `ipfs/go-ipfs` image name now shows a deprecation notice directing you to `ipfs/kubo`.
+
 ### 📦️ Important dependency updates
 
 ### 📝 Changelog


### PR DESCRIPTION
implements docker part of #10941 by creating a stub image that redirects users from `ipfs/go-ipfs` to `ipfs/kubo`. we will ship this in 0.39.

- Closes https://github.com/ipfs/kubo/issues/10941

### changes
- add stub dockerfile and script in `.github/legacy/`
- modify `docker-image.yml` to push stub to `ipfs/go-ipfs` with same tags as `ipfs/kubo`
- remove `ipfs/go-ipfs` from `get-docker-tags.sh` to prevent docker-hub job from pushing to legacy name
- stub displays clear deprecation message directing users to `ipfs/kubo:release`

### todo

- [x] test staging build
  - [x] passed: https://github.com/ipfs/kubo/actions/runs/18146109780/job/51648379336

### demo

```console
$ docker run --rm -it --net=host ipfs/go-ipfs:staging-2025-09-30-239669e
...
Status: Downloaded newer image for ipfs/go-ipfs:staging-2025-09-30-239669e
ERROR: The name 'go-ipfs' is no longer used.

Please update your Docker scripts to use 'ipfs/kubo' instead of 'ipfs/go-ipfs'.

For example:
  docker pull ipfs/kubo:release

More information:
  - https://github.com/ipfs/kubo#docker
  - https://hub.docker.com/r/ipfs/kubo
  - https://docs.ipfs.tech/install/run-ipfs-inside-docker/
```

