### PR TITLE
fix: gofmt -s composite literal simplification in test harness

### DIFF
--- a/test/cli/harness/node.go
+++ b/test/cli/harness/node.go
@@ -248,7 +248,7 @@ func (n *Node) Init(ipfsArgs ...string) *Node {
 		// Telemetry disabled by default in tests.
 		cfg.Plugins = config.Plugins{
 			Plugins: map[string]config.Plugin{
-				"telemetry": config.Plugin{
+				"telemetry": {
 					Disabled: true,
 				},
 			},


### PR DESCRIPTION
Fixes a `gofmt -s` issue in the test harness that was causing `make test_short` to fail.
The change removes a redundant type name in a map composite literal as suggested by `gofmt -s`.

### Changes
- Simplified composite literal in `test/cli/harness/node.go`
- Fixed formatting so that the short test suite passes again

### Related Issue
Fixes #11259 

### Notes
- This is a pure formatting fix (no functional changes)
- I have performed a self-review of my own code
- My code passes `make test_short`
- `gofmt -s` has been applied where needed