### PR TITLE
chore: add gomod dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      ipfs-ecosystem:
+        patterns:
+          - "github.com/ipfs/*"
+          - "github.com/ipfs-shipyard/*"
+          - "github.com/ipshipyard/*"
+          - "github.com/multiformats/*"
+          - "github.com/ipld/*"
+      libp2p-ecosystem:
+        patterns:
+          - "github.com/libp2p/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"


### PR DESCRIPTION
experimental setup to surface missed ecosystem updates via monthly PRs

groups ipfs, libp2p, multiformats, ipld, and golang.org/x dependencies to reduce noise while ensuring visibility into available updates

iiuc likely wont engage most of the time, because we update manually, but this is just a precaution, so there is a PR we will see and triage before making a release if we missed anything
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
