### PR TITLE
docs: improve README for first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Kubo was the first [IPFS](https://docs.ipfs.tech/concepts/what-is-ipfs/) impleme
 
 **Features:**
 
-- Runs an IPFS node as a network service (LAN and WAN DHT)
+- Runs an IPFS node as a network service (LAN [mDNS](https://github.com/libp2p/specs/blob/master/discovery/mdns.md) and WAN [Amino DHT](https://docs.ipfs.tech/concepts/glossary/#dht))
 - [Command-line interface](https://docs.ipfs.tech/reference/kubo/cli/) (`ipfs --help`)
 - [WebUI](https://github.com/ipfs/ipfs-webui/#readme) for node management
 - [HTTP Gateway](https://specs.ipfs.tech/http-gateways/) for trusted and [trustless](https://docs.ipfs.tech/reference/http/gateway/#trustless-verifiable-retrieval) content retrieval
@@ -120,7 +120,8 @@ For testing arbitrary commits and experimental patches (force push to `staging` 
 ```bash
 git clone https://github.com/ipfs/kubo.git
 cd kubo
-make install
+make build    # creates cmd/ipfs/ipfs
+make install  # installs to $GOPATH/bin/ipfs
 ```
 
 See the [Developer Guide](docs/developer-guide.md) for details, Windows instructions, and troubleshooting.


### PR DESCRIPTION
This PR cleans up README and makes  it easier to scan and find useful information for both humans and LLMs.

### Changes 

- add Quick Taste section with real CIDv1 example near top
- rewrite "What is Kubo?" with technical concepts (CIDs, DAGs, UnixFS, Bitswap)
- reorder features to follow user journey (CLI before advanced HTTP features)
- streamline install section with links to docs.ipfs.tech
- organize package managers in tables with Repology version badges
- add supply chain security warning for third-party packages
- surface important docs (metrics, debug guide, customizing)
- update maintainer info with Shipyard branding



Closes #11125
Closes #7298
Closes #5471
Closes #5087

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
