### PR TITLE
fix: drop high-cardinality server.address from http_server metrics

### DIFF
--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -146,7 +146,9 @@ func commandsOption(cctx oldcmds.Context, command *cmds.Command) ServeOption {
 			cmdHandler = withAuthSecrets(authorizations, cmdHandler)
 		}
 
-		cmdHandler = otelhttp.NewHandler(cmdHandler, "corehttp.cmdsHandler")
+		cmdHandler = otelhttp.NewHandler(cmdHandler, "corehttp.cmdsHandler",
+			otelhttp.WithMetricAttributesFn(staticServerDomainAttrFn("api")),
+		)
 		mux.Handle(APIPath+"/", cmdHandler)
 		return mux, nil
 	}

--- a/docs/changelogs/v0.40.md
+++ b/docs/changelogs/v0.40.md
@@ -30,6 +30,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
   - [🔖 New `ipfs name get|put` commands](#-new-ipfs-name-getput-commands)
   - [📋 Long listing format for `ipfs ls`](#-long-listing-format-for-ipfs-ls)
   - [🖥️ WebUI Improvements](#-webui-improvements)
+  - [📉 Fixed Prometheus metrics bloat on popular subdomain gateways](#-fixed-prometheus-metrics-bloat-on-popular-subdomain-gateways)
   - [📢 libp2p announces all interface addresses](#-libp2p-announces-all-interface-addresses)
   - [🗑️ Badger v1 datastore slated for removal this year](#-badger-v1-datastore-slated-for-removal-this-year)
   - [🐹 Go 1.26](#-go-126)
@@ -299,6 +300,17 @@ New screen under Diagnostics that shows the health of DHT Provide operations. Yo
 The Inspect button now resolves `/ipfs/` and `/ipns/` paths to their final CID before opening the IPLD Explorer. The Explore form also accepts `ipfs://` and `ipns://` protocol URLs. Previously, these would show a blank screen or an infinite spinner. Path resolution errors now also show better error pages:
 
 > ![Better path handling in Files](https://github.com/user-attachments/assets/3494835b-0b93-4990-9971-078273671928)
+
+#### 📉 Fixed Prometheus metrics bloat on popular subdomain gateways
+
+Most Kubo users are unaffected by this change. It matters if you run Kubo as a public subdomain gateway (with [`Gateway.PublicGateways`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaypublicgateways) and `UseSubdomains: true`), where the `otelhttp` instrumentation was including the raw `Host` header as the `server_address` metric label. Every unique hostname (e.g., each `CID.ipfs.dweb.link`) created a separate time series, resulting in millions of metric lines, multi-gigabyte `/debug/metrics/prometheus` responses, and Prometheus scrape timeouts.
+
+**What changed:**
+
+- The unbounded `server_address` label is now dropped from all `http_server_*` metrics via an OTel SDK View.
+- All handlers add a `server_domain` label instead. Gateway handlers group by matching `Gateway.PublicGateways` suffix (e.g., `dweb.link`, `ipfs.io`), with `localhost`, `loopback`, or `other` for unmatched hosts. The RPC API and Libp2p Gateway handlers use fixed values (`api`, `libp2p`).
+
+If you use [Rainbow](https://github.com/ipfs/rainbow) for your public gateway (recommended), this issue never applied to you -- Rainbow uses its own low-cardinality HTTP metrics.
 
 #### 📢 libp2p announces all interface addresses
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -110,6 +110,13 @@ Additional HTTP instrumentation for all handlers (Gateway, API commands, etc.):
 
 These metrics are automatically added to Gateway handlers, Hostname Gateway, Libp2p Gateway, and API command handlers.
 
+> [!NOTE]
+> The `server_address` label from `otelhttp` is dropped via an OTel SDK View to prevent cardinality explosion on subdomain gateways (where each unique `Host` header creates a new time series). All handlers include a `server_domain` label instead:
+>
+> - Gateway and Hostname Gateway handlers group requests by their matching [`Gateway.PublicGateways`](config.md#gatewaypublicgateways) domain suffix (e.g., `dweb.link`, `ipfs.io`). Unmatched hosts are labeled `localhost`, `loopback`, or `other`.
+> - The RPC API handler uses `api`.
+> - The Libp2p Gateway handler uses `libp2p`.
+
 ## OpenTelemetry Metadata
 
 Kubo uses Prometheus for metrics collection for historical reasons, but OpenTelemetry metrics are automatically exposed through the same Prometheus endpoint. These metadata metrics provide context about the instrumentation:


### PR DESCRIPTION
This PR removes `server_address` from `http_server*` metrics, and adds safer `server_domain` that does not baloon cardinality on subdomain gateways

### Explainer 

`otelhttp` derives server.address from the `Host` header, which creates a unique time series for every subdomain hostname on public gateways (e.g. each `CID.ipfs.dweb.link`). this caused multi-gigabyte prometheus responses and scrape timeouts on our staging test environment which received a chunk of production traffic from `ipfs.io`.

- `cmd/ipfs/kubo/daemon.go`: add OTel SDK View that drops server.address from all http.server.* metrics at the MeterProvider level
- `core/corehttp/gateway.go`: add server.domain attribute to Gateway and HostnameGateway handlers, grouping by Gateway.PublicGateways suffix (e.g. "dweb.link"), with "localhost", "loopback", or "other" fallbacks
- `core/corehttp/commands.go`: add server.domain="api" to RPC handler
- `core/corehttp/gateway.g`o: add server.domain="libp2p" to libp2p handler
- `docs/changelogs/v0.40.md`: add changelog highlight
- `docs/metrics.md`: document `server_domain` label and `server_address` drop

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
