### PR TITLE
feat(client/rpc): add `provide stat` and `dag import` support

### DIFF
--- a/client/rpc/dag.go
+++ b/client/rpc/dag.go
@@ -180,7 +180,7 @@ func (api *HttpDagServ) Import(ctx context.Context, file files.File, opts ...opt
 			if err := dec.Decode(&event); err != nil {
 				if err != io.EOF {
 					select {
-					case out <- iface.DagImportResult{}:
+					case out <- iface.DagImportResult{Err: err}:
 					case <-ctx.Done():
 					}
 				}

--- a/client/rpc/routing_test.go
+++ b/client/rpc/routing_test.go
@@ -1,0 +1,163 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	boxoprovider "github.com/ipfs/boxo/provider"
+	iface "github.com/ipfs/kubo/core/coreiface"
+	"github.com/ipfs/kubo/core/coreiface/options"
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/libp2p/go-libp2p-kad-dht/provider/stats"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time check: ensure our response type is compatible with kubo's provideStats
+// This verifies that JSON marshaling/unmarshaling will work correctly
+var _ = func() {
+	// Create instance of command's provideStats structure
+	cmdStats := struct {
+		Sweep  *stats.Stats                  `json:"Sweep,omitempty"`
+		Legacy *boxoprovider.ReproviderStats `json:"Legacy,omitempty"`
+		FullRT bool                          `json:"FullRT,omitempty"`
+	}{}
+
+	// Marshal and unmarshal to verify compatibility
+	data, _ := json.Marshal(cmdStats)
+	var ifaceStats iface.ProvideStatsResponse
+	_ = json.Unmarshal(data, &ifaceStats)
+}
+
+// testProvideStats mirrors the subset of fields we verify in tests.
+// Intentionally independent from coreiface types to detect breaking changes.
+type testProvideStats struct {
+	Sweep *struct {
+		Connectivity struct {
+			Status string `json:"status"`
+		} `json:"connectivity"`
+		Queues struct {
+			PendingKeyProvides int `json:"pending_key_provides"`
+		} `json:"queues"`
+		Schedule struct {
+			Keys int `json:"keys"`
+		} `json:"schedule"`
+	} `json:"Sweep,omitempty"`
+	Legacy *struct {
+		TotalReprovides uint64 `json:"TotalReprovides"`
+	} `json:"Legacy,omitempty"`
+}
+
+func TestProvideStats_WithSweepProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := harness.NewT(t)
+	node := h.NewNode().Init()
+
+	// Explicitly enable Sweep provider (default in v0.39)
+	node.SetIPFSConfig("Provide.DHT.SweepEnabled", true)
+	node.SetIPFSConfig("Provide.Enabled", true)
+
+	node.StartDaemon()
+	defer node.StopDaemon()
+
+	apiMaddr, err := node.TryAPIAddr()
+	require.NoError(t, err)
+
+	api, err := NewApi(apiMaddr)
+	require.NoError(t, err)
+
+	// Get provide stats
+	result, err := api.Routing().ProvideStats(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify Sweep stats are present, Legacy is not
+	require.NotNil(t, result.Sweep, "Sweep provider should return Sweep stats")
+	require.Nil(t, result.Legacy, "Sweep provider should not return Legacy stats")
+
+	// Marshal to JSON and unmarshal to test struct to verify structure
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var testStats testProvideStats
+	err = json.Unmarshal(data, &testStats)
+	require.NoError(t, err)
+
+	// Verify key fields exist and have reasonable values
+	require.NotNil(t, testStats.Sweep)
+	require.NotEmpty(t, testStats.Sweep.Connectivity.Status, "connectivity status should be present")
+	require.GreaterOrEqual(t, testStats.Sweep.Queues.PendingKeyProvides, 0, "queue size should be non-negative")
+	require.GreaterOrEqual(t, testStats.Sweep.Schedule.Keys, 0, "scheduled keys should be non-negative")
+}
+
+func TestProvideStats_WithLegacyProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := harness.NewT(t)
+	node := h.NewNode().Init()
+
+	// Explicitly disable Sweep to use Legacy provider
+	node.SetIPFSConfig("Provide.DHT.SweepEnabled", false)
+	node.SetIPFSConfig("Provide.Enabled", true)
+
+	node.StartDaemon()
+	defer node.StopDaemon()
+
+	apiMaddr, err := node.TryAPIAddr()
+	require.NoError(t, err)
+
+	api, err := NewApi(apiMaddr)
+	require.NoError(t, err)
+
+	// Get provide stats
+	result, err := api.Routing().ProvideStats(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify Legacy stats are present, Sweep is not
+	require.Nil(t, result.Sweep, "Legacy provider should not return Sweep stats")
+	require.NotNil(t, result.Legacy, "Legacy provider should return Legacy stats")
+
+	// Marshal to JSON and unmarshal to test struct to verify structure
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var testStats testProvideStats
+	err = json.Unmarshal(data, &testStats)
+	require.NoError(t, err)
+
+	// Verify Legacy field exists
+	require.NotNil(t, testStats.Legacy)
+	require.GreaterOrEqual(t, testStats.Legacy.TotalReprovides, uint64(0), "total reprovides should be non-negative")
+}
+
+func TestProvideStats_LANFlagErrorWithLegacy(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := harness.NewT(t)
+	node := h.NewNode().Init()
+
+	// Use Legacy provider - LAN flag should error
+	node.SetIPFSConfig("Provide.DHT.SweepEnabled", false)
+	node.SetIPFSConfig("Provide.Enabled", true)
+
+	node.StartDaemon()
+	defer node.StopDaemon()
+
+	apiMaddr, err := node.TryAPIAddr()
+	require.NoError(t, err)
+
+	api, err := NewApi(apiMaddr)
+	require.NoError(t, err)
+
+	// Try to get LAN stats with Legacy provider
+	// This should return an error
+	_, err = api.Routing().ProvideStats(ctx, options.Routing.UseLAN(true))
+	require.Error(t, err, "LAN flag should error with Legacy provider")
+	require.Contains(t, err.Error(), "LAN stats only available for Sweep provider with Dual DHT",
+		"error should indicate LAN stats unavailable")
+}

--- a/client/rpc/unixfs.go
+++ b/client/rpc/unixfs.go
@@ -56,6 +56,14 @@ func (api *UnixfsAPI) Add(ctx context.Context, f files.Node, opts ...caopts.Unix
 		req.Option("raw-leaves", options.RawLeaves)
 	}
 
+	if options.FastProvideRootSet {
+		req.Option("fast-provide-root", options.FastProvideRoot)
+	}
+
+	if options.FastProvideWaitSet {
+		req.Option("fast-provide-wait", options.FastProvideWait)
+	}
+
 	switch options.Layout {
 	case caopts.BalancedLayout:
 		// noop, default

--- a/core/coreapi/dag.go
+++ b/core/coreapi/dag.go
@@ -2,11 +2,20 @@ package coreapi
 
 import (
 	"context"
+	"fmt"
+	"io"
 
+	"github.com/ipfs/boxo/files"
 	dag "github.com/ipfs/boxo/ipld/merkledag"
 	pin "github.com/ipfs/boxo/pinning/pinner"
+	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+	ipldlegacy "github.com/ipfs/go-ipld-legacy"
+	"github.com/ipfs/kubo/config"
+	iface "github.com/ipfs/kubo/core/coreiface"
+	"github.com/ipfs/kubo/core/coreiface/options"
+	gocarv2 "github.com/ipld/go-car/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -66,6 +75,250 @@ func (api *dagAPI) Pinning() ipld.NodeAdder {
 
 func (api *dagAPI) Session(ctx context.Context) ipld.NodeGetter {
 	return dag.NewSession(ctx, api.DAGService)
+}
+
+func (api *dagAPI) Import(ctx context.Context, file files.File, opts ...options.DagImportOption) (<-chan iface.DagImportResult, error) {
+	// Parse options
+	settings, err := options.DagImportOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get config for batch settings
+	cfg, err := api.core.repo.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create block decoder for IPLD nodes
+	blockDecoder := ipldlegacy.NewDecoder()
+
+	// Create batch for efficient block addition
+	// Uses config values for batch size tuning
+	batch := ipld.NewBatch(ctx, api.DAGService,
+		ipld.MaxNodesBatchOption(int(cfg.Import.BatchMaxNodes.WithDefault(config.DefaultBatchMaxNodes))),
+		ipld.MaxSizeBatchOption(int(cfg.Import.BatchMaxSize.WithDefault(config.DefaultBatchMaxSize))),
+	)
+
+	// Create output channel
+	out := make(chan iface.DagImportResult)
+
+	// Process import in background
+	go func() {
+		defer close(out)
+		defer file.Close()
+
+		// Acquire pinlock if pinning roots (also serves as GC lock)
+		if settings.PinRoots {
+			unlocker := api.core.blockstore.PinLock(ctx)
+			defer unlocker.Unlock(ctx)
+		}
+
+		// Track roots from CAR headers and stats
+		roots := cid.NewSet()
+		var blockCount, blockBytesCount uint64
+
+		// Parse CAR file
+		car, err := gocarv2.NewBlockReader(file)
+		if err != nil {
+			out <- iface.DagImportResult{Err: fmt.Errorf("failed to create CAR reader: %w", err)}
+			return
+		}
+
+		// Collect roots from CAR header
+		for _, c := range car.Roots {
+			roots.Add(c)
+		}
+
+		// Process all blocks from CAR file
+		var previous blocks.Block
+		for {
+			block, err := car.Next()
+			if err != nil {
+				if err != io.EOF {
+					if previous != nil {
+						out <- iface.DagImportResult{Err: fmt.Errorf("error reading block after %s: %w", previous.Cid(), err)}
+					} else {
+						out <- iface.DagImportResult{Err: fmt.Errorf("error reading CAR blocks: %w", err)}
+					}
+				}
+				break
+			}
+			if block == nil {
+				break
+			}
+
+			// Decode block into IPLD node
+			nd, err := blockDecoder.DecodeNode(ctx, block)
+			if err != nil {
+				out <- iface.DagImportResult{Err: fmt.Errorf("failed to decode block %s: %w", block.Cid(), err)}
+				return
+			}
+
+			// Add node to batch
+			if err := batch.Add(ctx, nd); err != nil {
+				out <- iface.DagImportResult{Err: fmt.Errorf("failed to add block %s to batch: %w", nd.Cid(), err)}
+				return
+			}
+
+			blockCount++
+			blockBytesCount += uint64(len(block.RawData()))
+			previous = block
+
+			// Check context cancellation
+			select {
+			case <-ctx.Done():
+				out <- iface.DagImportResult{Err: ctx.Err()}
+				return
+			default:
+			}
+		}
+
+		// Commit batch to blockstore
+		if err := batch.Commit(); err != nil {
+			out <- iface.DagImportResult{Err: fmt.Errorf("failed to commit batch: %w", err)}
+			return
+		}
+
+		// Emit all roots (with pin status if requested)
+		err = roots.ForEach(func(c cid.Cid) error {
+			result := iface.DagImportResult{
+				Root: &iface.DagImportRoot{Cid: c},
+			}
+
+			// Attempt to pin if requested
+			if settings.PinRoots {
+				// Verify block exists in blockstore
+				block, err := api.core.blockstore.Get(ctx, c)
+				if err != nil {
+					result.Root.PinErrorMsg = fmt.Sprintf("blockstore get: %v", err)
+				} else {
+					// Decode node for pinning
+					nd, err := blockDecoder.DecodeNode(ctx, block)
+					if err != nil {
+						result.Root.PinErrorMsg = fmt.Sprintf("decode node: %v", err)
+					} else {
+						// Pin recursively
+						err = api.core.pinning.Pin(ctx, nd, true, "")
+						if err != nil {
+							result.Root.PinErrorMsg = fmt.Sprintf("pin: %v", err)
+						} else {
+							// Flush pins to storage
+							err = api.core.pinning.Flush(ctx)
+							if err != nil {
+								result.Root.PinErrorMsg = fmt.Sprintf("flush: %v", err)
+							}
+						}
+					}
+				}
+			}
+
+			// Send root result
+			select {
+			case out <- result:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			return nil
+		})
+		if err != nil {
+			out <- iface.DagImportResult{Err: fmt.Errorf("error emitting roots: %w", err)}
+			return
+		}
+
+		// Emit stats if requested
+		if settings.Stats {
+			select {
+			case out <- iface.DagImportResult{
+				Stats: &iface.DagImportStats{
+					BlockCount:      blockCount,
+					BlockBytesCount: blockBytesCount,
+				},
+			}:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		// Execute fast-provide (will check if enabled)
+		if err := api.executeFastProvide(ctx, cfg, roots, settings.FastProvideRoot, settings.FastProvideWait, settings.PinRoots, settings.PinRoots, false); err != nil {
+			select {
+			case out <- iface.DagImportResult{Err: err}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+// executeFastProvide announces roots to the DHT for faster discovery
+func (api *dagAPI) executeFastProvide(ctx context.Context, cfg *config.Config, roots *cid.Set, enabled bool, wait bool, isPinned bool, isPinnedRoot bool, isMFS bool) error {
+	// Check if fast-provide is enabled
+	if !enabled {
+		if wait {
+			log.Debugw("fast-provide-root: skipped", "reason", "disabled by flag or config", "wait-flag-ignored", true)
+		} else {
+			log.Debugw("fast-provide-root: skipped", "reason", "disabled by flag or config")
+		}
+		return nil
+	}
+
+	log.Debugw("fast-provide-root: enabled", "wait", wait)
+
+	// Check preconditions for providing
+	if !cfg.Provide.Enabled.WithDefault(config.DefaultProvideEnabled) {
+		log.Debugw("fast-provide-root: skipped", "reason", "Provide.Enabled is false")
+		return nil
+	}
+
+	if cfg.Provide.DHT.Interval.WithDefault(config.DefaultProvideDHTInterval) == 0 {
+		log.Debugw("fast-provide-root: skipped", "reason", "Provide.DHT.Interval is 0")
+		return nil
+	}
+
+	if !api.core.nd.HasActiveDHTClient() {
+		log.Debugw("fast-provide-root: skipped", "reason", "DHT not available")
+		return nil
+	}
+
+	// Check provide strategy
+	strategyStr := cfg.Provide.Strategy.WithDefault(config.DefaultProvideStrategy)
+	strategy := config.ParseProvideStrategy(strategyStr)
+	shouldProvide := config.ShouldProvideForStrategy(strategy, isPinned, isPinnedRoot, isMFS)
+
+	if !shouldProvide {
+		log.Debugw("fast-provide-root: skipped", "reason", "strategy does not match content", "strategy", strategyStr, "pinned", isPinned, "pinnedRoot", isPinnedRoot, "mfs", isMFS)
+		return nil
+	}
+
+	// Provide each root
+	return roots.ForEach(func(c cid.Cid) error {
+		if wait {
+			// Synchronous mode: block until provide completes
+			log.Debugw("fast-provide-root: providing synchronously", "cid", c)
+			if err := api.core.nd.DHTClient.Provide(ctx, c, true); err != nil {
+				log.Warnw("fast-provide-root: sync provide failed", "cid", c, "error", err)
+				return fmt.Errorf("fast-provide: %w", err)
+			}
+			log.Debugw("fast-provide-root: sync provide completed", "cid", c)
+		} else {
+			// Asynchronous mode: fire-and-forget in goroutine
+			log.Debugw("fast-provide-root: providing asynchronously", "cid", c)
+			go func(rootCid cid.Cid) {
+				// Use detached context with timeout to prevent hanging
+				asyncCtx, cancel := context.WithTimeout(context.Background(), config.DefaultFastProvideTimeout)
+				defer cancel()
+				if err := api.core.nd.DHTClient.Provide(asyncCtx, rootCid, true); err != nil {
+					log.Warnw("fast-provide-root: async provide failed", "cid", rootCid, "error", err)
+				} else {
+					log.Debugw("fast-provide-root: async provide completed", "cid", rootCid)
+				}
+			}(c)
+		}
+		return nil
+	})
 }
 
 var (

--- a/core/coreiface/dag.go
+++ b/core/coreiface/dag.go
@@ -14,6 +14,7 @@ import (
 type DagImportResult struct {
 	Root  *DagImportRoot
 	Stats *DagImportStats
+	Err   error
 }
 
 // DagImportRoot represents a root CID from a CAR file header

--- a/core/coreiface/dag.go
+++ b/core/coreiface/dag.go
@@ -1,8 +1,32 @@
 package iface
 
 import (
+	"context"
+
+	"github.com/ipfs/boxo/files"
+	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/kubo/core/coreiface/options"
 )
+
+// DagImportResult represents the result of importing roots or stats from CAR files.
+// Each result has either Root or Stats set, never both.
+type DagImportResult struct {
+	Root  *DagImportRoot
+	Stats *DagImportStats
+}
+
+// DagImportRoot represents a root CID from a CAR file header
+type DagImportRoot struct {
+	Cid         cid.Cid
+	PinErrorMsg string
+}
+
+// DagImportStats contains statistics about the import operation
+type DagImportStats struct {
+	BlockCount      uint64
+	BlockBytesCount uint64
+}
 
 // APIDagService extends ipld.DAGService
 type APIDagService interface {
@@ -10,4 +34,10 @@ type APIDagService interface {
 
 	// Pinning returns special NodeAdder which recursively pins added nodes
 	Pinning() ipld.NodeAdder
+
+	// Import imports data from CAR files.
+	// Returns a channel that streams results for each root CID found in CAR headers,
+	// and optionally stats at the end if requested via options.
+	// Supports importing multiple CAR files, each with multiple roots.
+	Import(context.Context, files.File, ...options.DagImportOption) (<-chan DagImportResult, error)
 }

--- a/core/coreiface/options/dag.go
+++ b/core/coreiface/options/dag.go
@@ -1,0 +1,80 @@
+package options
+
+type DagImportSettings struct {
+	PinRoots           bool
+	PinRootsSet        bool
+	Stats              bool
+	StatsSet           bool
+	FastProvideRoot    bool
+	FastProvideRootSet bool
+	FastProvideWait    bool
+	FastProvideWaitSet bool
+}
+
+type DagImportOption func(*DagImportSettings) error
+
+func DagImportOptions(opts ...DagImportOption) (*DagImportSettings, error) {
+	options := &DagImportSettings{
+		PinRoots:           false,
+		PinRootsSet:        false,
+		Stats:              false,
+		StatsSet:           false,
+		FastProvideRoot:    false,
+		FastProvideRootSet: false,
+		FastProvideWait:    false,
+		FastProvideWaitSet: false,
+	}
+
+	for _, opt := range opts {
+		err := opt(options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return options, nil
+}
+
+type dagOpts struct{}
+
+var Dag dagOpts
+
+// PinRoots sets whether to pin roots listed in CAR headers after importing.
+// If not set, server uses command default (true).
+func (dagOpts) PinRoots(pin bool) DagImportOption {
+	return func(settings *DagImportSettings) error {
+		settings.PinRoots = pin
+		settings.PinRootsSet = true
+		return nil
+	}
+}
+
+// Stats enables output of import statistics (block count and bytes).
+// If not set, server uses command default (false).
+func (dagOpts) Stats(enable bool) DagImportOption {
+	return func(settings *DagImportSettings) error {
+		settings.Stats = enable
+		settings.StatsSet = true
+		return nil
+	}
+}
+
+// FastProvideRoot sets whether to immediately provide root CIDs to DHT for faster discovery.
+// If not set, server uses Import.FastProvideRoot config value (default: true).
+func (dagOpts) FastProvideRoot(enable bool) DagImportOption {
+	return func(settings *DagImportSettings) error {
+		settings.FastProvideRoot = enable
+		settings.FastProvideRootSet = true
+		return nil
+	}
+}
+
+// FastProvideWait sets whether to block until fast provide completes.
+// If not set, server uses Import.FastProvideWait config value (default: false).
+func (dagOpts) FastProvideWait(enable bool) DagImportOption {
+	return func(settings *DagImportSettings) error {
+		settings.FastProvideWait = enable
+		settings.FastProvideWaitSet = true
+		return nil
+	}
+}

--- a/core/coreiface/options/routing.go
+++ b/core/coreiface/options/routing.go
@@ -96,3 +96,34 @@ func (routingOpts) AllowOffline(allow bool) RoutingPutOption {
 		return nil
 	}
 }
+
+type RoutingProvideStatSettings struct {
+	UseLAN bool
+}
+
+type RoutingProvideStatOption func(*RoutingProvideStatSettings) error
+
+func RoutingProvideStatOptions(opts ...RoutingProvideStatOption) (*RoutingProvideStatSettings, error) {
+	options := &RoutingProvideStatSettings{
+		UseLAN: false,
+	}
+
+	for _, opt := range opts {
+		err := opt(options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return options, nil
+}
+
+// UseLAN is an option for [Routing.ProvideStats] which specifies whether to
+// return stats for LAN DHT only (only valid for Sweep provider with Dual DHT).
+// Default value is false (WAN DHT stats).
+func (routingOpts) UseLAN(useLAN bool) RoutingProvideStatOption {
+	return func(settings *RoutingProvideStatSettings) error {
+		settings.UseLAN = useLAN
+		return nil
+	}
+}

--- a/core/coreiface/options/unixfs.go
+++ b/core/coreiface/options/unixfs.go
@@ -52,6 +52,11 @@ type UnixfsAddSettings struct {
 	PreserveMtime bool
 	Mode          os.FileMode
 	Mtime         time.Time
+
+	FastProvideRoot    bool
+	FastProvideRootSet bool
+	FastProvideWait    bool
+	FastProvideWaitSet bool
 }
 
 type UnixfsLsSettings struct {
@@ -97,6 +102,11 @@ func UnixfsAddOptions(opts ...UnixfsAddOption) (*UnixfsAddSettings, cid.Prefix, 
 		PreserveMtime: false,
 		Mode:          0,
 		Mtime:         time.Time{},
+
+		FastProvideRoot:    false,
+		FastProvideRootSet: false,
+		FastProvideWait:    false,
+		FastProvideWaitSet: false,
 	}
 
 	for _, opt := range opts {
@@ -393,6 +403,26 @@ func (unixfsOpts) Mtime(seconds int64, nsecs uint32) UnixfsAddOption {
 			return errors.New("mtime nanoseconds must be in range [1, 999999999]")
 		}
 		settings.Mtime = time.Unix(seconds, int64(nsecs))
+		return nil
+	}
+}
+
+// FastProvideRoot sets whether to immediately provide root CID to DHT for faster discovery.
+// If not set, server uses Import.FastProvideRoot config value (default: true).
+func (unixfsOpts) FastProvideRoot(enable bool) UnixfsAddOption {
+	return func(settings *UnixfsAddSettings) error {
+		settings.FastProvideRoot = enable
+		settings.FastProvideRootSet = true
+		return nil
+	}
+}
+
+// FastProvideWait sets whether to block until fast provide completes.
+// If not set, server uses Import.FastProvideWait config value (default: false).
+func (unixfsOpts) FastProvideWait(enable bool) UnixfsAddOption {
+	return func(settings *UnixfsAddSettings) error {
+		settings.FastProvideWait = enable
+		settings.FastProvideWaitSet = true
 		return nil
 	}
 }

--- a/core/coreiface/routing.go
+++ b/core/coreiface/routing.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/ipfs/boxo/path"
+	boxoprovider "github.com/ipfs/boxo/provider"
 	"github.com/ipfs/kubo/core/coreiface/options"
+	"github.com/libp2p/go-libp2p-kad-dht/provider/stats"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
@@ -26,4 +28,15 @@ type RoutingAPI interface {
 
 	// Provide announces to the network that you are providing given values
 	Provide(context.Context, path.Path, ...options.RoutingProvideOption) error
+
+	// ProvideStats returns statistics about the provide system.
+	// Returns stats for either sweep provider (new default) or legacy provider.
+	ProvideStats(context.Context, ...options.RoutingProvideStatOption) (*ProvideStatsResponse, error)
+}
+
+// ProvideStatsResponse contains statistics about the provide system
+type ProvideStatsResponse struct {
+	Sweep  *stats.Stats                  `json:"Sweep,omitempty"`
+	Legacy *boxoprovider.ReproviderStats `json:"Legacy,omitempty"`
+	FullRT bool                          `json:"FullRT,omitempty"`
 }

--- a/test/cli/dag_test.go
+++ b/test/cli/dag_test.go
@@ -120,7 +120,7 @@ func TestDagImportFastProvide(t *testing.T) {
 		node.StartDaemonWithReq(harness.RunRequest{
 			CmdOpts: []harness.CmdOpt{
 				harness.RunWithEnv(map[string]string{
-					"GOLOG_LOG_LEVEL": "error,core/commands=debug,core/commands/cmdenv=debug",
+					"GOLOG_LOG_LEVEL": "error,coreapi=debug",
 				}),
 			},
 		}, "")
@@ -146,7 +146,7 @@ func TestDagImportFastProvide(t *testing.T) {
 		node.StartDaemonWithReq(harness.RunRequest{
 			CmdOpts: []harness.CmdOpt{
 				harness.RunWithEnv(map[string]string{
-					"GOLOG_LOG_LEVEL": "error,core/commands=debug,core/commands/cmdenv=debug",
+					"GOLOG_LOG_LEVEL": "error,coreapi=debug",
 				}),
 			},
 		}, "")
@@ -183,7 +183,7 @@ func TestDagImportFastProvide(t *testing.T) {
 		node.StartDaemonWithReq(harness.RunRequest{
 			CmdOpts: []harness.CmdOpt{
 				harness.RunWithEnv(map[string]string{
-					"GOLOG_LOG_LEVEL": "error,core/commands=debug,core/commands/cmdenv=debug",
+					"GOLOG_LOG_LEVEL": "error,coreapi=debug",
 				}),
 			},
 		}, "")
@@ -226,7 +226,7 @@ func TestDagImportFastProvide(t *testing.T) {
 		node.StartDaemonWithReq(harness.RunRequest{
 			CmdOpts: []harness.CmdOpt{
 				harness.RunWithEnv(map[string]string{
-					"GOLOG_LOG_LEVEL": "error,core/commands=debug,core/commands/cmdenv=debug",
+					"GOLOG_LOG_LEVEL": "error,coreapi=debug",
 				}),
 			},
 		}, "")
@@ -254,7 +254,7 @@ func TestDagImportFastProvide(t *testing.T) {
 		node.StartDaemonWithReq(harness.RunRequest{
 			CmdOpts: []harness.CmdOpt{
 				harness.RunWithEnv(map[string]string{
-					"GOLOG_LOG_LEVEL": "error,core/commands=debug,core/commands/cmdenv=debug",
+					"GOLOG_LOG_LEVEL": "error,coreapi=debug",
 				}),
 			},
 		}, "")
@@ -284,7 +284,7 @@ func TestDagImportFastProvide(t *testing.T) {
 		node.StartDaemonWithReq(harness.RunRequest{
 			CmdOpts: []harness.CmdOpt{
 				harness.RunWithEnv(map[string]string{
-					"GOLOG_LOG_LEVEL": "error,core/commands=debug,core/commands/cmdenv=debug",
+					"GOLOG_LOG_LEVEL": "error,coreapi=debug",
 				}),
 			},
 		}, "")

--- a/test/cli/provide_stats_test.go
+++ b/test/cli/provide_stats_test.go
@@ -180,7 +180,7 @@ func TestProvideStatBasic(t *testing.T) {
 
 		res := node.RunIPFS("provide", "stat")
 		assert.Error(t, res.Err)
-		assert.Contains(t, res.Stderr.String(), "this command must be run in online mode")
+		assert.Contains(t, res.Stderr.String(), "this action must be run in online mode")
 	})
 }
 

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -249,6 +249,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.7.1 // indirect
+	github.com/probe-lab/go-libdht v0.4.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -650,6 +650,8 @@ github.com/polyfloyd/go-errorlint v1.7.1 h1:RyLVXIbosq1gBdk/pChWA8zWYLsq9UEw7a1L
 github.com/polyfloyd/go-errorlint v1.7.1/go.mod h1:aXjNb1x2TNhoLsk26iv1yl7a+zTnXPhwEMtEXukiLR8=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
+github.com/probe-lab/go-libdht v0.4.0 h1:LAqHuko/owRW6+0cs5wmJXbHzg09EUMJEh5DI37yXqo=
+github.com/probe-lab/go-libdht v0.4.0/go.mod h1:hamw22kI6YkPQFGy5P6BrWWDrgE9ety5Si8iWAyuDvc=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=


### PR DESCRIPTION
> [!WARNING]
> Not ready yet, opening draft PR to see if there are any test failures. I will work on this is spare time, but likely 0.40.

This PR adds `client/rpc` (RPC library for GO) support for:
- `ipfs provide stat`
- `ipfs dag import` (with `--fast-provide-root`/`--fast-provide-wait`)

To enable this, refactored commands to use `CoreAPI`, which is reusable layer shared between commands (cli/rpc) and client/rpc (remote rpc client library for go):
- add ProvideStats() to RoutingAPI interface and implementation
- add Import() to APIDagService interface and implementation
- commands delegate to CoreAPI (provide.go, dag/import.go)

We shoul've done that when we added original commands / flags, making sure things end up in CoreAPI to work with `client/rpc`, but we do this very rarely so we forgot. This PR cleans this up.