### PR TITLE
fix: return original error in PathOrCidPath fallback

### DIFF
--- a/core/commands/cmdutils/utils.go
+++ b/core/commands/cmdutils/utils.go
@@ -74,10 +74,13 @@ func PathOrCidPath(str string) (path.Path, error) {
 		return p, nil
 	}
 
+	// Save the original error before attempting fallback
+	originalErr := err
+
 	if p, err := path.NewPath("/ipfs/" + str); err == nil {
 		return p, nil
 	}
 
 	// Send back original err.
-	return nil, err
+	return nil, originalErr
 }


### PR DESCRIPTION
PathOrCidPath was returning the error from the second path.NewPath call instead of the original error when both attempts failed. This fix preserves the first error before attempting the fallback, ensuring users get the most relevant error message about their input.