### PR TITLE
refactor: replace context.WithCancel with t.Context

### DIFF
--- a/core/commands/files_test.go
+++ b/core/commands/files_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -12,8 +11,7 @@ import (
 )
 
 func TestFilesCp_DagCborNodeFails(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	cmdCtx, err := coremock.MockCmdsCtx()
 	require.NoError(t, err)

--- a/core/commands/get_test.go
+++ b/core/commands/get_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -52,8 +51,7 @@ func TestGetOutputPath(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%s-%d", t.Name(), i), func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			req, err := cmds.NewRequest(ctx, []string{}, tc.opts, tc.args, nil, GetCmd)
 			if err != nil {

--- a/core/coreapi/test/path_test.go
+++ b/core/coreapi/test/path_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestPathUnixFSHAMTPartial(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Create a node
 	apis, err := NodeProvider{}.MakeAPISwarm(t, ctx, true, true, 1)

--- a/core/coreiface/tests/block.go
+++ b/core/coreiface/tests/block.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"strings"
 	"testing"
@@ -55,8 +54,7 @@ func (tp *TestSuite) TestBlock(t *testing.T) {
 
 // when no opts are passed, produced CID has 'raw' codec
 func (tp *TestSuite) TestBlockPut(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -75,8 +73,7 @@ func (tp *TestSuite) TestBlockPut(t *testing.T) {
 // Format is deprecated, it used invalid codec names.
 // Confirm 'cbor' gets fixed to 'dag-cbor'
 func (tp *TestSuite) TestBlockPutFormatDagCbor(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -95,8 +92,7 @@ func (tp *TestSuite) TestBlockPutFormatDagCbor(t *testing.T) {
 // Format is deprecated, it used invalid codec names.
 // Confirm 'protobuf' got fixed to 'dag-pb'
 func (tp *TestSuite) TestBlockPutFormatDagPb(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -115,8 +111,7 @@ func (tp *TestSuite) TestBlockPutFormatDagPb(t *testing.T) {
 // Format is deprecated, it used invalid codec names.
 // Confirm fake codec 'v0' got fixed to CIDv0 (with implicit dag-pb codec)
 func (tp *TestSuite) TestBlockPutFormatV0(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -133,8 +128,7 @@ func (tp *TestSuite) TestBlockPutFormatV0(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBlockPutCidCodecDagCbor(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -151,8 +145,7 @@ func (tp *TestSuite) TestBlockPutCidCodecDagCbor(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBlockPutCidCodecDagPb(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -169,8 +162,7 @@ func (tp *TestSuite) TestBlockPutCidCodecDagPb(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBlockPutHash(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -192,8 +184,7 @@ func (tp *TestSuite) TestBlockPutHash(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBlockGet(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -230,8 +221,7 @@ func (tp *TestSuite) TestBlockGet(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBlockRm(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -284,8 +274,7 @@ func (tp *TestSuite) TestBlockRm(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBlockStat(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -311,8 +300,7 @@ func (tp *TestSuite) TestBlockStat(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBlockPin(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/core/coreiface/tests/dag.go
+++ b/core/coreiface/tests/dag.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math"
 	"strings"
 	"testing"
@@ -38,8 +37,7 @@ var treeExpected = map[string]struct{}{
 }
 
 func (tp *TestSuite) TestPut(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -61,8 +59,7 @@ func (tp *TestSuite) TestPut(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPutWithHash(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -84,8 +81,7 @@ func (tp *TestSuite) TestPutWithHash(t *testing.T) {
 }
 
 func (tp *TestSuite) TestDagPath(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -132,8 +128,7 @@ func (tp *TestSuite) TestDagPath(t *testing.T) {
 }
 
 func (tp *TestSuite) TestTree(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -167,8 +162,7 @@ func (tp *TestSuite) TestTree(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBatch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/core/coreiface/tests/key.go
+++ b/core/coreiface/tests/key.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -43,8 +42,7 @@ func (tp *TestSuite) TestKey(t *testing.T) {
 }
 
 func (tp *TestSuite) TestListSelf(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -60,8 +58,7 @@ func (tp *TestSuite) TestListSelf(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRenameSelf(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -74,8 +71,7 @@ func (tp *TestSuite) TestRenameSelf(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRemoveSelf(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -85,8 +81,7 @@ func (tp *TestSuite) TestRemoveSelf(t *testing.T) {
 }
 
 func (tp *TestSuite) TestGenerate(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -113,8 +108,7 @@ func verifyIPNSPath(t *testing.T, p string) {
 }
 
 func (tp *TestSuite) TestGenerateSize(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -129,8 +123,7 @@ func (tp *TestSuite) TestGenerateSize(t *testing.T) {
 func (tp *TestSuite) TestGenerateType(t *testing.T) {
 	t.Skip("disabled until libp2p/specs#111 is fixed")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -143,8 +136,7 @@ func (tp *TestSuite) TestGenerateType(t *testing.T) {
 }
 
 func (tp *TestSuite) TestGenerateExisting(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -160,8 +152,7 @@ func (tp *TestSuite) TestGenerateExisting(t *testing.T) {
 }
 
 func (tp *TestSuite) TestList(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -180,8 +171,7 @@ func (tp *TestSuite) TestList(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRename(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -196,8 +186,7 @@ func (tp *TestSuite) TestRename(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRenameToSelf(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -210,8 +199,7 @@ func (tp *TestSuite) TestRenameToSelf(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRenameToSelfForce(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -224,8 +212,7 @@ func (tp *TestSuite) TestRenameToSelfForce(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRenameOverwriteNoForce(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -241,8 +228,7 @@ func (tp *TestSuite) TestRenameOverwriteNoForce(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRenameOverwrite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -261,8 +247,7 @@ func (tp *TestSuite) TestRenameOverwrite(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRenameSameNameNoForce(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -277,8 +262,7 @@ func (tp *TestSuite) TestRenameSameNameNoForce(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRenameSameName(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -293,8 +277,7 @@ func (tp *TestSuite) TestRenameSameName(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRemove(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -317,8 +300,7 @@ func (tp *TestSuite) TestRemove(t *testing.T) {
 }
 
 func (tp *TestSuite) TestSign(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -348,8 +330,7 @@ func (tp *TestSuite) TestVerify(t *testing.T) {
 	t.Run("Verify Own Key", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		api, err := tp.makeAPI(t, ctx)
 		require.NoError(t, err)
@@ -370,8 +351,7 @@ func (tp *TestSuite) TestVerify(t *testing.T) {
 	t.Run("Verify Self", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		api, err := tp.makeAPIWithIdentityAndOffline(t, ctx)
 		require.NoError(t, err)
@@ -390,8 +370,7 @@ func (tp *TestSuite) TestVerify(t *testing.T) {
 		t.Parallel()
 
 		// Spin some node and get signature out.
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		api, err := tp.makeAPI(t, ctx)
 		require.NoError(t, err)
@@ -411,8 +390,7 @@ func (tp *TestSuite) TestVerify(t *testing.T) {
 			{"Prefixed IPNS Path", ipns.NameFromPeer(key.ID()).AsPath().String()},
 		} {
 			t.Run(testCase[0], func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+				ctx := t.Context()
 
 				// Spin new node.
 				api, err := tp.makeAPI(t, ctx)

--- a/core/coreiface/tests/name.go
+++ b/core/coreiface/tests/name.go
@@ -35,8 +35,7 @@ func addTestObject(ctx context.Context, api coreiface.CoreAPI) (path.Path, error
 }
 
 func (tp *TestSuite) TestPublishResolve(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	init := func() (coreiface.CoreAPI, path.Path) {
 		apis, err := tp.MakeAPISwarm(t, ctx, 5)
 		require.NoError(t, err)
@@ -120,8 +119,7 @@ func (tp *TestSuite) TestPublishResolve(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBasicPublishResolveKey(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	apis, err := tp.MakeAPISwarm(t, ctx, 5)
 	require.NoError(t, err)
 	api := apis[0]
@@ -142,8 +140,7 @@ func (tp *TestSuite) TestBasicPublishResolveKey(t *testing.T) {
 }
 
 func (tp *TestSuite) TestBasicPublishResolveTimeout(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	apis, err := tp.MakeAPISwarm(t, ctx, 5)
 	require.NoError(t, err)
 	api := apis[0]

--- a/core/coreiface/tests/object.go
+++ b/core/coreiface/tests/object.go
@@ -45,8 +45,7 @@ func putDagPbNode(t *testing.T, ctx context.Context, api iface.CoreAPI, data str
 }
 
 func (tp *TestSuite) TestObjectAddLink(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
 
@@ -72,8 +71,7 @@ func (tp *TestSuite) TestObjectAddLink(t *testing.T) {
 }
 
 func (tp *TestSuite) TestObjectAddLinkCreate(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
 
@@ -102,8 +100,7 @@ func (tp *TestSuite) TestObjectAddLinkCreate(t *testing.T) {
 }
 
 func (tp *TestSuite) TestObjectRmLink(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
 
@@ -127,8 +124,7 @@ func (tp *TestSuite) TestObjectRmLink(t *testing.T) {
 }
 
 func (tp *TestSuite) TestDiffTest(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
 

--- a/core/coreiface/tests/path.go
+++ b/core/coreiface/tests/path.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -32,8 +31,7 @@ func (tp *TestSuite) TestPath(t *testing.T) {
 }
 
 func (tp *TestSuite) TestMutablePath(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -49,8 +47,7 @@ func (tp *TestSuite) TestMutablePath(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPathRemainder(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -71,8 +68,7 @@ func (tp *TestSuite) TestPathRemainder(t *testing.T) {
 }
 
 func (tp *TestSuite) TestEmptyPathRemainder(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -90,8 +86,7 @@ func (tp *TestSuite) TestEmptyPathRemainder(t *testing.T) {
 }
 
 func (tp *TestSuite) TestInvalidPathRemainder(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
@@ -112,8 +107,7 @@ func (tp *TestSuite) TestInvalidPathRemainder(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPathRoot(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)

--- a/core/coreiface/tests/pin.go
+++ b/core/coreiface/tests/pin.go
@@ -33,8 +33,7 @@ func (tp *TestSuite) TestPin(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPinAdd(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -52,8 +51,7 @@ func (tp *TestSuite) TestPinAdd(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPinSimple(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -104,8 +102,7 @@ func (tp *TestSuite) TestPinSimple(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPinRecursive(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -251,8 +248,7 @@ func (tp *TestSuite) TestPinRecursive(t *testing.T) {
 
 // TestPinLsIndirect verifies that indirect nodes are listed by pin ls even if a parent node is directly pinned
 func (tp *TestSuite) TestPinLsIndirect(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -284,8 +280,7 @@ func (tp *TestSuite) TestPinLsPrecedence(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPinLsPredenceRecursiveIndirect(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -308,8 +303,7 @@ func (tp *TestSuite) TestPinLsPredenceRecursiveIndirect(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPinLsPrecedenceDirectIndirect(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -332,8 +326,7 @@ func (tp *TestSuite) TestPinLsPrecedenceDirectIndirect(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPinLsPrecedenceRecursiveDirect(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -368,8 +361,7 @@ func (tp *TestSuite) TestPinLsPrecedenceRecursiveDirect(t *testing.T) {
 }
 
 func (tp *TestSuite) TestPinIsPinned(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -583,8 +575,7 @@ func assertIsPinned(t *testing.T, ctx context.Context, api iface.CoreAPI, p path
 }
 
 func (tp *TestSuite) TestPinNames(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	require.NoError(t, err)
 

--- a/core/coreiface/tests/routing.go
+++ b/core/coreiface/tests/routing.go
@@ -41,8 +41,7 @@ func (tp *TestSuite) testRoutingPublishKey(t *testing.T, ctx context.Context, ap
 }
 
 func (tp *TestSuite) TestRoutingGet(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	apis, err := tp.MakeAPISwarm(t, ctx, 2)
 	require.NoError(t, err)
@@ -63,8 +62,7 @@ func (tp *TestSuite) TestRoutingGet(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRoutingPut(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	apis, err := tp.MakeAPISwarm(t, ctx, 2)
 	require.NoError(t, err)
 
@@ -81,8 +79,7 @@ func (tp *TestSuite) TestRoutingPut(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRoutingPutOffline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// init a swarm & publish an IPNS entry to get a valid payload
 	apis, err := tp.MakeAPISwarm(t, ctx, 2)
@@ -104,8 +101,7 @@ func (tp *TestSuite) TestRoutingPutOffline(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRoutingFindPeer(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	apis, err := tp.MakeAPISwarm(t, ctx, 5)
 	if err != nil {
 		t.Fatal(err)
@@ -159,8 +155,7 @@ func (tp *TestSuite) TestRoutingFindPeer(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRoutingFindProviders(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	apis, err := tp.MakeAPISwarm(t, ctx, 5)
 	if err != nil {
 		t.Fatal(err)
@@ -198,8 +193,7 @@ func (tp *TestSuite) TestRoutingFindProviders(t *testing.T) {
 }
 
 func (tp *TestSuite) TestRoutingProvide(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	apis, err := tp.MakeAPISwarm(t, ctx, 5)
 	if err != nil {
 		t.Fatal(err)

--- a/core/coreiface/tests/unixfs.go
+++ b/core/coreiface/tests/unixfs.go
@@ -98,8 +98,7 @@ func wrapped(names ...string) func(f files.Node) files.Node {
 }
 
 func (tp *TestSuite) TestAdd(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -532,8 +531,7 @@ func (tp *TestSuite) TestAdd(t *testing.T) {
 }
 
 func (tp *TestSuite) TestAddPinned(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -558,8 +556,7 @@ func (tp *TestSuite) TestAddPinned(t *testing.T) {
 }
 
 func (tp *TestSuite) TestAddHashOnly(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -584,8 +581,7 @@ func (tp *TestSuite) TestAddHashOnly(t *testing.T) {
 }
 
 func (tp *TestSuite) TestGetEmptyFile(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -617,8 +613,7 @@ func (tp *TestSuite) TestGetEmptyFile(t *testing.T) {
 }
 
 func (tp *TestSuite) TestGetDir(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -645,8 +640,7 @@ func (tp *TestSuite) TestGetDir(t *testing.T) {
 }
 
 func (tp *TestSuite) TestGetNonUnixfs(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -665,8 +659,7 @@ func (tp *TestSuite) TestGetNonUnixfs(t *testing.T) {
 }
 
 func (tp *TestSuite) TestLs(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -769,8 +762,7 @@ func (tp *TestSuite) TestEntriesExpired(t *testing.T) {
 }
 
 func (tp *TestSuite) TestLsEmptyDir(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -802,8 +794,7 @@ func (tp *TestSuite) TestLsEmptyDir(t *testing.T) {
 
 // TODO(lgierth) this should test properly, with len(links) > 0
 func (tp *TestSuite) TestLsNonUnixfs(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -870,8 +861,7 @@ func (f *closeTestF) Close() error {
 }
 
 func (tp *TestSuite) TestAddCloses(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -908,8 +898,7 @@ func (tp *TestSuite) TestAddCloses(t *testing.T) {
 }
 
 func (tp *TestSuite) TestGetSeek(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -1014,8 +1003,7 @@ func (tp *TestSuite) TestGetSeek(t *testing.T) {
 }
 
 func (tp *TestSuite) TestGetReadAt(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	api, err := tp.makeAPI(t, ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/core/node/libp2p/rcmgr_logging_test.go
+++ b/core/node/libp2p/rcmgr_logging_test.go
@@ -1,7 +1,6 @@
 package libp2p
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -42,8 +41,7 @@ func TestLoggingResourceManager(t *testing.T) {
 	}
 
 	// run the logger which will write an entry for those errors
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	lrm.start(ctx)
 	clock.Add(3 * time.Second)
 

--- a/repo/fsrepo/migrations/fetch_test.go
+++ b/repo/fsrepo/migrations/fetch_test.go
@@ -3,7 +3,6 @@ package migrations
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,8 +41,7 @@ func TestGetDistPath(t *testing.T) {
 }
 
 func TestHttpFetch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	fetcher := NewHttpFetcher(testIpfsDist, testServer.URL, "", 0)
 
@@ -79,8 +77,7 @@ func TestHttpFetch(t *testing.T) {
 func TestFetchBinary(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	fetcher := NewHttpFetcher(testIpfsDist, testServer.URL, "", 0)
 
@@ -162,8 +159,7 @@ func TestFetchBinary(t *testing.T) {
 }
 
 func TestMultiFetcher(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	badFetcher := NewHttpFetcher("", "bad-url", "", 0)
 	fetcher := NewHttpFetcher(testIpfsDist, testServer.URL, "", 0)

--- a/repo/fsrepo/migrations/ipfsfetcher/ipfsfetcher_test.go
+++ b/repo/fsrepo/migrations/ipfsfetcher/ipfsfetcher_test.go
@@ -3,7 +3,6 @@ package ipfsfetcher
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,8 +22,7 @@ func init() {
 func TestIpfsFetcher(t *testing.T) {
 	skipUnlessEpic(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	fetcher := NewIpfsFetcher("", 0, nil, "")
 	defer fetcher.Close()
@@ -58,8 +56,7 @@ func TestIpfsFetcher(t *testing.T) {
 }
 
 func TestInitIpfsFetcher(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	f := NewIpfsFetcher("", 0, nil, "")
 	defer f.Close()

--- a/repo/fsrepo/migrations/migrations_test.go
+++ b/repo/fsrepo/migrations/migrations_test.go
@@ -15,8 +15,7 @@ import (
 func TestFindMigrations(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	migs, bins, err := findMigrations(ctx, 0, 5)
 	if err != nil {
@@ -60,8 +59,7 @@ func TestFindMigrations(t *testing.T) {
 func TestFindMigrationsReverse(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	migs, bins, err := findMigrations(ctx, 5, 0)
 	if err != nil {
@@ -103,8 +101,7 @@ func TestFindMigrationsReverse(t *testing.T) {
 }
 
 func TestFetchMigrations(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	fetcher := NewHttpFetcher(testIpfsDist, testServer.URL, "", 0)
 
@@ -156,8 +153,7 @@ func TestRunMigrations(t *testing.T) {
 
 	fetcher := NewHttpFetcher(testIpfsDist, testServer.URL, "", 0)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	targetVer := 9
 

--- a/repo/fsrepo/migrations/versions_test.go
+++ b/repo/fsrepo/migrations/versions_test.go
@@ -1,7 +1,6 @@
 package migrations
 
 import (
-	"context"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -10,8 +9,7 @@ import (
 const testDist = "go-ipfs"
 
 func TestDistVersions(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	fetcher := NewHttpFetcher(testIpfsDist, testServer.URL, "", 0)
 
@@ -27,8 +25,7 @@ func TestDistVersions(t *testing.T) {
 }
 
 func TestLatestDistVersion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	fetcher := NewHttpFetcher(testIpfsDist, testServer.URL, "", 0)
 

--- a/test/integration/bitswap_wo_routing_test.go
+++ b/test/integration/bitswap_wo_routing_test.go
@@ -2,7 +2,6 @@ package integrationtest
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -14,8 +13,7 @@ import (
 )
 
 func TestBitswapWithoutRouting(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	const numPeers = 4
 
 	// create network


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

The addition of the Context method to Go's testing.T provides significant improvements for writing concurrent tests. It allows better management of goroutines, ensuring they properly exit and preventing issues like deadlocks and unfinished processes.

By using Context, errors and cancellations can be handled more effectively, making tests more robust and easier to reason about. This change also enables tighter integration between tests and the application code, especially for systems that span multiple concurrent components. Overall, it simplifies test code and enhances test stability and maintainability.

More info: [golang/go#18368](https://github.com/golang/go/issues/18368)