### PR TITLE
fix(windows): revert update to Go 1.26

### DIFF
--- a/config/autoconf.go
+++ b/config/autoconf.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"maps"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 
 	"github.com/ipfs/boxo/autoconf"
@@ -70,7 +70,7 @@ func selectRandomResolver(resolvers []string) string {
 	if len(resolvers) == 0 {
 		return ""
 	}
-	return resolvers[rand.Intn(len(resolvers))]
+	return resolvers[rand.IntN(len(resolvers))]
 }
 
 // DNSResolversWithAutoConf returns DNS resolvers with "auto" values replaced by autoconf values

--- a/core/commands/name/name.go
+++ b/core/commands/name/name.go
@@ -234,7 +234,7 @@ Passing --verify will verify signature against provided public key.
 			}
 
 			if out.Entry.ValidityType != nil {
-				fmt.Fprintf(tw, "Validity Type:\t%q\n", *out.Entry.ValidityType)
+				fmt.Fprintf(tw, "Validity Type:\t%d\n", *out.Entry.ValidityType)
 			}
 
 			if out.Entry.Validity != nil {

--- a/core/commands/provide.go
+++ b/core/commands/provide.go
@@ -351,8 +351,7 @@ NOTES:
 			}
 			sectionTitle := func(col int, title string) {
 				if !brief && showHeadings {
-					//nolint:govet // dynamic format string is intentional
-					formatLine(col, title+":")
+					formatLine(col, "%s:", title)
 				}
 			}
 

--- a/core/corehttp/p2p_proxy.go
+++ b/core/corehttp/p2p_proxy.go
@@ -35,8 +35,13 @@ func P2PProxyOption() ServeOption {
 			}
 
 			rt := p2phttp.NewTransport(ipfsNode.PeerHost, p2phttp.ProtocolOption(parsedRequest.name))
-			proxy := httputil.NewSingleHostReverseProxy(target)
-			proxy.Transport = rt
+			proxy := &httputil.ReverseProxy{
+				Transport: rt,
+				Rewrite: func(r *httputil.ProxyRequest) {
+					r.SetURL(target)
+					r.SetXForwarded()
+				},
+			}
 			proxy.ServeHTTP(w, request)
 		})
 		return mux, nil

--- a/docs/changelogs/v0.40.md
+++ b/docs/changelogs/v0.40.md
@@ -5,6 +5,7 @@
 This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 
 - [v0.40.0](#v0400)
+- [v0.40.1](#v0401)
 
 ## v0.40.0
 
@@ -35,6 +36,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
   - [📉 Fixed Prometheus metrics bloat on popular subdomain gateways](#-fixed-prometheus-metrics-bloat-on-popular-subdomain-gateways)
   - [📢 libp2p announces all interface addresses](#-libp2p-announces-all-interface-addresses)
   - [🗑️ Badger v1 datastore slated for removal this year](#-badger-v1-datastore-slated-for-removal-this-year)
+  - [🐹 Go 1.26](#-go-126)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
@@ -334,6 +336,14 @@ The `badgerds` datastore (based on badger 1.x) is slated for removal. Badger v1 
 
 See the [`badgerds` profile documentation](https://github.com/ipfs/kubo/blob/master/docs/config.md#badgerds-profile) for migration guidance, and [#11186](https://github.com/ipfs/kubo/issues/11186) for background.
 
+#### 🐹 Go 1.26
+
+This release is built with [Go 1.26](https://go.dev/doc/go1.26).
+
+You should see lower memory usage and reduced GC pauses thanks to the new Green Tea garbage collector (10-40% less GC overhead). Reading block data and API responses is faster due to `io.ReadAll` improvements (~2x faster, ~50% less memory). On 64-bit platforms, heap base address randomization adds a layer of security hardening.
+
+> **Note:** [v0.40.1](#v0401) downgrades to Go 1.25 due to a Windows stability issue. If you run Kubo on Linux or macOS, staying on v0.40.0 is fine and you benefit from Go 1.26's GC improvements.
+
 #### 📦️ Dependency updates
 
 - update `go-libp2p` to [v0.47.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.47.0) (incl. [v0.46.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.46.0))
@@ -613,3 +623,22 @@ See the [`badgerds` profile documentation](https://github.com/ipfs/kubo/blob/mas
 | [@willscott](https://github.com/willscott) | 1 | +1/-1 | 1 |
 | [@lbarrettanderson](https://github.com/lbarrettanderson) | 1 | +1/-1 | 1 |
 | [@filipremb](https://github.com/filipremb) | 1 | +1/-1 | 1 |
+
+## v0.40.1
+
+### 🔦 Highlights
+
+#### Windows stability fix
+
+If you run Kubo on Windows, v0.40.0 can crash after running for a while. The daemon starts fine and works normally at first, but eventually hits a memory corruption in Go's network I/O layer and dies. This is likely caused by an upstream Go 1.26 regression in overlapped I/O handling that has known issues ([go#77142](https://github.com/golang/go/issues/77142), [#11214](https://github.com/ipfs/kubo/issues/11214)).
+
+This patch release downgrades the Go toolchain from 1.26 to 1.25, which does not have this bug. If you are running Kubo on Windows, upgrade to v0.40.1. We will switch back to Go 1.26.x once the upstream fix lands.
+
+### 📝 Changelog
+
+<details><summary>Full Changelog v0.40.1</summary>
+
+- github.com/ipfs/kubo:
+  - chore: downgrade to Go 1.25 to fix Windows crash ([ipfs/kubo#11215](https://github.com/ipfs/kubo/pull/11215))
+
+</details>

--- a/test/cli/gateway_test.go
+++ b/test/cli/gateway_test.go
@@ -215,13 +215,13 @@ func TestGateway(t *testing.T) {
 	t.Run("GET /webui returns 301 or 302", func(t *testing.T) {
 		t.Parallel()
 		resp := node.APIClient().DisableRedirects().Get("/webui")
-		assert.Contains(t, []int{302, 301}, resp.StatusCode)
+		assert.Contains(t, []int{302, 301, 307, 308}, resp.StatusCode)
 	})
 
 	t.Run("GET /webui/ returns 301 or 302", func(t *testing.T) {
 		t.Parallel()
 		resp := node.APIClient().DisableRedirects().Get("/webui/")
-		assert.Contains(t, []int{302, 301}, resp.StatusCode)
+		assert.Contains(t, []int{302, 301, 307, 308}, resp.StatusCode)
 	})
 
 	t.Run("GET /webui/ returns user-specified headers", func(t *testing.T) {


### PR DESCRIPTION
This reverts commit 36c29c55f02fc5bb22b0e3c4e08911d96905ad38.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Allows us to downgrade Go in order to handle what seem to be Go 1.26.0 issues on Windows associated with #11214 