### PR TITLE
fix: resolve addresses from host for HTTP delegated routing

### DIFF
--- a/core/node/libp2p/routingopt.go
+++ b/core/node/libp2p/routingopt.go
@@ -288,9 +288,14 @@ func ConstructDelegatedRouting(routers config.Routers, methods config.Methods, p
 				Datastore:      args.Datastore,
 				Context:        args.Ctx,
 			},
+				var strAddrs []string
+				for _, addr := range httpAddrs {
+					strAddrs = append(strAddrs, addr.String())
+				}
+
 			&irouting.ExtraHTTPParams{
 				PeerID:        peerID,
-				Addrs:         httpAddrs,
+				Addrs:         strAddrs,
 				PrivKeyB64:    privKey,
 				HTTPRetrieval: httpRetrieval,
 			},


### PR DESCRIPTION
## Summary

When using custom HTTP delegated routing (`Routing.Type=custom`), the raw listen
addresses from config (e.g., `/ip4/0.0.0.0/tcp/24199`) were sent to HTTP routers
instead of resolved interface addresses.

## Problem

The `httpAddrsFromConfig` function returned raw config addresses without resolving
`0.0.0.0` to actual interface addresses. This caused provider records sent to HTTP
routers to contain unusable `0.0.0.0` addresses, forcing clients to fall back to
DHT `FIND_PEER` queries and defeating the purpose of HTTP routing.

Meanwhile, `ipfs id` correctly resolves these addresses using `host.InfoFromHost()`.

## Solution

Replace `httpAddrsFromConfig(addrs)` with `peer.AddrInfoToP2pAddrs(host.InfoFromHost(args.Host))`
to obtain resolved addresses from the libp2p host, matching the behavior of `ipfs id`.

## Testing

This fix addresses the issue described in https://github.com/ipfs/kubo/issues/11213 where
HTTP Routing V1 provider records contain raw `0.0.0.0` listen addresses instead of
resolved interface addresses.

## Changes

- `core/node/libp2p/routingopt.go`: Modified `ConstructDelegatedRouting` to use
  host-derived addresses instead of config-derived addresses.
