### PR TITLE
refactor: remove deprecated otelhttp.WithMetricAttributesFn

### DIFF
--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -146,9 +146,7 @@ func commandsOption(cctx oldcmds.Context, command *cmds.Command) ServeOption {
 			cmdHandler = withAuthSecrets(authorizations, cmdHandler)
 		}
 
-		cmdHandler = otelhttp.NewHandler(cmdHandler, "corehttp.cmdsHandler",
-			otelhttp.WithMetricAttributesFn(staticServerDomainAttrFn("api")),
-		)
+		cmdHandler = otelhttp.NewHandler(withMetricLabels(cmdHandler, staticServerDomainAttrFn("api")), "corehttp.cmdsHandler")
 		mux.Handle(APIPath+"/", cmdHandler)
 		return mux, nil
 	}

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -44,11 +44,10 @@ func GatewayOption(paths ...string) ServeOption {
 
 		handler := gateway.NewHandler(config, backend)
 		handler = gateway.NewHeaders(headers).ApplyCors().Wrap(handler)
-		var otelOpts []otelhttp.Option
 		if fn := newServerDomainAttrFn(n); fn != nil {
-			otelOpts = append(otelOpts, otelhttp.WithMetricAttributesFn(fn))
+			handler = withMetricLabels(handler, fn)
 		}
-		handler = otelhttp.NewHandler(handler, "Gateway", otelOpts...)
+		handler = otelhttp.NewHandler(handler, "Gateway")
 
 		for _, p := range paths {
 			mux.Handle(p+"/", handler)
@@ -75,11 +74,10 @@ func HostnameOption() ServeOption {
 		var handler http.Handler
 		handler = gateway.NewHostnameHandler(config, backend, childMux)
 		handler = gateway.NewHeaders(headers).ApplyCors().Wrap(handler)
-		var otelOpts []otelhttp.Option
 		if fn := newServerDomainAttrFn(n); fn != nil {
-			otelOpts = append(otelOpts, otelhttp.WithMetricAttributesFn(fn))
+			handler = withMetricLabels(handler, fn)
 		}
-		handler = otelhttp.NewHandler(handler, "HostnameGateway", otelOpts...)
+		handler = otelhttp.NewHandler(handler, "HostnameGateway")
 
 		mux.Handle("/", handler)
 		return childMux, nil
@@ -131,9 +129,7 @@ func Libp2pGatewayOption() ServeOption {
 		}
 
 		handler := gateway.NewHandler(gwConfig, &offlineGatewayErrWrapper{gwimpl: backend})
-		handler = otelhttp.NewHandler(handler, "Libp2p-Gateway",
-			otelhttp.WithMetricAttributesFn(staticServerDomainAttrFn("libp2p")),
-		)
+		handler = otelhttp.NewHandler(withMetricLabels(handler, staticServerDomainAttrFn("libp2p")), "Libp2p-Gateway")
 
 		mux.Handle("/ipfs/", handler)
 
@@ -272,6 +268,19 @@ var defaultPaths = []string{"/ipfs/", "/ipns/", "/p2p/"}
 // or "other".
 var serverDomainAttrKey = attribute.Key("server.domain")
 
+// withMetricLabels wraps a handler so that otelhttp metric attributes are
+// added via the request-scoped [otelhttp.Labeler] instead of the deprecated
+// [otelhttp.WithMetricAttributesFn] option. The wrapper must run inside
+// [otelhttp.NewHandler] (which injects the labeler into the context).
+func withMetricLabels(next http.Handler, fn func(*http.Request) []attribute.KeyValue) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if l, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+			l.Add(fn(r)...)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // staticServerDomainAttrFn returns a MetricAttributesFn that always returns
 // a fixed server.domain value. Use for handlers where the domain is known
 // statically (e.g. "api", "libp2p") to keep the label set consistent across
@@ -281,7 +290,7 @@ func staticServerDomainAttrFn(domain string) func(*http.Request) []attribute.Key
 	return func(*http.Request) []attribute.KeyValue { return attrs }
 }
 
-// newServerDomainAttrFn returns an otelhttp.WithMetricAttributesFn callback
+// newServerDomainAttrFn returns an attribute callback for [withMetricLabels]
 // that adds a server.domain attribute grouping requests by their matching
 // Gateway.PublicGateways hostname suffix (e.g. "dweb.link", "ipfs.io").
 // Requests that don't match any configured gateway get "other".


### PR DESCRIPTION
## Problem

#11208  added `otelhttp.WithMetricAttributesFn` calls when otelhttp was at v0.65.0 and the function was not yet deprecated. The `feat/provide-entity-roots-with-dedup` branch bumps otelhttp to v0.67.0, which marks the function deprecated, breaking Go Lint with `staticcheck` SA1019:

https://github.com/ipfs/kubo/actions/runs/23673403623

```
core/corehttp/commands.go:150:4: SA1019: otelhttp.WithMetricAttributesFn is deprecated
core/corehttp/gateway.go:49:32:  SA1019: otelhttp.WithMetricAttributesFn is deprecated
core/corehttp/gateway.go:80:32:  SA1019: otelhttp.WithMetricAttributesFn is deprecated
```

This is an early warning we should move away from `otelhttp.WithMetricAttributesFn` :)

## Solution

Replace `WithMetricAttributesFn` with a `withMetricLabels` middleware that uses the request-scoped `otelhttp.Labeler` (the officially recommended replacement).

```go
func withMetricLabels(next http.Handler, fn func(*http.Request) []attribute.KeyValue) http.Handler
```

Wraps a handler inside `otelhttp.NewHandler` to call `LabelerFromContext` and add attributes before delegating.

**Code:** otelhttp `handler.go:201` shows both the old and new paths converge at the same metric recording point, feeding into the same `http_server_*` metrics through `semconv/server.go`.

**Manual test:** i've built the binary, started a daemon with `PublicGateways` configured, fired requests, scraped `/debug/metrics/prometheus`:

| Request | `server_domain` | Handler |
|---|---|---|
| `POST /api/v0/id` | `"api"` | `commands.go` (static) |
| `GET /ipfs/Qm...` on `127.0.0.1` | `"loopback"` | `GatewayOption` (dynamic) |
| `Host: *.ipns.localhost` | `"localhost"` | `HostnameOption` (dynamic) |

Confirmed `server_domain` present on `http_server_request_body_size_bytes`, `http_server_response_body_size_bytes`, and `http_server_request_duration_seconds` for all three paths.

So this is functionally equivalent, just uses more modern API.