### PR TITLE
fix(cmd): use restrictive file permissions for exported keys

### DIFF
--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -269,8 +269,8 @@ elsewhere. For example, using openssl to get a PEM with public key:
 				outPath = filepath.Clean(outPath)
 			}
 
-			// create file
-			file, err := os.Create(outPath)
+			// create file with owner-only permissions to protect private key material
+			file, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 			if err != nil {
 				return err
 			}

--- a/test/cli/key_test.go
+++ b/test/cli/key_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyExportFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions not applicable on Windows")
+	}
+
+	node := harness.NewT(t).NewNode().Init()
+
+	node.IPFS("key", "gen", "--type=ed25519", "testkey")
+
+	t.Run("libp2p-protobuf-cleartext format", func(t *testing.T) {
+		t.Parallel()
+		exportPath := filepath.Join(t.TempDir(), "testkey.key")
+		node.IPFS("key", "export", "testkey", "-o", exportPath)
+
+		info, err := os.Stat(exportPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+			"exported key file should have owner-only permissions")
+	})
+
+	t.Run("pem-pkcs8-cleartext format", func(t *testing.T) {
+		t.Parallel()
+		exportPath := filepath.Join(t.TempDir(), "testkey.pem")
+		node.IPFS("key", "export", "testkey", "-o", exportPath, "-f", "pem-pkcs8-cleartext")
+
+		info, err := os.Stat(exportPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+			"exported PEM key file should have owner-only permissions")
+	})
+}


### PR DESCRIPTION
small tweak to follow best practices

## problem

`ipfs key export` was using `os.Create` (0o666 pre-umask, typically 0o644) making exported private keys world-readable on multi-user systems. 

## fix

Use `os.OpenFile` with 0o600 to match the restrictive permissions the keystore itself uses for key files.

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
