### PR TITLE
fix: inlude symlinks in scanning for init scripts

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -50,6 +50,6 @@ else
   unset IPFS_SWARM_KEY_FILE
 fi
 
-find /container-init.d -maxdepth 1 -type f -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run
+find /container-init.d -maxdepth 1 \( -type f -o -type l \) -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run
 
 exec ipfs "$@"


### PR DESCRIPTION
When the `/container-init.d` directory is mounted from a ConfigMap in k8s, the file type of init script could be a symbolic link not a regular file.

Steps to reproduce:

Create init file

```bash
mkdir ipfs-container-init-d
echo "ipfs config Routing.Type dhtserver" > ipfs-container-init-d/01_init.sh
```

Create this kustomization.yaml file:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
configMapGenerator:
- name: ipfs-container-init-d
  files:
    - ipfs-container-init-d/01_init.sh
resources:
- k8s.yaml
```

Create a StatefulSet with the secret volume mount:

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ipfs
spec:
  selector:
    matchLabels:
      app: ipfs
  replicas: 1
  template:
    metadata:
      labels:
        app: ipfs
    spec:
      containers:
      - name: kubo
        image: ipfs/kubo:v0.38.2  # https://github.com/ipfs/kubo/releases/tag/v0.38.2
        ports:
        - containerPort: 4001
          protocol: TCP
        - containerPort: 4001
          protocol: UDP
        - containerPort: 5001
        - containerPort: 8080
        volumeMounts:
        - name: ipfs-container-init-d
          mountPath: /container-init.d
      volumes:
      - name: ipfs-container-init-d
        configMap:
          name: ipfs-container-init-d
```

Apply with `kubectl apply -k .`

Using `kubectl logs` observe the init script is NOT loaded unless this fix is applied.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
