### PR TITLE
refactor: check if boxo/files.File is io.Seeker

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -158,7 +159,11 @@ func cat(ctx context.Context, api iface.CoreAPI, paths []string, offset int64, m
 			continue
 		}
 
-		count, err := file.Seek(offset, io.SeekStart)
+		seeker, ok := file.(io.Seeker)
+		if !ok {
+			return nil, 0, fmt.Errorf("file does not support seeking")
+		}
+		count, err := seeker.Seek(offset, io.SeekStart)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/core/coreiface/tests/unixfs.go
+++ b/core/coreiface/tests/unixfs.go
@@ -938,9 +938,14 @@ func (tp *TestSuite) TestGetSeek(t *testing.T) {
 		t.Fatal("not a file")
 	}
 
+	fSeeker, ok := f.(io.Seeker)
+	if !ok {
+		t.Fatal("file does not support seeking")
+	}
+
 	test := func(offset int64, whence int, read int, expect int64, shouldEof bool) {
 		t.Run(fmt.Sprintf("seek%d+%d-r%d-%d", whence, offset, read, expect), func(t *testing.T) {
-			n, err := f.Seek(offset, whence)
+			n, err := fSeeker.Seek(offset, whence)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.2
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e
+	github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/multiformats/go-multiaddr v0.16.1

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -352,8 +352,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e h1:kuArrVMzJ0eBOu4NsG7V4hPHLMn7o8UUHOOTA8+hPZI=
-github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e/go.mod h1:o+77q6sNLx04X1pWLTICgi+MimNAKFy9HJ2qfhNUTRs=
+github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f h1:gLeZpSeenmziHSu41hV0ztWpH4eFzzcA3HxdZ4mz6/A=
+github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f/go.mod h1:o+77q6sNLx04X1pWLTICgi+MimNAKFy9HJ2qfhNUTRs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e
+	github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f
 	github.com/ipfs/go-block-format v0.2.3
 	github.com/ipfs/go-cid v0.6.1
 	github.com/ipfs/go-cidutil v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e h1:kuArrVMzJ0eBOu4NsG7V4hPHLMn7o8UUHOOTA8+hPZI=
-github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e/go.mod h1:o+77q6sNLx04X1pWLTICgi+MimNAKFy9HJ2qfhNUTRs=
+github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f h1:gLeZpSeenmziHSu41hV0ztWpH4eFzzcA3HxdZ4mz6/A=
+github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f/go.mod h1:o+77q6sNLx04X1pWLTICgi+MimNAKFy9HJ2qfhNUTRs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e // indirect
+	github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.3 // indirect
 	github.com/ipfs/go-cid v0.6.1 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -452,8 +452,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e h1:kuArrVMzJ0eBOu4NsG7V4hPHLMn7o8UUHOOTA8+hPZI=
-github.com/ipfs/boxo v0.39.1-0.20260514201954-b2b5d8a2ae5e/go.mod h1:o+77q6sNLx04X1pWLTICgi+MimNAKFy9HJ2qfhNUTRs=
+github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f h1:gLeZpSeenmziHSu41hV0ztWpH4eFzzcA3HxdZ4mz6/A=
+github.com/ipfs/boxo v0.39.1-0.20260515000232-c8708232456f/go.mod h1:o+77q6sNLx04X1pWLTICgi+MimNAKFy9HJ2qfhNUTRs=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.3 h1:mpCuDaNXJ4wrBJLrtEaGFGXkferrw5eqVvzaHhtFKQk=


### PR DESCRIPTION

This PR updates boxo to ipfs/boxo#1128 which removes `io.Seeker` from the `files.File` interface. 
The goal is to see what happens. Callers that need seeking now type-assert to `io.Seeker`.

Turns our we dont have that many?

- core/commands/cat: type-assert before seeking
- core/coreiface/tests: type-assert before seeking


## TODO

- [x] CI is green here (lint is not related to this)
- [x] Discuss if we do https://github.com/ipfs/boxo/pull/1128 or if this PR can be closed without merging.
- [x] If we do this, switch to boxo@main or release once ipfs/boxo#1128 os merged