### PR TITLE
chore(deps): ignore datastore backends in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      # Updated via go-ds-* wrappers in ipfs-ecosystem group
+      - dependency-name: "github.com/cockroachdb/pebble*"
+      - dependency-name: "github.com/syndtr/goleveldb"
+      - dependency-name: "github.com/dgraph-io/badger*"
     groups:
       ipfs-ecosystem:
         patterns:


### PR DESCRIPTION
i think pebble, leveldb, and badger should be updated via `go-ds-*` wrappers to ensure compatibility

or we keep them, but are aware that we should update go-ds-* first?
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
