### PR TITLE
fix(ci): reduce flakiness

### DIFF
--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/ipfs/boxo v0.35.3-0.20251202220026-0842ad274a0c
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.46.0
-	github.com/multiformats/go-multiaddr v0.16.1
 )
 
 require (
@@ -137,6 +136,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
+	github.com/multiformats/go-multiaddr v0.16.1 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.4.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect

--- a/docs/examples/kubo-as-a-library/main.go
+++ b/docs/examples/kubo-as-a-library/main.go
@@ -5,17 +5,16 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/ipfs/boxo/bootstrap"
 	"github.com/ipfs/boxo/files"
 	"github.com/ipfs/boxo/path"
 	icore "github.com/ipfs/kubo/core/coreiface"
-	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core"
@@ -67,6 +66,10 @@ func createTempRepo(swarmPort int) (string, error) {
 		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1/webtransport", swarmPort),
 		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/webrtc-direct", swarmPort),
 	}
+
+	// Disable auto-bootstrap. For this example, we manually connect only the peers we need.
+	// In production, you'd typically keep the default bootstrap peers to join the network.
+	cfg.Bootstrap = []string{}
 
 	// When creating the repository, you can define custom settings on the repository, such as enabling experimental
 	// features (See experimental-features.md) or customizing the gateway endpoint.
@@ -144,40 +147,6 @@ func spawnEphemeral(ctx context.Context, swarmPort int) (icore.CoreAPI, *core.Ip
 	return api, node, err
 }
 
-func connectToPeers(ctx context.Context, ipfs icore.CoreAPI, peers []string) error {
-	var wg sync.WaitGroup
-	peerInfos := make(map[peer.ID]*peer.AddrInfo, len(peers))
-	for _, addrStr := range peers {
-		addr, err := ma.NewMultiaddr(addrStr)
-		if err != nil {
-			return err
-		}
-		pii, err := peer.AddrInfoFromP2pAddr(addr)
-		if err != nil {
-			return err
-		}
-		pi, ok := peerInfos[pii.ID]
-		if !ok {
-			pi = &peer.AddrInfo{ID: pii.ID}
-			peerInfos[pi.ID] = pi
-		}
-		pi.Addrs = append(pi.Addrs, pii.Addrs...)
-	}
-
-	wg.Add(len(peerInfos))
-	for _, peerInfo := range peerInfos {
-		go func(peerInfo *peer.AddrInfo) {
-			defer wg.Done()
-			err := ipfs.Swarm().Connect(ctx, *peerInfo)
-			if err != nil {
-				log.Printf("failed to connect to %s: %s", peerInfo.ID, err)
-			}
-		}(peerInfo)
-	}
-	wg.Wait()
-	return nil
-}
-
 func getUnixfsNode(path string) (files.Node, error) {
 	st, err := os.Stat(path)
 	if err != nil {
@@ -203,7 +172,7 @@ func main() {
 
 	fmt.Println("-- Getting an IPFS node running -- ")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	// Spawn a local peer using a temporary path, for testing purposes
@@ -224,7 +193,7 @@ func main() {
 	// Spawn a node using a temporary path, creating a temporary repo for the run
 	// Using port 4011 (different from nodeA's port 4010)
 	fmt.Println("Spawning Kubo node on a temporary repo")
-	ipfsB, _, err := spawnEphemeral(ctx, 4011)
+	ipfsB, nodeB, err := spawnEphemeral(ctx, 4011)
 	if err != nil {
 		panic(fmt.Errorf("failed to spawn ephemeral node: %s", err))
 	}
@@ -297,38 +266,25 @@ func main() {
 
 	fmt.Printf("Got directory back from IPFS (IPFS path: %s) and wrote it to %s\n", cidDirectory.String(), outputPathDirectory)
 
-	/// --- Part IV: Getting a file from the IPFS Network
+	/// --- Part IV: Getting a file from another IPFS node
 
-	fmt.Println("\n-- Going to connect to a few nodes in the Network as bootstrappers --")
+	fmt.Println("\n-- Connecting to nodeA and fetching content via bitswap --")
 
-	// Get nodeA's address so we can fetch the file we added to it
-	peerAddrs, err := ipfsA.Swarm().LocalAddrs(ctx)
-	if err != nil {
-		panic(fmt.Errorf("could not get peer addresses: %s", err))
+	// In production, you'd typically connect to bootstrap peers to join the IPFS network.
+	// autoconf.FallbackBootstrapPeers from boxo/autoconf provides well-known bootstrap peers:
+	// "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+	// "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
+	// "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+	//
+	// For this example, we only connect nodeB to nodeA to demonstrate direct bitswap.
+	// We use Bootstrap() instead of raw Swarm().Connect() because Bootstrap() properly
+	// integrates peers into the routing system and ensures bitswap learns about them.
+	fmt.Println("Bootstrapping nodeB to nodeA...")
+	nodeAPeerInfo := nodeA.Peerstore.PeerInfo(nodeA.Identity)
+	if err := nodeB.Bootstrap(bootstrap.BootstrapConfigWithPeers([]peer.AddrInfo{nodeAPeerInfo})); err != nil {
+		panic(fmt.Errorf("failed to bootstrap nodeB to nodeA: %s", err))
 	}
-	peerMa := peerAddrs[0].String() + "/p2p/" + nodeA.Identity.String()
-
-	bootstrapNodes := []string{
-		// In production, use autoconf.FallbackBootstrapPeers from boxo/autoconf
-		// which includes well-known IPFS bootstrap peers like:
-		// "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-		// "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-		// "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-
-		// You can add custom peers here. For example, another IPFS node:
-		// "/ip4/192.0.2.1/tcp/4001/p2p/QmYourPeerID...",
-		// "/ip4/192.0.2.1/udp/4001/quic-v1/p2p/QmYourPeerID...",
-
-		// nodeA's address (the peer we created above that has our test file)
-		peerMa,
-	}
-
-	fmt.Println("Connecting to peers...")
-	err = connectToPeers(ctx, ipfsB, bootstrapNodes)
-	if err != nil {
-		panic(fmt.Errorf("failed to connect to peers: %s", err))
-	}
-	fmt.Println("Connected to peers")
+	fmt.Println("nodeB is now connected to nodeA")
 
 	exampleCIDStr := peerCidFile.RootCid().String()
 

--- a/test/cli/delegated_routing_v1_http_server_test.go
+++ b/test/cli/delegated_routing_v1_http_server_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -20,11 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// swarmPeersOutput is used to parse the JSON output of 'ipfs swarm peers --enc=json'
-type swarmPeersOutput struct {
-	Peers []struct{} `json:"Peers"`
-}
 
 func TestRoutingV1Server(t *testing.T) {
 	t.Parallel()
@@ -206,11 +200,14 @@ func TestRoutingV1Server(t *testing.T) {
 				c, err := client.New(node.GatewayURL())
 				require.NoError(t, err)
 
-				// Try to get closest peers - should fail gracefully with an error
+				// Try to get closest peers - should fail gracefully with an error.
+				// Use 60-second timeout (server has 30s routing timeout).
 				testCid, err := cid.Decode("QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn")
 				require.NoError(t, err)
 
-				_, err = c.GetClosestPeers(context.Background(), testCid)
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				defer cancel()
+				_, err = c.GetClosestPeers(ctx, testCid)
 				require.Error(t, err)
 				// All these routing types should indicate DHT is not available
 				// The exact error message may vary based on implementation details
@@ -224,7 +221,7 @@ func TestRoutingV1Server(t *testing.T) {
 		}
 	})
 
-	t.Run("GetClosestPeers returns peers for self", func(t *testing.T) {
+	t.Run("GetClosestPeers returns peers", func(t *testing.T) {
 		t.Parallel()
 
 		routingTypes := []string{"auto", "autoclient", "dht", "dhtclient"}
@@ -242,47 +239,33 @@ func TestRoutingV1Server(t *testing.T) {
 				})
 				node.StartDaemon()
 
-				// Create client before waiting so we can probe DHT readiness
 				c, err := client.New(node.GatewayURL())
 				require.NoError(t, err)
 
 				// Query for closest peers to our own peer ID
 				key := peer.ToCid(node.PeerID())
 
-				// Wait for node to connect to bootstrap peers and populate WAN DHT routing table
-				minPeers := len(autoconf.FallbackBootstrapPeers)
-				require.EventuallyWithT(t, func(t *assert.CollectT) {
-					res := node.RunIPFS("swarm", "peers", "--enc=json")
-					var output swarmPeersOutput
-					err := json.Unmarshal(res.Stdout.Bytes(), &output)
-					assert.NoError(t, err)
-					peerCount := len(output.Peers)
-					// Wait until we have at least minPeers connected
-					assert.GreaterOrEqual(t, peerCount, minPeers,
-						"waiting for at least %d bootstrap peers, currently have %d", minPeers, peerCount)
-				}, 60*time.Second, time.Second)
-
-				// Wait for DHT to be ready by probing GetClosestPeers until it succeeds
-				require.EventuallyWithT(t, func(t *assert.CollectT) {
-					probeCtx, probeCancel := context.WithTimeout(context.Background(), 30*time.Second)
-					defer probeCancel()
-					probeIter, probeErr := c.GetClosestPeers(probeCtx, key)
-					if probeErr == nil {
-						probeIter.Close()
+				// Wait for WAN DHT routing table to be populated.
+				// The server has a 30-second routing timeout, so we use 60 seconds
+				// per request to allow for network latency while preventing hangs.
+				// Total wait time is 3 minutes (locally passes in under 1 minute).
+				var records []*types.PeerRecord
+				require.EventuallyWithT(t, func(ct *assert.CollectT) {
+					ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+					defer cancel()
+					resultsIter, err := c.GetClosestPeers(ctx, key)
+					if !assert.NoError(ct, err) {
+						return
 					}
-					assert.NoError(t, probeErr, "DHT should be ready to handle GetClosestPeers")
-				}, 2*time.Minute, 5*time.Second)
-
-				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-				defer cancel()
-				resultsIter, err := c.GetClosestPeers(ctx, key)
-				require.NoError(t, err)
-
-				records, err := iter.ReadAllResults(resultsIter)
-				require.NoError(t, err)
+					records, err = iter.ReadAllResults(resultsIter)
+					assert.NoError(ct, err)
+				}, 3*time.Minute, 5*time.Second)
 
 				// Verify we got some peers back from WAN DHT
-				assert.NotEmpty(t, records, "should return some peers close to own peerid")
+				require.NotEmpty(t, records, "should return peers close to own peerid")
+
+				// Per IPIP-0476, GetClosestPeers returns at most 20 peers
+				assert.LessOrEqual(t, len(records), 20, "IPIP-0476 limits GetClosestPeers to 20 peers")
 
 				// Verify structure of returned records
 				for _, record := range records {


### PR DESCRIPTION
- reduce minPeers from 7 to 2 (don't require all bootstrap peers)
- increase probe timeout from 30s to 1m
- increase overall timeout from 2m to 10m

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
