### PR TITLE
output stdout and stderr on example test failure

### DIFF
--- a/docs/examples/kubo-as-a-library/main_test.go
+++ b/docs/examples/kubo-as-a-library/main_test.go
@@ -9,7 +9,11 @@ import (
 func TestExample(t *testing.T) {
 	out, err := exec.Command("go", "run", "main.go").Output()
 	if err != nil {
-		t.Fatalf("running example (%v)", err)
+		var stderr string
+		if xe, ok := err.(*exec.ExitError); ok {
+			stderr = string(xe.Stderr)
+		}
+		t.Fatalf("running example (%v): %s\n%s", err, string(out), stderr)
 	}
 	if !strings.Contains(string(out), "All done!") {
 		t.Errorf("example did not run successfully")


### PR DESCRIPTION
Sometimes this test is failing in CI, so it is helpful to see why.