### PR TITLE
test(gateway-conformance): run with DNSLink -> IPNS test (v0.11)

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.10
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.11
         with:
           output: fixtures
 
@@ -93,7 +93,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.10
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.11
         with:
           gateway-url: http://127.0.0.1:8080
           subdomain-url: http://localhost:8080
@@ -127,7 +127,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.10
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.11
         with:
           output: fixtures
 
@@ -199,7 +199,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.10
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.11
         with:
           gateway-url: http://127.0.0.1:8092
           args: --specs "trustless-gateway,-trustless-ipns-gateway" -skip 'TestGatewayCar/GET_response_for_application/vnd.ipld.car/Header_Content-Length'

--- a/docs/changelogs/v0.41.md
+++ b/docs/changelogs/v0.41.md
@@ -17,6 +17,10 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 
 ### 🔦 Highlights
 
+#### 📦️ Dependency updates
+
+- update `gateway-conformance` tests to [v0.11](https://github.com/ipfs/gateway-conformance/releases/tag/v0.11.0)
+
 ### 📝 Changelog
 
 ### 👨‍👩‍👧‍👦 Contributors


### PR DESCRIPTION
point gateway-conformance v0.11 which adds a conformance test for DNSLink TXT records pointing to `/ipns/<key>` instead of `/ipfs/<cid>`.

- https://github.com/ipfs/gateway-conformance/pull/272
- https://github.com/ipfs/gateway-conformance/releases/tag/v0.11.0

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
