### PR TITLE
feat(provider): info log AcceleratedDHTClient crawl

### DIFF
--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -54,7 +54,7 @@ const (
 	keystoreDatastorePath = "keystore"
 )
 
-var errFullRTNotReady = errors.New("fullrt: router not ready")
+var errAcceleratedDHTNotReady = errors.New("AcceleratedDHTClient: routing table not ready")
 
 // Interval between reprovide queue monitoring checks for slow reprovide alerts.
 // Used when Provide.DHT.SweepEnabled=true
@@ -346,15 +346,15 @@ func (fr *fullrtRouter) GetClosestPeers(ctx context.Context, key string) ([]peer
 	if fr.ready {
 		if !fr.Ready() {
 			fr.ready = false
-			fr.logger.Info("fullrt: waiting for network crawl to complete before providing")
-			return nil, errFullRTNotReady
+			fr.logger.Info("AcceleratedDHTClient: waiting for routing table initialization (5-10 min, depends on DHT size and network) to complete before providing")
+			return nil, errAcceleratedDHTNotReady
 		}
 	} else {
 		if fr.Ready() {
 			fr.ready = true
-			fr.logger.Info("fullrt: network crawl complete")
+			fr.logger.Info("AcceleratedDHTClient: routing table ready, providing can begin")
 		} else {
-			return nil, errFullRTNotReady
+			return nil, errAcceleratedDHTNotReady
 		}
 	}
 	return fr.FullRT.GetClosestPeers(ctx, key)


### PR DESCRIPTION
Supersedes https://github.com/libp2p/go-libp2p-kad-dht/pull/1214

Follow up to https://github.com/ipfs/kubo/pull/11137

When the accelerated DHT client is used in combination with reprovide sweep, logs at the `info` level in `dht/provider` that the network crawl is running and when it completes, so that users don't expect provides operations to start immediately. Provide operations start when the network crawl is finished.

```
2026-01-13T15:00:22.139+0100	DEBUG	dht/provider	provider/provider.go:470	Starting SweepingProvider
2026-01-13T15:00:22.139+0100	INFO	dht/provider	node/provider.go:349	fullrt: waiting for network crawl to complete before providing
[...]
Daemon is ready


ℹ️ Routing.AcceleratedDHTClient is enabled for faster content discovery
ℹ️ and DHT provides. Routing table is initializing. IPFS is ready to use,
ℹ️ but performance will improve over time as more peers are discovered

2026-01-13T15:05:04.443+0100	INFO	dht/provider	node/provider.go:355	fullrt: network crawl complete
2026-01-13T15:05:04.452+0100	DEBUG	dht/provider	provider/provider.go:722	prefix len approximation is 7
```