### PR TITLE
refactor(ci): add caching to ipfs-webui interop tests

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,3 +1,17 @@
+# Interoperability Tests
+#
+# This workflow ensures Kubo remains compatible with the broader IPFS ecosystem.
+# It builds Kubo from source, then runs:
+#
+# 1. helia-interop: Tests compatibility with Helia (JavaScript IPFS implementation)
+#    using Playwright-based tests from @helia/interop package.
+#
+# 2. ipfs-webui: Runs E2E tests from ipfs/ipfs-webui repository to verify
+#    the web interface works correctly with the locally built Kubo binary.
+#
+# Both jobs use caching to speed up repeated runs (npm dependencies, Playwright
+# browsers, and webui build artifacts).
+
 name: Interop
 
 on:


### PR DESCRIPTION
cache node_modules, Playwright browsers, and test build output to speed up repeated CI runs. also use node version from ipfs-webui/.tool-versions instead of hardcoding, and upload test artifacts on failure.

this aims to avoid vasting time and resources, and making ci finish faster

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
