### PR TITLE
fix: prevent otel exemplar rune overflow in http metrics

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -44,7 +44,6 @@ import (
 	prometheus "github.com/prometheus/client_golang/prometheus"
 	promauto "github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	promexporter "go.opentelemetry.io/otel/exporters/prometheus"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
@@ -225,20 +224,6 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		log.Errorf("Creating prometheus exporter for OpenTelemetry failed: %s (some metrics will be missing from /debug/metrics/prometheus)\n", err.Error())
 	} else {
 		meterProvider := sdkmetric.NewMeterProvider(
-			// Drop high-cardinality server.address attribute from http.server.*
-			// metrics. otelhttp derives it from the Host header, which causes
-			// cardinality explosion on subdomain gateways where each
-			// CID.ipfs.example.com hostname is a unique label value.
-			// Per-domain visibility is provided by the lower-cardinality
-			// server.domain attribute added in core/corehttp/gateway.go.
-			sdkmetric.WithView(sdkmetric.NewView(
-				sdkmetric.Instrument{Name: "http.server.*"},
-				sdkmetric.Stream{
-					AttributeFilter: attribute.NewDenyKeysFilter(
-						attribute.Key("server.address"),
-					),
-				},
-			)),
 			sdkmetric.WithReader(exporter),
 		)
 		otel.SetMeterProvider(meterProvider)

--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -147,7 +147,7 @@ func commandsOption(cctx oldcmds.Context, command *cmds.Command) ServeOption {
 		}
 
 		cmdHandler = otelhttp.NewHandler(cmdHandler, "corehttp.cmdsHandler",
-			otelhttp.WithMetricAttributesFn(staticServerDomainAttrFn("api")),
+			otelhttp.WithServerName("api"),
 		)
 		mux.Handle(APIPath+"/", cmdHandler)
 		return mux, nil

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -8,8 +8,6 @@ import (
 	"maps"
 	"net"
 	"net/http"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/ipfs/boxo/blockservice"
@@ -27,7 +25,6 @@ import (
 	"github.com/ipfs/kubo/core/node"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 func GatewayOption(paths ...string) ServeOption {
@@ -44,11 +41,9 @@ func GatewayOption(paths ...string) ServeOption {
 
 		handler := gateway.NewHandler(config, backend)
 		handler = gateway.NewHeaders(headers).ApplyCors().Wrap(handler)
-		var otelOpts []otelhttp.Option
-		if fn := newServerDomainAttrFn(n); fn != nil {
-			otelOpts = append(otelOpts, otelhttp.WithMetricAttributesFn(fn))
-		}
-		handler = otelhttp.NewHandler(handler, "Gateway", otelOpts...)
+		handler = otelhttp.NewHandler(handler, "Gateway",
+			otelhttp.WithServerName("gateway"),
+		)
 
 		for _, p := range paths {
 			mux.Handle(p+"/", handler)
@@ -75,11 +70,9 @@ func HostnameOption() ServeOption {
 		var handler http.Handler
 		handler = gateway.NewHostnameHandler(config, backend, childMux)
 		handler = gateway.NewHeaders(headers).ApplyCors().Wrap(handler)
-		var otelOpts []otelhttp.Option
-		if fn := newServerDomainAttrFn(n); fn != nil {
-			otelOpts = append(otelOpts, otelhttp.WithMetricAttributesFn(fn))
-		}
-		handler = otelhttp.NewHandler(handler, "HostnameGateway", otelOpts...)
+		handler = otelhttp.NewHandler(handler, "HostnameGateway",
+			otelhttp.WithServerName("gateway"),
+		)
 
 		mux.Handle("/", handler)
 		return childMux, nil
@@ -132,7 +125,7 @@ func Libp2pGatewayOption() ServeOption {
 
 		handler := gateway.NewHandler(gwConfig, &offlineGatewayErrWrapper{gwimpl: backend})
 		handler = otelhttp.NewHandler(handler, "Libp2p-Gateway",
-			otelhttp.WithMetricAttributesFn(staticServerDomainAttrFn("libp2p")),
+			otelhttp.WithServerName("libp2p"),
 		)
 
 		mux.Handle("/ipfs/", handler)
@@ -264,95 +257,6 @@ func (o *offlineGatewayErrWrapper) GetDNSLinkRecord(ctx context.Context, s strin
 var _ gateway.IPFSBackend = (*offlineGatewayErrWrapper)(nil)
 
 var defaultPaths = []string{"/ipfs/", "/ipns/", "/p2p/"}
-
-// serverDomainAttrKey is the OTel attribute key for the logical server domain.
-// It replaces the high-cardinality server.address attribute (dropped by the
-// View in cmd/ipfs/kubo/daemon.go) with a bounded set of values: configured
-// Gateway.PublicGateways suffixes, "localhost", "loopback", "api", "libp2p",
-// or "other".
-var serverDomainAttrKey = attribute.Key("server.domain")
-
-// staticServerDomainAttrFn returns a MetricAttributesFn that always returns
-// a fixed server.domain value. Use for handlers where the domain is known
-// statically (e.g. "api", "libp2p") to keep the label set consistent across
-// all http_server_* metrics.
-func staticServerDomainAttrFn(domain string) func(*http.Request) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{serverDomainAttrKey.String(domain)}
-	return func(*http.Request) []attribute.KeyValue { return attrs }
-}
-
-// newServerDomainAttrFn returns an otelhttp.WithMetricAttributesFn callback
-// that adds a server.domain attribute grouping requests by their matching
-// Gateway.PublicGateways hostname suffix (e.g. "dweb.link", "ipfs.io").
-// Requests that don't match any configured gateway get "other".
-//
-// All return values are pre-allocated at setup time so the per-request
-// closure is zero-allocation.
-func newServerDomainAttrFn(n *core.IpfsNode) func(*http.Request) []attribute.KeyValue {
-	cfg, err := n.Repo.Config()
-	if err != nil {
-		return nil
-	}
-
-	// Collect non-nil gateway domain suffixes, sorted longest-first
-	// so more-specific suffixes match before shorter ones.
-	// Strip ports from keys to match boxo's fallback behavior
-	// (boxo tries exact match with port, then strips port and retries).
-	seen := make(map[string]struct{}, len(cfg.Gateway.PublicGateways))
-	suffixes := make([]string, 0, len(cfg.Gateway.PublicGateways))
-	for hostname, gw := range cfg.Gateway.PublicGateways {
-		if gw == nil {
-			continue
-		}
-		if h, _, err := net.SplitHostPort(hostname); err == nil {
-			hostname = h
-		}
-		if _, ok := seen[hostname]; ok {
-			continue
-		}
-		seen[hostname] = struct{}{}
-		suffixes = append(suffixes, hostname)
-	}
-	slices.SortFunc(suffixes, func(a, b string) int {
-		return len(b) - len(a)
-	})
-
-	// Pre-allocate attribute slices so the per-request closure only returns
-	// existing slices and does not allocate.
-	suffixAttrs := make([][]attribute.KeyValue, len(suffixes))
-	for i, s := range suffixes {
-		suffixAttrs[i] = []attribute.KeyValue{serverDomainAttrKey.String(s)}
-	}
-	localhostAttr := []attribute.KeyValue{serverDomainAttrKey.String("localhost")}
-	loopbackAttr := []attribute.KeyValue{serverDomainAttrKey.String("loopback")}
-	otherAttr := []attribute.KeyValue{serverDomainAttrKey.String("other")}
-
-	return func(r *http.Request) []attribute.KeyValue {
-		host := r.Host
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = h
-		}
-
-		// Check localhost/loopback before iterating suffixes.
-		// "localhost" is an implicit default gateway (defaultKnownGateways)
-		// not present in cfg.Gateway.PublicGateways, so it won't appear
-		// in suffixes.
-		if host == "localhost" || strings.HasSuffix(host, ".localhost") {
-			return localhostAttr
-		}
-		if strings.HasPrefix(host, "127.") || host == "::1" {
-			return loopbackAttr
-		}
-
-		for i, suffix := range suffixes {
-			if strings.HasSuffix(host, suffix) {
-				return suffixAttrs[i]
-			}
-		}
-
-		return otherAttr
-	}
-}
 
 var subdomainGatewaySpec = &gateway.PublicGateway{
 	Paths:         defaultPaths,

--- a/docs/changelogs/v0.40.md
+++ b/docs/changelogs/v0.40.md
@@ -307,8 +307,7 @@ Most Kubo users are unaffected by this change. It matters if you run Kubo as a p
 
 **What changed:**
 
-- The unbounded `server_address` label is now dropped from all `http_server_*` metrics via an OTel SDK View.
-- All handlers add a `server_domain` label instead. Gateway handlers group by matching `Gateway.PublicGateways` suffix (e.g., `dweb.link`, `ipfs.io`), with `localhost`, `loopback`, or `other` for unmatched hosts. The RPC API and Libp2p Gateway handlers use fixed values (`api`, `libp2p`).
+- The `server_address` label in all `http_server_*` metrics is set to a fixed value per handler (`gateway`, `api`, or `libp2p`) via `otelhttp.WithServerName`, replacing the raw `Host` header value that caused the cardinality explosion.
 
 If you use [Rainbow](https://github.com/ipfs/rainbow) for your public gateway (recommended), this issue never applied to you -- Rainbow uses its own low-cardinality HTTP metrics.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -111,11 +111,7 @@ Additional HTTP instrumentation for all handlers (Gateway, API commands, etc.):
 These metrics are automatically added to Gateway handlers, Hostname Gateway, Libp2p Gateway, and API command handlers.
 
 > [!NOTE]
-> The `server_address` label from `otelhttp` is dropped via an OTel SDK View to prevent cardinality explosion on subdomain gateways (where each unique `Host` header creates a new time series). All handlers include a `server_domain` label instead:
->
-> - Gateway and Hostname Gateway handlers group requests by their matching [`Gateway.PublicGateways`](config.md#gatewaypublicgateways) domain suffix (e.g., `dweb.link`, `ipfs.io`). Unmatched hosts are labeled `localhost`, `loopback`, or `other`.
-> - The RPC API handler uses `api`.
-> - The Libp2p Gateway handler uses `libp2p`.
+> The `server_address` label is set to a fixed value per handler via `otelhttp.WithServerName` to prevent cardinality explosion on subdomain gateways (where each unique `Host` header would create a new time series). Values are `gateway` (Gateway and Hostname Gateway), `api` (RPC API), and `libp2p` (Libp2p Gateway).
 
 ## OpenTelemetry Metadata
 


### PR DESCRIPTION
#11208 dropped `server.address` via an otel SDK View, but the SDK STILL passes View-dropped attributes into exemplars as `FilteredAttributes`. 

CID subdomain hostnames (~85 runes for key+value) push exemplar labels past the Prometheus 128-rune limit, causing per-scrape log spam on kubo staging box 02:

```
Feb 25 00:49:25 kubo-staging-us-east-02 ipfs[1839418]: 2026-02-25T00:49:25.942Z        INFO        exemplar labels have 151 runes, exceeding the limit of 128
Feb 25 00:49:25 kubo-staging-us-east-02 ipfs[1839418]: 2026-02-25T00:49:25.942Z        INFO        exemplar labels have 151 runes, exceeding the limit of 128
Feb 25 00:49:25 kubo-staging-us-east-02 ipfs[1839418]: 2026-02-25T00:49:25.942Z        INFO        exemplar labels have 151 runes, exceeding the limit of 128
Feb 25 00:49:25 kubo-staging-us-east-02 ipfs[1839418]: 2026-02-25T00:49:25.942Z        INFO        exemplar labels have 151 runes, exceeding the limit of 128
Feb 25 00:49:25 kubo-staging-us-east-02 ipfs[1839418]: 2026-02-25T00:49:25.942Z
....
```


This PR goes with simpler static approach: replace the View+`server.domain` with static `otelhttp.WithServerName`, which sets `server.address` to a fixed short value at the source. Nothing leaks into exemplars because the attribute is never dropped by a View.

- `cmd/ipfs/kubo/daemon.go`: remove `WithView` and attribute import
- `core/corehttp/gateway.go`: remove `server.domain` logic, use WithServerName("gateway") and `WithServerName("libp2p")`
- `core/corehttp/commands.go`: use `WithServerName("api")`
- `docs/metrics.md`, `docs/changelogs/v0.40.md`: update accordingly

