### PR TITLE
test: fix flaky ipfswatch test

### DIFF
--- a/test/cli/ipfswatch_test.go
+++ b/test/cli/ipfswatch_test.go
@@ -86,7 +86,9 @@ func TestIPFSWatch(t *testing.T) {
 
 		// Kill ipfswatch to release the repo lock
 		if result.Cmd.Process != nil {
-			_ = result.Cmd.Process.Kill()
+			if err = result.Cmd.Process.Signal(os.Interrupt); err != nil {
+				_ = result.Cmd.Process.Kill()
+			}
 			_, _ = result.Cmd.Process.Wait()
 		}
 


### PR DESCRIPTION
Gracefully shutdown the ipfs node to ensure data is saved. Forceful shutdown is done if there is an error sending the interrupt signal to the process, such as on Windows.
