### PR TITLE
fix: update webui to v4.11.1

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -12,11 +12,12 @@ import (
 )
 
 // WebUI version confirmed to work with this Kubo version
-const WebUIPath = "/ipfs/bafybeidfgbcqy435sdbhhejifdxq4o64tlsezajc272zpyxcsmz47uyc64" // v4.11.0
+const WebUIPath = "/ipfs/bafybeiddnr2jz65byk67sjt6jsu6g7tueddr7odhzzpzli3rgudlbnc6iq" // v4.11.1
 
 // WebUIPaths is a list of all past webUI paths.
 var WebUIPaths = []string{
 	WebUIPath,
+	"/ipfs/bafybeidfgbcqy435sdbhhejifdxq4o64tlsezajc272zpyxcsmz47uyc64", // v4.11.0
 	"/ipfs/bafybeidsjptidvb6wf6benznq2pxgnt5iyksgtecpmjoimlmswhtx2u5ua", // v4.10.0
 	"/ipfs/bafybeicg7e6o2eszkfdzxg5233gmuip2a7kfzoloh7voyvt2r6ivdet54u", // v4.9.1
 	"/ipfs/bafybeifplj2s3yegn7ko7tdnwpoxa4c5uaqnk2ajnw5geqm34slcj6b6mu", // v4.8.0

--- a/docs/changelogs/v0.40.md
+++ b/docs/changelogs/v0.40.md
@@ -342,7 +342,7 @@ You should see lower memory usage and reduced GC pauses thanks to the new Green 
 - update `go-ipld-prime` to [v0.22.0](https://github.com/ipld/go-ipld-prime/releases/tag/v0.22.0)
 - update `boxo` to [v0.37.0](https://github.com/ipfs/boxo/releases/tag/v0.37.0) (incl. [v0.36.0](https://github.com/ipfs/boxo/releases/tag/v0.36.0))
 - update `go-libp2p-kad-dht` to [v0.38.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.38.0) (includes [v0.37.1](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.37.1), [v0.37.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.37.0))
-- update `ipfs-webui` to [v4.11.0](https://github.com/ipfs/ipfs-webui/releases/tag/v4.11.0)
+- update `ipfs-webui` to [v4.11.1](https://github.com/ipfs/ipfs-webui/releases/tag/v4.11.1) (incl. [v4.11.0](https://github.com/ipfs/ipfs-webui/releases/tag/v4.11.0))
 - update `gateway-conformance` tests to [v0.10](https://github.com/ipfs/gateway-conformance/releases/tag/v0.10.0) (incl. [v0.9](https://github.com/ipfs/gateway-conformance/releases/tag/v0.9.0))
 
 ### 📝 Changelog


### PR DESCRIPTION
https://github.com/ipfs/ipfs-webui/releases/tag/v4.11.1

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
