### PR TITLE
chore: replace libp2p.io URL with Internet Archive

### DIFF
--- a/docs/changelogs/v0.18.md
+++ b/docs/changelogs/v0.18.md
@@ -265,11 +265,11 @@ since Kubo 0.13, but in this release it will also include the size column.
 #### QUIC and WebTransport
 
 ##### WebTransport enabled by default
-[WebTransport](https://docs.libp2p.io/concepts/transports/webtransport/) is a new libp2p transport that [was introduced in v0.16](https://github.com/ipfs/kubo/blob/master/docs/changelogs/v0.16.md#-webtransport-new-experimental-transport) that is based on top of QUIC and HTTP3.
+[WebTransport](https://web.archive.org/web/20260128152314/https://docs.libp2p.io/concepts/transports/webtransport/) is a new libp2p transport that [was introduced in v0.16](https://github.com/ipfs/kubo/blob/master/docs/changelogs/v0.16.md#-webtransport-new-experimental-transport) that is based on top of QUIC and HTTP3.
 
 This allows browser-based nodes to contact Kubo nodes, so now instead of just serving requests for other system-level application nodes, you can also serve requests directly to a node running inside a browser page.
 
-For the full story see [connectivity.libp2p.io](https://connectivity.libp2p.io/).
+For the full story see [connectivity.libp2p.io](https://web.archive.org/web/20251118040510/https://connectivity.libp2p.io/).
 
 ##### QUIC and WebTransport share a single port
 WebTransport is enabled by default in part because [go-libp2p now supports running WebTransport and QUIC transports on the same QUIC listener](https://github.com/libp2p/go-libp2p/issues/1759).  No additional port needs to be opened.

--- a/docs/changelogs/v0.24.md
+++ b/docs/changelogs/v0.24.md
@@ -78,7 +78,7 @@ introduced in [`go-libp2p`](https://github.com/libp2p/go-libp2p/releases/tag/v0.
 > allows browser nodes to connect to go-libp2p nodes directly,
 > without any configuration (e.g. TLS certificates) needed on the go-libp2p
 > side. This is useful for browser nodes that aren’t able to use
-> [WebTransport](https://blog.libp2p.io/2022-12-19-libp2p-webtransport/).
+> [WebTransport](https://web.archive.org/web/20260107053250/https://blog.libp2p.io/2022-12-19-libp2p-webtransport/).
 
 The `/webrtc-direct` transport is disabled by default in Kubo 0.24,
 and not ready for production use yet, but we plan to enable it in a future release.

--- a/docs/changelogs/v0.34.md
+++ b/docs/changelogs/v0.34.md
@@ -50,7 +50,7 @@ AutoTLS will remain disabled under the following conditions:
 
 To troubleshoot, use `GOLOG_LOG_LEVEL="error,autotls=info`.
 
-For more details, check out the [`AutoTLS` configuration documentation](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotls) or dive deeper with [AutoTLS libp2p blog post](https://blog.libp2p.io/autotls/).
+For more details, check out the [`AutoTLS` configuration documentation](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotls) or dive deeper with [AutoTLS libp2p blog post](https://web.archive.org/web/20260112031855/https://blog.libp2p.io/autotls/).
 
 #### New WebUI features
 

--- a/docs/changelogs/v0.40.md
+++ b/docs/changelogs/v0.40.md
@@ -134,7 +134,7 @@ Previously, provide operations could start before the Accelerated DHT Client dis
 
 #### 🌐 No unnecessary DNS lookups for AutoTLS addresses
 
-Kubo no longer makes DNS queries for [AutoTLS](https://blog.libp2p.io/autotls/) addresses like `1-2-3-4.peerid.libp2p.direct`. Since the IP is encoded in the hostname (`1-2-3-4` means `1.2.3.4`), Kubo extracts it locally. This reduces load on the public good DNS servers at `libp2p.direct` run by [Shipyard](https://ipshipyard.com), reserving them for web browsers which lack direct DNS access and must rely on the browser's resolver.
+Kubo no longer makes DNS queries for [AutoTLS](https://web.archive.org/web/20260112031855/https://blog.libp2p.io/autotls/) addresses like `1-2-3-4.peerid.libp2p.direct`. Since the IP is encoded in the hostname (`1-2-3-4` means `1.2.3.4`), Kubo extracts it locally. This reduces load on the public good DNS servers at `libp2p.direct` run by [Shipyard](https://ipshipyard.com), reserving them for web browsers which lack direct DNS access and must rely on the browser's resolver.
 
 To disable, set [`AutoTLS.SkipDNSLookup`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotlsskipdnslookup) to `false`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -717,7 +717,7 @@ Type: `flag`
 
 ## `AutoTLS`
 
-The [AutoTLS](https://blog.libp2p.io/autotls/) feature enables publicly reachable Kubo nodes (those dialable from the public
+The [AutoTLS](https://web.archive.org/web/20260112031855/https://blog.libp2p.io/autotls/) feature enables publicly reachable Kubo nodes (those dialable from the public
 internet) to automatically obtain a wildcard TLS certificate for a DNS name
 unique to their PeerID at `*.[PeerID].libp2p.direct`. This enables direct
 libp2p connections and retrieval of IPFS content from browsers [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
@@ -725,7 +725,7 @@ using transports such as [Secure WebSockets](https://github.com/libp2p/specs/blo
 without requiring user to do any manual domain registration and certificate configuration.
 
 Under the hood, [p2p-forge] client uses public utility service at `libp2p.direct` as an [ACME DNS-01 Challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)
-broker enabling peer to obtain a wildcard TLS certificate tied to public key of their [PeerID](https://docs.libp2p.io/concepts/fundamentals/peers/#peer-id).
+broker enabling peer to obtain a wildcard TLS certificate tied to public key of their [PeerID](https://web.archive.org/web/20251112181025/https://docs.libp2p.io/concepts/fundamentals/peers/#peer-id).
 
 By default, the certificates are requested from Let's Encrypt. Origin and rationale for this project can be found in [community.letsencrypt.org discussion](https://community.letsencrypt.org/t/feedback-on-raising-certificates-per-registered-domain-to-enable-peer-to-peer-networking/223003).
 
@@ -2423,7 +2423,7 @@ Replaced with [`Provide.DHT.MaxWorkers`](#providedhtmaxworkers).
 
 ## `Pubsub`
 
-Pubsub configures Kubo's opt-in, opinionated [libp2p pubsub](https://docs.libp2p.io/concepts/pubsub/overview/) instance.
+Pubsub configures Kubo's opt-in, opinionated [libp2p pubsub](https://web.archive.org/web/20260116065034/https://docs.libp2p.io/concepts/pubsub/overview/) instance.
 To enable, set `Pubsub.Enabled` to `true`.
 
 **EXPERIMENTAL:** This is an opt-in feature. Its primary use case is
@@ -3357,7 +3357,7 @@ NATs.
 
 See also:
 
-- Docs: [Libp2p Circuit Relay](https://docs.libp2p.io/concepts/circuit-relay/)
+- Docs: [Libp2p Circuit Relay](https://web.archive.org/web/20260128152445/https://docs.libp2p.io/concepts/nat/circuit-relay/)
 - [`Swarm.RelayClient.Enabled`](#swarmrelayclientenabled) for getting a public
 - `/p2p-circuit` address when behind a firewall.
 - [`Swarm.EnableHolePunching`](#swarmenableholepunching) for direct connection upgrade through relay
@@ -3405,7 +3405,7 @@ is a transport protocol that provides another way for browsers to
 connect to the rest of the libp2p network. WebRTC Direct allows for browser
 nodes to connect to other nodes without special configuration, such as TLS
 certificates. This can be useful for browser nodes that do not yet support
-[WebTransport](https://blog.libp2p.io/2022-12-19-libp2p-webtransport/),
+[WebTransport](https://web.archive.org/web/20260107053250/https://blog.libp2p.io/2022-12-19-libp2p-webtransport/),
 which is still relatively new and has [known issues](https://github.com/libp2p/js-libp2p/issues/2572).
 
 Enabling this transport allows Kubo node to act on `/udp/4001/webrtc-direct`


### PR DESCRIPTION
swap to last working snapshots until libp2p project fixes their websites

Right now its either broken due to Fleek shutting down: https://web.archive.org/web/20260201232813/https://docs.libp2p.io/concepts/pubsub/overview/ or URLs changed by being moved to new place at:
https://web.archive.org/web/20260204171903/https://libp2p.io/guides/circuit-relay/

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
