### PR TITLE
ci: update gateway-conformance to v0.13

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.12
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.13
         with:
           output: fixtures
 
@@ -93,7 +93,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.12
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.13
         with:
           gateway-url: http://127.0.0.1:8080
           subdomain-url: http://localhost:8080
@@ -127,7 +127,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.12
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.13
         with:
           output: fixtures
 
@@ -199,7 +199,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.12
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.13
         with:
           gateway-url: http://127.0.0.1:8092
           args: --specs "trustless-gateway,-trustless-ipns-gateway" -skip 'TestGatewayCar/GET_response_for_application/vnd.ipld.car/Header_Content-Length'

--- a/docs/changelogs/v0.41.md
+++ b/docs/changelogs/v0.41.md
@@ -103,7 +103,7 @@ A `--allow-non-unixfs` flag is available on both `ipfs object patch` commands to
 - update `go-libp2p` to [v0.48.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.48.0)
 - update `go-libp2p-kad-dht` to [v0.39.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.39.0)
 - update `ipfs-webui` to [v4.12.0](https://github.com/ipfs/ipfs-webui/releases/tag/v4.12.0)
-- update `gateway-conformance` tests to [v0.11](https://github.com/ipfs/gateway-conformance/releases/tag/v0.11.0)
+- update `gateway-conformance` tests to [v0.13](https://github.com/ipfs/gateway-conformance/releases/tag/v0.13.0) (incl. [v0.12](https://github.com/ipfs/gateway-conformance/releases/tag/v0.12.0), [v0.11](https://github.com/ipfs/gateway-conformance/releases/tag/v0.11.0))
 
 ### 📝 Changelog
 


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
