### PR TITLE
fix(log): scope provide logs to "provider" subsystem

### DIFF
--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -70,6 +70,13 @@ var (
 	keystoreDatastoreKey = datastore.NewKey("keystore")
 )
 
+// providerLog is the go-log subsystem used for provide/reprovide-related
+// messages emitted from kubo's own orchestration code. It shares the
+// "provider" subsystem name with boxo's provider package so users can set
+// GOLOG_LOG_LEVEL=provider=<level> to control both layers at once. See
+// docs/debug-guide.md for the full list of provide-related subsystems.
+var providerLog = log.Logger("provider")
+
 var errAcceleratedDHTNotReady = errors.New("AcceleratedDHTClient: routing table not ready")
 
 // validateKeystoreSuffix rejects any suffix other than "0" or "1".
@@ -237,7 +244,7 @@ func LegacyProviderOpt(reprovideInterval time.Duration, strategy string, acceler
 								KeysOnly: true,
 							})
 							if err != nil {
-								logger.Errorf("fetching AllKeysChain in provider ThroughputReport: %v", err)
+								providerLog.Errorf("fetching AllKeysChain in provider ThroughputReport: %v", err)
 								return false
 							}
 							defer qr.Close()
@@ -258,7 +265,7 @@ func LegacyProviderOpt(reprovideInterval time.Duration, strategy string, acceler
 									// How long per block that lasts us.
 									expectedProvideSpeed := reprovideInterval / probableBigBlockstore
 									if avgProvideSpeed > expectedProvideSpeed {
-										logger.Errorf(`
+										providerLog.Errorf(`
 🔔🔔🔔 Reprovide Operations Too Slow 🔔🔔🔔
 
 Your node may be falling behind on DHT reprovides, which could affect content availability.
@@ -287,7 +294,7 @@ Learn more: https://github.com/ipfs/kubo/blob/master/docs/config.md#provide`,
 						}
 
 						if avgProvideSpeed > expectedProvideSpeed {
-							logger.Errorf(`
+							providerLog.Errorf(`
 🔔🔔🔔 Reprovide Operations Too Slow 🔔🔔🔔
 
 Your node is falling behind on DHT reprovides, which will affect content availability.
@@ -430,7 +437,7 @@ func findRootDatastoreSpec(spec map[string]any) map[string]any {
 		return spec
 	default:
 		if _, hasChild := spec["child"]; hasChild {
-			logger.Warnw("unrecognized datastore wrapper type, using as-is",
+			providerLog.Warnw("unrecognized datastore wrapper type, using as-is",
 				"type", spec["type"])
 		}
 		return spec
@@ -585,7 +592,7 @@ func purgeOrphanedKeystoreData(ctx context.Context, ds datastore.Batching) error
 		}
 	}
 	if count > 0 {
-		logger.Infow("purged orphaned provider keystore data from shared datastore", "keys", count)
+		providerLog.Infow("purged orphaned provider keystore data from shared datastore", "keys", count)
 	}
 	return nil
 }
@@ -630,7 +637,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 			if err != nil {
 				return nil, err
 			}
-			logger.Infow("provider keystore: opened datastore", "suffix", suffix, "path", filepath.Join(keystoreBasePath, suffix))
+			providerLog.Infow("provider keystore: opened datastore", "suffix", suffix, "path", filepath.Join(keystoreBasePath, suffix))
 			return ds, nil
 		}
 
@@ -638,7 +645,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 			if err := validateKeystoreSuffix(suffix); err != nil {
 				return err
 			}
-			logger.Infow("provider keystore: removing datastore from disk", "suffix", suffix, "path", filepath.Join(keystoreBasePath, suffix))
+			providerLog.Infow("provider keystore: removing datastore from disk", "suffix", suffix, "path", filepath.Join(keystoreBasePath, suffix))
 			return os.RemoveAll(filepath.Join(keystoreBasePath, suffix))
 		}
 
@@ -656,7 +663,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 		// NewResettableKeystore to avoid racing with reads on the same
 		// namespace.
 		if _, statErr := os.Stat(keystoreBasePath); os.IsNotExist(statErr) {
-			logger.Infow("migrating provider keystore data from shared datastore to separate filesystem datastores", "path", keystoreBasePath)
+			providerLog.Infow("migrating provider keystore data from shared datastore to separate filesystem datastores", "path", keystoreBasePath)
 			// Create a cancellable context for the purge. The OnStop hook
 			// below calls purgeCancel when the node receives a shutdown
 			// signal (e.g., SIGINT), which interrupts the purge loop
@@ -670,12 +677,12 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 			})
 			if purgeErr := purgeOrphanedKeystoreData(purgeCtx, in.Repo.Datastore()); purgeErr != nil {
 				if purgeCtx.Err() != nil {
-					logger.Infow("provider keystore migration interrupted by shutdown, will resume on next start")
+					providerLog.Infow("provider keystore migration interrupted by shutdown, will resume on next start")
 				} else {
-					logger.Warnw("provider keystore migration failed, will retry on next start", "error", purgeErr)
+					providerLog.Warnw("provider keystore migration failed, will retry on next start", "error", purgeErr)
 				}
 			} else {
-				logger.Infow("provider keystore migration completed")
+				providerLog.Infow("provider keystore migration completed")
 			}
 			purgeCancel()
 		}
@@ -825,7 +832,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 				return err
 			}
 			if err := in.Provider.RefreshSchedule(); err != nil {
-				logger.Infow("refreshing provider schedule", "err", err)
+				providerLog.Infow("refreshing provider schedule", "err", err)
 			}
 			return nil
 		}
@@ -842,16 +849,16 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 					// we need to walk the DAG of objects matching the provide strategy,
 					// which can take a while.
 					strategy := cfg.Provide.Strategy.WithDefault(config.DefaultProvideStrategy)
-					logger.Infow("provider keystore sync started", "strategy", strategy)
+					providerLog.Infow("provider keystore sync started", "strategy", strategy)
 					if err := syncKeystore(ctx); err != nil {
 						if ctx.Err() == nil {
-							logger.Errorw("provider keystore sync failed", "err", err, "strategy", strategy)
+							providerLog.Errorw("provider keystore sync failed", "err", err, "strategy", strategy)
 						} else {
-							logger.Debugw("provider keystore sync interrupted by shutdown", "err", err, "strategy", strategy)
+							providerLog.Debugw("provider keystore sync interrupted by shutdown", "err", err, "strategy", strategy)
 						}
 						return
 					}
-					logger.Infow("provider keystore sync completed", "strategy", strategy)
+					providerLog.Infow("provider keystore sync completed", "strategy", strategy)
 				}()
 
 				gcCtx, c := context.WithCancel(context.Background())
@@ -868,7 +875,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 							return
 						case <-ticker.C:
 							if err := syncKeystore(gcCtx); err != nil {
-								logger.Errorw("provider keystore sync", "err", err)
+								providerLog.Errorw("provider keystore sync", "err", err)
 							}
 						}
 					}
@@ -915,7 +922,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 				// Close provider first - waits for all worker goroutines to exit.
 				// This ensures no code can access keystore after this returns.
 				if err := in.Provider.Close(); err != nil {
-					logger.Errorw("error closing provider during shutdown", "error", err)
+					providerLog.Errorw("error closing provider during shutdown", "error", err)
 				}
 
 				// Close keystore - safe now, provider is fully shut down
@@ -989,7 +996,7 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 						if prevQueuedWorkers && queuedWorkers && queueSize > prevQueueSize {
 							count++
 							if count >= consecutiveAlertsThreshold {
-								logger.Errorf(`
+								providerLog.Errorf(`
 🔔🔔🔔 Reprovide Operations Too Slow 🔔🔔🔔
 
 Your node is falling behind on DHT reprovides, which will affect content availability.
@@ -1188,7 +1195,7 @@ func persistUniqueCount(ds datastore.Datastore, count uint64) {
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, count)
 	if err := ds.Put(context.Background(), datastore.NewKey(reprovideLastUniqueCountKey), buf); err != nil {
-		logger.Errorf("failed to persist unique count: %s", err)
+		providerLog.Errorf("failed to persist unique count: %s", err)
 	}
 }
 
@@ -1329,7 +1336,7 @@ func createKeyProvider(strategyFlag config.ProvideStrategy, fpRate uint, in prov
 					if ctx.Err() == nil {
 						persistUniqueCount(ds, tracker.Count())
 					}
-					logger.Infow("unique reprovide cycle finished",
+					providerLog.Infow("unique reprovide cycle finished",
 						"providedCIDs", tracker.Count(),
 						"skippedBranches", tracker.Deduplicated())
 					close(ch)
@@ -1343,7 +1350,7 @@ func createKeyProvider(strategyFlag config.ProvideStrategy, fpRate uint, in prov
 				}
 			}()
 
-			logger.Infow("unique reprovide cycle started",
+			providerLog.Infow("unique reprovide cycle started",
 				"expectedItems", expectedItems,
 				"previousCount", count,
 			)
@@ -1406,7 +1413,7 @@ func handleStrategyChange(strategy string, provider DHTProvider, ds datastore.Da
 
 	previous, changed, err := detectStrategyChange(ctx, strategy, ds)
 	if err != nil {
-		logger.Error("cannot read previous reprovide strategy", "err", err)
+		providerLog.Error("cannot read previous reprovide strategy", "err", err)
 		return
 	}
 
@@ -1414,11 +1421,11 @@ func handleStrategyChange(strategy string, provider DHTProvider, ds datastore.Da
 		return
 	}
 
-	logger.Infow("Provide.Strategy changed, clearing provide queue", "previous", previous, "current", strategy)
+	providerLog.Infow("Provide.Strategy changed, clearing provide queue", "previous", previous, "current", strategy)
 	provider.Clear()
 
 	if err := persistStrategy(ctx, strategy, ds); err != nil {
-		logger.Error("cannot update reprovide strategy", "err", err)
+		providerLog.Error("cannot update reprovide strategy", "err", err)
 	}
 }
 

--- a/docs/debug-guide.md
+++ b/docs/debug-guide.md
@@ -7,6 +7,7 @@ This is a document for helping debug Kubo. Please add to it if you can!
 - [General performance debugging guidelines](#general-performance-debugging-guidelines)
 - [Table of Contents](#table-of-contents)
     - [Beginning](#beginning)
+    - [Known logger subsystems](#known-logger-subsystems)
     - [Analyzing the stack dump](#analyzing-the-stack-dump)
     - [Analyzing the CPU Profile](#analyzing-the-cpu-profile)
     - [Analyzing vars and memory statistics](#analyzing-vars-and-memory-statistics)
@@ -37,6 +38,23 @@ If you feel intrepid, you can dump this information and investigate it yourself:
 - system information
   - `ipfs diag sys > ipfs.sysinfo`
 
+
+### Known logger subsystems
+
+`GOLOG_LOG_LEVEL` matches subsystem names exactly (no prefix or wildcard matching beyond `*` for "all subsystems"). The same names work with the runtime command `ipfs log level <subsystem> <level>`. The list below covers the outbound provide/reprovide pipeline, which spans multiple packages and therefore multiple subsystems.
+
+| Subsystem | Source | Purpose |
+| --- | --- | --- |
+| `provider` | kubo `core/node`, boxo `provider` | Kubo provider orchestration (keystore lifecycle, strategy changes, reprovide cycle start/finish, throughput alarms) and boxo's legacy provider system (active when `Provide.DHT.SweepEnabled=false` or for non-DHT routers) |
+| `dht/provider` | `go-libp2p-kad-dht` | Sweep-based DHT provider (active when `Provide.DHT.SweepEnabled=true`, the default), including the buffered wrapper, keystore, and resettable keystore |
+| `dht/provider/lan` | `go-libp2p-kad-dht` (dual) | LAN half of the dual DHT provider; the WAN half reuses `dht/provider` |
+| `dsqueue` | `go-dsqueue` | Generic datastore queue used by the legacy provider queue |
+
+To see everything the provide system emits, for example at `debug` level:
+
+```shell
+GOLOG_LOG_LEVEL="provider=debug,dht/provider=debug,dht/provider/lan=debug" ipfs daemon
+```
 
 ### Analyzing the stack dump
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -76,6 +76,8 @@ GOLOG_LOG_LEVEL="error,core/server=debug" ipfs daemon
 
 Logging can also be configured at runtime, both globally and on a per-subsystem basis, with the `ipfs log` command.
 
+See [Known logger subsystems](./debug-guide.md#known-logger-subsystems) for subsystem names related to the provide/reprovide pipeline.
+
 ## `GOLOG_LOG_FMT`
 
 Specifies the log message format.  It supports the following values:

--- a/test/cli/provider_test.go
+++ b/test/cli/provider_test.go
@@ -1270,7 +1270,7 @@ func TestProviderUniqueDedupLogging(t *testing.T) {
 		nodes[0].StartDaemonWithReq(harness.RunRequest{
 			CmdOpts: []harness.CmdOpt{
 				harness.RunWithEnv(map[string]string{
-					"GOLOG_LOG_LEVEL": "error,dagwalker=info,core:constructor=info",
+					"GOLOG_LOG_LEVEL": "error,dagwalker=info,provider=info",
 				}),
 			},
 		}, "")


### PR DESCRIPTION
Provide/reprovide messages from `core/node/provider.go` were emitted under `core:constructor` (the shared core/node constructor subsystem), making `GOLOG_LOG_LEVEL` and `ipfs log level` hard to target for provide  visibility. Scope them to `"provider"`, matching boxo's provider package so a single lever covers both layers.

## Changes

- core/node/provider.go: new providerLog at the "provider" subsystem, applied to 25 keystore/reprovide/strategy/throughput call sites
- test/cli/provider_test.go: reprovide dedup subtest raises provider=info instead of core:constructor=info
- docs/debug-guide.md: new "Known logger subsystems" section listing provider, dht/provider, dht/provider/lan, dsqueue
- docs/environment-variables.md: link to the new section from under GOLOG_LOG_LEVEL
