### PR TITLE
fix(cli): deduplicate dag stat blocks by multihash

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -377,7 +377,10 @@ var DagStatCmd = &cmds.Command{
 'ipfs dag stat' fetches a DAG and returns various statistics about it.
 Statistics include size and number of blocks.
 
-Note: This command skips duplicate blocks in reporting both size and the number of blocks
+Note: Duplicate blocks are identified by content hash (multihash) to reflect
+actual disk usage. Identical data referenced via different CIDs is counted
+once. 'dag export' uses CID-based keying and may include the same data
+multiple times if referenced by different CIDs.
 `,
 	},
 	Arguments: []cmds.Argument{

--- a/docs/changelogs/v0.40.md
+++ b/docs/changelogs/v0.40.md
@@ -11,7 +11,8 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [Routing V1 HTTP API now exposed by default](#routing-v1-http-api-now-exposed-by-default)
-  - [Track total size when adding pins](#track-total-size-when-adding-pins]
+  - [Track total size when adding pins](#track-total-size-when-adding-pins)
+  - [Fixed `ipfs dag stat` block counting](#fixed-ipfs-dag-stat-block-counting)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -31,6 +32,10 @@ Example output:
 ```
 Fetched/Processed 336 nodes (83 MB)
 ```
+
+#### Fixed `ipfs dag stat` block counting
+
+Since Kubo v0.12.0, blocks are stored by multihash, so the same data is stored only once regardless of which CID references it. The `dag stat` command now reflects actual storage by deduplicating blocks by content hash (e.g., data referenced via both CIDv0 and CIDv1 is counted once). See `ipfs dag stat --help` for more details.
 
 ### 📝 Changelog
 


### PR DESCRIPTION
This PR closes https://github.com/ipfs/kubo/issues/8794, but imo is just a formality.

In practice, unlikely this will impact anyone, DAGs with the same block being addressed multiple times with different codec is virtually never happening.

## Rationale

since Kubo v0.12.0, blocks are stored by multihash, so identical data with different CIDs (e.g., CIDv0 vs CIDv1) is stored once. dag stat now reflects actual storage by using multihash-based deduplication instead of CID-based.

updated help text to clarify deduplication behavior and note that CAR export (`dag export`) uses CID-based keying and may include duplicates. this addresses concern raised in https://github.com/ipfs/kubo/pull/8843#discussion_r840617339

added regression test for multihash deduplication.


