### PR TITLE
feat(cmd): add 'ipfs cid inspect' command

### DIFF
--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -511,7 +511,7 @@ Use --enc=json for machine-readable output same as the HTTP RPC API.
 			Code:   dmh.Code,
 			Name:   hashName,
 			Length: dmh.Length,
-			Digest: "0x" + strings.ToUpper(hex.EncodeToString(dmh.Digest)),
+			Digest: hex.EncodeToString(dmh.Digest),
 		}
 
 		// CIDv0: only possible with dag-pb + sha2-256-256

--- a/docs/changelogs/v0.41.md
+++ b/docs/changelogs/v0.41.md
@@ -11,6 +11,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [🗑️ Faster Provide Queue Disk Reclamation](#-faster-provide-queue-disk-reclamation)
+  - [✨ New `ipfs cid inspect` command](#-new-ipfs-cid-inspect-command)
   - [🖥️ WebUI Improvements](#-webui-improvements)
   - [🔧 Correct provider addresses for custom HTTP routing](#-correct-provider-addresses-for-custom-http-routing)
   - [📦️ Dependency updates](#-dependency-updates)
@@ -41,6 +42,25 @@ shared datastore automatically.
 To learn more, see [kubo#11096](https://github.com/ipfs/kubo/issues/11096),
 [kubo#11198](https://github.com/ipfs/kubo/pull/11198), and
 [go-libp2p-kad-dht#1233](https://github.com/libp2p/go-libp2p-kad-dht/pull/1233).
+
+#### ✨ New `ipfs cid inspect` command
+
+New subcommand for breaking down a CID into its components. Works offline, supports `--enc=json`.
+
+```console
+$ ipfs cid inspect bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+CID:        bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+Version:    1
+Multibase:  base32 (b)
+Multicodec: dag-pb (0x70)
+Multihash:  sha2-256 (0x12)
+  Length:   32 bytes
+  Digest:   c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a
+CIDv0:      QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
+CIDv1:      bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+```
+
+See `ipfs cid --help` for all CID-related commands.
 
 #### 🖥️ WebUI Improvements
 

--- a/docs/changelogs/v0.42.md
+++ b/docs/changelogs/v0.42.md
@@ -10,32 +10,12 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
-  - [✨ New `ipfs cid inspect` command](#-new-ipfs-cid-inspect-command)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
 ### Overview
 
 ### 🔦 Highlights
-
-#### ✨ New `ipfs cid inspect` command
-
-New subcommand for breaking down a CID into its components. Works offline, supports `--enc=json`.
-
-```console
-$ ipfs cid inspect bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
-CID:        bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
-Version:    1
-Multibase:  base32 (b)
-Multicodec: dag-pb (0x70)
-Multihash:  sha2-256 (0x12)
-  Length:   32 bytes
-  Digest:   0xC3C4733EC8AFFD06CF9E9FF50FFC6BCD2EC85A6170004BB709669C31DE94391A
-CIDv0:      QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
-CIDv1:      bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
-```
-
-Thanks to @jolo18 for this quality of life improvement ([#11241](https://github.com/ipfs/kubo/pull/11241)).
 
 ### 📝 Changelog
 

--- a/test/cli/cid_test.go
+++ b/test/cli/cid_test.go
@@ -40,7 +40,7 @@ func testCidInspect(t *testing.T) {
 		assert.Contains(t, out, "Multicodec: dag-pb (0x70, implicit)")
 		assert.Contains(t, out, "Multihash:  sha2-256 (0x12, implicit)")
 		assert.Contains(t, out, "  Length:   32 bytes")
-		assert.Contains(t, out, "  Digest:   0xC3C4733EC8AFFD06CF9E9FF50FFC6BCD2EC85A6170004BB709669C31DE94391A")
+		assert.Contains(t, out, "  Digest:   c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a")
 		assert.Contains(t, out, "CIDv0:      QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR")
 		assert.Contains(t, out, "CIDv1:      bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 	})
@@ -55,7 +55,7 @@ func testCidInspect(t *testing.T) {
 		assert.Contains(t, out, "Multicodec: dag-pb (0x70)")
 		assert.Contains(t, out, "Multihash:  sha2-256 (0x12)")
 		assert.Contains(t, out, "  Length:   32 bytes")
-		assert.Contains(t, out, "  Digest:   0xC3C4733EC8AFFD06CF9E9FF50FFC6BCD2EC85A6170004BB709669C31DE94391A")
+		assert.Contains(t, out, "  Digest:   c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a")
 		assert.NotContains(t, out, "implicit")
 		assert.Contains(t, out, "CIDv0:      QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR")
 		assert.Contains(t, out, "CIDv1:      bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
@@ -70,7 +70,7 @@ func testCidInspect(t *testing.T) {
 		assert.Contains(t, out, "Multicodec: raw (0x55)")
 		assert.Contains(t, out, "Multihash:  sha2-256 (0x12)")
 		assert.Contains(t, out, "  Length:   32 bytes")
-		assert.Contains(t, out, "  Digest:   0xC3C4733EC8AFFD06CF9E9FF50FFC6BCD2EC85A6170004BB709669C31DE94391A")
+		assert.Contains(t, out, "  Digest:   c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a")
 		assert.Contains(t, out, "CIDv0:      not possible, requires dag-pb (0x70), got raw (0x55)")
 		assert.Contains(t, out, "CIDv1:      bafkreigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 	})
@@ -82,7 +82,7 @@ func testCidInspect(t *testing.T) {
 		assert.Contains(t, out, "CID:        k2jmtxw8rjh1z69c6not3wtdxb0u3urbzhyll1t9jg6ox26dhi5sfi1m")
 		assert.Contains(t, out, "Multibase:  base36 (k)")
 		assert.Contains(t, out, "Multicodec: dag-pb (0x70)")
-		assert.Contains(t, out, "  Digest:   0xC3C4733EC8AFFD06CF9E9FF50FFC6BCD2EC85A6170004BB709669C31DE94391A")
+		assert.Contains(t, out, "  Digest:   c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a")
 		assert.Contains(t, out, "CIDv0:      QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR")
 		assert.Contains(t, out, "CIDv1:      bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 	})
@@ -119,7 +119,7 @@ func testCidInspect(t *testing.T) {
 	})
 
 	t.Run("identity multihash CID", func(t *testing.T) {
-		// raw codec + identity multihash: digest is the raw content ("test" = 0x74657374)
+		// raw codec + identity multihash: digest is the raw content ("test" = 74657374)
 		res := node.RunIPFS("cid", "inspect", "bafkqabdumvzxi")
 		assert.Equal(t, 0, res.ExitCode())
 		out := res.Stdout.String()
@@ -127,7 +127,7 @@ func testCidInspect(t *testing.T) {
 		assert.Contains(t, out, "Multicodec: raw (0x55)")
 		assert.Contains(t, out, "Multihash:  identity (0x0)")
 		assert.Contains(t, out, "  Length:   4 bytes")
-		assert.Contains(t, out, "  Digest:   0x74657374")
+		assert.Contains(t, out, "  Digest:   74657374")
 	})
 
 	t.Run("unknown codec", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds new `ipfs cid inspect <cid>` subcommand to display detailed CID information
- Shows CID version, multibase encoding, multicodec, multihash (algorithm, length, digest)
- Provides equivalent CIDv0/CIDv1 representations when applicable
- Supports `--enc=json` for machine-readable output
- Works offline (no daemon required)

## Example Output

```
$ ipfs cid inspect bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
CID:        bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
Version:    1
Multibase:  base32 (b)
Multicodec: dag-pb (0x70)
Multihash:  sha2-256 (0x12)
  Length:   32 bytes
  Digest:   c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a
CIDv0:      QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
CIDv1:      bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
```

## Test Plan

- [x] `make build` succeeds
- [x] `go test ./core/commands/... -run TestCid` passes
- [x] `go test ./test/cli/... -run TestCommandDocsWidth` passes
- [x] Manual testing with CIDv0, CIDv1, and invalid CIDs

## References

- Closes https://github.com/ipfs/kubo/issues/11205