### PR TITLE
test: replace `go-clock` with `testing/synctest`

### DIFF
--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ipfs/kubo/core/node/helpers"
 	"github.com/ipfs/kubo/repo"
 
-	"github.com/filecoin-project/go-clock"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -112,7 +111,6 @@ filled in with autocomputed defaults.`)
 				return nil, opts, fmt.Errorf("creating libp2p resource manager: %w", err)
 			}
 			lrm := &loggingResourceManager{
-				clock:    clock.New(),
 				logger:   &logging.Logger("resourcemanager").SugaredLogger,
 				delegate: manager,
 			}

--- a/core/node/libp2p/rcmgr_logging.go
+++ b/core/node/libp2p/rcmgr_logging.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -17,7 +16,6 @@ import (
 )
 
 type loggingResourceManager struct {
-	clock       clock.Clock
 	logger      *zap.SugaredLogger
 	delegate    network.ResourceManager
 	logInterval time.Duration
@@ -42,7 +40,7 @@ func (n *loggingResourceManager) start(ctx context.Context) {
 	if logInterval == 0 {
 		logInterval = 10 * time.Second
 	}
-	ticker := n.clock.Ticker(logInterval)
+	ticker := time.NewTicker(logInterval)
 	go func() {
 		defer ticker.Stop()
 		for {

--- a/core/node/libp2p/rcmgr_logging_test.go
+++ b/core/node/libp2p/rcmgr_logging_test.go
@@ -2,9 +2,9 @@ package libp2p
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
 	"github.com/libp2p/go-libp2p/core/network"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	ma "github.com/multiformats/go-multiaddr"
@@ -14,48 +14,49 @@ import (
 )
 
 func TestLoggingResourceManager(t *testing.T) {
-	clock := clock.NewMock()
-	orig := rcmgr.DefaultLimits.AutoScale()
-	limits := orig.ToPartialLimitConfig()
-	limits.System.Conns = 1
-	limits.System.ConnsInbound = 1
-	limits.System.ConnsOutbound = 1
-	limiter := rcmgr.NewFixedLimiter(limits.Build(orig))
-	rm, err := rcmgr.NewResourceManager(limiter)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	oCore, oLogs := observer.New(zap.WarnLevel)
-	oLogger := zap.New(oCore)
-	lrm := &loggingResourceManager{
-		clock:       clock,
-		logger:      oLogger.Sugar(),
-		delegate:    rm,
-		logInterval: 1 * time.Second,
-	}
-
-	// 2 of these should result in resource limit exceeded errors and subsequent log messages
-	for i := 0; i < 3; i++ {
-		_, _ = lrm.OpenConnection(network.DirInbound, false, ma.StringCast("/ip4/127.0.0.1/tcp/1234"))
-	}
-
-	// run the logger which will write an entry for those errors
-	ctx := t.Context()
-	lrm.start(ctx)
-	clock.Add(3 * time.Second)
-
-	timer := time.NewTimer(1 * time.Second)
-	for {
-		select {
-		case <-timer.C:
-			t.Fatalf("expected logs never arrived")
-		default:
-			if oLogs.Len() == 0 {
-				continue
-			}
-			require.Equal(t, "Protected from exceeding resource limits 2 times.  libp2p message: \"system: cannot reserve inbound connection: resource limit exceeded\".", oLogs.All()[0].Message)
-			return
+	synctest.Test(t, func(t *testing.T) {
+		orig := rcmgr.DefaultLimits.AutoScale()
+		limits := orig.ToPartialLimitConfig()
+		limits.System.Conns = 1
+		limits.System.ConnsInbound = 1
+		limits.System.ConnsOutbound = 1
+		limiter := rcmgr.NewFixedLimiter(limits.Build(orig))
+		rm, err := rcmgr.NewResourceManager(limiter)
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
+		defer rm.Close()
+
+		oCore, oLogs := observer.New(zap.WarnLevel)
+		oLogger := zap.New(oCore)
+		lrm := &loggingResourceManager{
+			logger:      oLogger.Sugar(),
+			delegate:    rm,
+			logInterval: 1 * time.Second,
+		}
+
+		// 2 of these should result in resource limit exceeded errors and subsequent log messages
+		for i := 0; i < 3; i++ {
+			_, _ = lrm.OpenConnection(network.DirInbound, false, ma.StringCast("/ip4/127.0.0.1/tcp/1234"))
+		}
+
+		// run the logger which will write an entry for those errors
+		ctx := t.Context()
+		lrm.start(ctx)
+		time.Sleep(3 * time.Second)
+
+		timer := time.NewTimer(1 * time.Second)
+		for {
+			select {
+			case <-timer.C:
+				t.Fatalf("expected logs never arrived")
+			default:
+				if oLogs.Len() == 0 {
+					continue
+				}
+				require.Equal(t, "Protected from exceeding resource limits 2 times.  libp2p message: \"system: cannot reserve inbound connection: resource limit exceeded\".", oLogs.All()[0].Message)
+				return
+			}
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elgris/jsondiff v0.0.0-20160530203242-765b5c24c302
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5
-	github.com/filecoin-project/go-clock v0.1.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
@@ -126,6 +125,7 @@ require (
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/filecoin-project/go-clock v0.1.0 // indirect
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
 	github.com/gammazero/chanqueue v1.1.1 // indirect


### PR DESCRIPTION
Use `testing/synctest` instead of `go-clock` for artificial time control.