### PR TITLE
docs: note sweep+accelerated DHT client limitation

### DIFF
--- a/docs/changelogs/v0.39.md
+++ b/docs/changelogs/v0.39.md
@@ -46,6 +46,7 @@ The Amino DHT Sweep provider system, introduced as experimental in v0.38, is now
 - If you were using the default settings, you'll automatically get the sweep provider
 - To opt out and return to legacy behavior: `ipfs config --json Provide.DHT.SweepEnabled false`
 - Providers with medium to large datasets may need to adjust defaults; see [Capacity Planning](https://github.com/ipfs/kubo/blob/master/docs/provide-stats.md#capacity-planning)
+- When `Routing.AcceleratedDHTClient` is enabled, full sweep efficiency may not be available yet; consider disabling the accelerated client as sweep is sufficient for most workloads. See [caveat 4](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingaccelerateddhtclient).
 
 **New features available with sweep mode:**
 
@@ -77,7 +78,7 @@ ipfs dag import file.car              # Same for CAR imports
 
 **Configuration:** Set defaults via `Import.FastProvideRoot` (default: `true`) and `Import.FastProvideWait` (default: `false`). See `ipfs add --help` and `ipfs dag import --help` for more details and examples.
 
-This optimization works best with the sweep provider and accelerated DHT client, where provide operations are significantly faster. Automatically skipped when DHT is unavailable (e.g., `Routing.Type=none` or delegated-only configurations).
+Fast root CID provide is automatically skipped when DHT routing is unavailable (e.g., `Routing.Type=none` or delegated-only configurations).
 
 #### ⏯️ Provider state persists across restarts
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -2640,6 +2640,10 @@ prepared. This means operations like searching the DHT for particular peers or c
    - You can see if the DHT has been initially populated by running `ipfs stats dht`
 3. Currently, the accelerated DHT client is not compatible with LAN-based DHTs and will not perform operations against
 them
+4. (⚠️ 0.39 limitation) When used with [`Provide.DHT.SweepEnabled`](#providedhtsweepenabled), the sweep provider may
+fail to estimate DHT size during the accelerated client's network crawl, resulting in all CIDs grouped into a
+single region. Content still gets reprovided, but without sweep efficiency gains. Consider disabling the
+accelerated client when using sweep mode.
 
 Default: `false`
 

--- a/docs/provide-stats.md
+++ b/docs/provide-stats.md
@@ -221,6 +221,11 @@ reprovide duration gives CIDs/min/worker.
 
 Number of regions reprovided in the last cycle.
 
+> [!NOTE]
+> (⚠️ 0.39 limitation) If this shows 1 region while using
+> [`Routing.AcceleratedDHTClient`](./config.md#routingaccelerateddhtclient), sweep mode lost
+> efficiency gains. Consider disabling the accelerated client. See [caveat 4](./config.md#routingaccelerateddhtclient).
+
 ## Workers
 
 ### Active workers
@@ -278,6 +283,9 @@ To check if your provide system has sufficient capacity:
 - High active workers with growing reprovide queue: Need more workers or network connectivity is limiting throughput
 - Low active workers with non-empty reprovide queue: Workers may be waiting for network or DHT operations
 - Check [Reachable peers](#reachable-peers) to diagnose network connectivity issues
+- (⚠️ 0.39 limitation) If [Regions scheduled](#regions-scheduled) shows 1 while using
+  [`Routing.AcceleratedDHTClient`](./config.md#routingaccelerateddhtclient), consider disabling
+  the accelerated client to restore sweep efficiency. See [caveat 4](./config.md#routingaccelerateddhtclient).
 
 ## See Also
 


### PR DESCRIPTION
document known 0.39 limitation where sweep provider may fail to estimate DHT size when accelerated client is still crawling the network, resulting in single-region mode without efficiency gains.

also remove accelerated client recommendation from changelog since it may mislead users into enabling both together.

cc @guillaumemichel 

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
