### PR TITLE
config: increase default Provide.DHT.MaxProvideConnsPerWorker

### DIFF
--- a/config/provide.go
+++ b/config/provide.go
@@ -18,7 +18,7 @@ const (
 	DefaultProvideDHTSweepEnabled             = false
 	DefaultProvideDHTDedicatedPeriodicWorkers = 2
 	DefaultProvideDHTDedicatedBurstWorkers    = 1
-	DefaultProvideDHTMaxProvideConnsPerWorker = 16
+	DefaultProvideDHTMaxProvideConnsPerWorker = 20
 	DefaultProvideDHTKeystoreBatchSize        = 1 << 14 // ~544 KiB per batch (1 multihash = 34 bytes)
 	DefaultProvideDHTOfflineDelay             = 2 * time.Hour
 )

--- a/docs/config.md
+++ b/docs/config.md
@@ -2167,7 +2167,13 @@ from that keyspace region until all provider records are assigned.
 This option defines how many such connections can be open concurrently by a
 single worker.
 
-Default: `16`
+> [!NOTE]
+> Increasing this value can speed up the provide operation, at the cost of
+> opening more simultaneous connections to DHT servers. A keyspace typically
+> has less than 60 peers, so you may hit a performance ceiling beyond which
+> increasing this value has no effect.
+
+Default: `20`
 
 Type: `optionalInteger` (non-negative)
 


### PR DESCRIPTION
Increase default Provide.DHT.MaxProvideConnsPerWorker value to match the DHT replication factor (16 -> 20). A similar value is used in legacy systems (with and without accelerated DHT client).