### PR TITLE
docs(changelog): add highlight for libp2p AllAddrs behavior change

### DIFF
--- a/docs/changelogs/v0.40.md
+++ b/docs/changelogs/v0.40.md
@@ -28,6 +28,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
   - [🔖 New `ipfs name get|put` commands](#-new-ipfs-name-getput-commands)
   - [📋 Long listing format for `ipfs ls`](#-long-listing-format-for-ipfs-ls)
   - [🖥️ WebUI Improvements](#-webui-improvements)
+  - [📢 libp2p announces all interface addresses](#-libp2p-announces-all-interface-addresses)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
@@ -246,6 +247,21 @@ New screen under Diagnostics that shows the health of DHT Provide operations. Yo
 The Inspect button now resolves `/ipfs/` and `/ipns/` paths to their final CID before opening the IPLD Explorer. The Explore form also accepts `ipfs://` and `ipns://` protocol URLs. Previously, these would show a blank screen or an infinite spinner. Path resolution errors now also show better error pages:
 
 > ![Better path handling in Files](https://github.com/user-attachments/assets/3494835b-0b93-4990-9971-078273671928)
+
+#### 📢 libp2p announces all interface addresses
+
+go-libp2p [v0.47.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.47.0) includes a rewritten routing library ([`go-netroute`](https://github.com/libp2p/go-netroute/pull/64)) that fixes interop with VPN and WireGuard/Tailscale setups. A side effect: when listening on `0.0.0.0`, libp2p now returns addresses from all network interfaces instead of just the primary one ([go-libp2p#3460](https://github.com/libp2p/go-libp2p/issues/3460)).
+
+This means easier connectivity and less manual configuration for most desktop, VPN, and self-hosted users. However, if you don't run with the [`server` profile](https://github.com/ipfs/kubo/blob/master/docs/config.md#server-profile) and have an empty [`Addresses.NoAnnounce`](https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesnoannounce), your node may now announce internal addresses (e.g. Docker bridge `172.17.0.0/16` or Tailscale `100.64.0.0/10`) to the DHT. In the default setup, AutoNAT will probe and mark unreachable ones as offline and they won't be listed, but you can also filter them out explicitly.
+
+To check what your node announces and filter out unwanted ranges:
+
+```console
+$ ipfs swarm addrs local
+$ ipfs config --json Addresses.NoAnnounce '["/ip4/172.17.0.0/ipcidr/16"]'
+```
+
+The [`server` profile](https://github.com/ipfs/kubo/blob/master/docs/config.md#server-profile) already [filters common private ranges](https://github.com/ipfs/kubo/blob/master/config/profile.go#L24-L43) via `Addresses.NoAnnounce`.
 
 #### 📦️ Dependency updates
 


### PR DESCRIPTION
go-libp2p v0.47.0 [^1] returns addresses from all interfaces when listening on 0.0.0.0, improving VPN/WireGuard/Tailscale connectivity. note impact for users without the server profile.

[^1]: https://github.com/libp2p/go-libp2p/releases/tag/v0.47.0

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
