### PR TITLE
fix(provider): tie keystore-sync goroutine to gcCtx so shutdown cancels it

### DIFF
--- a/core/node/provider.go
+++ b/core/node/provider.go
@@ -839,6 +839,9 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 
 		lc.Append(fx.Hook{
 			OnStart: func(ctx context.Context) error {
+				gcCtx, c := context.WithCancel(context.Background())
+				cancel = c
+
 				// Set the KeyProvider as a garbage collection function for the
 				// keystore. Periodically purge the Keystore from all its keys and
 				// replace them with the keys that needs to be reprovided, coming from
@@ -847,11 +850,14 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 				go func() {
 					// Sync the keystore once at startup. This operation is async since
 					// we need to walk the DAG of objects matching the provide strategy,
-					// which can take a while.
+					// which can take a while. Use gcCtx (cancelled on shutdown) rather
+					// than the OnStart ctx so a long-running sync that outlives
+					// OnStart is torn down when the datastore closes, preventing
+					// 'pebble: closed' panics from in-flight Query() calls.
 					strategy := cfg.Provide.Strategy.WithDefault(config.DefaultProvideStrategy)
 					providerLog.Infow("provider keystore sync started", "strategy", strategy)
-					if err := syncKeystore(ctx); err != nil {
-						if ctx.Err() == nil {
+					if err := syncKeystore(gcCtx); err != nil {
+						if gcCtx.Err() == nil {
 							providerLog.Errorw("provider keystore sync failed", "err", err, "strategy", strategy)
 						} else {
 							providerLog.Debugw("provider keystore sync interrupted by shutdown", "err", err, "strategy", strategy)
@@ -860,9 +866,6 @@ func SweepingProviderOpt(cfg *config.Config) fx.Option {
 					}
 					providerLog.Infow("provider keystore sync completed", "strategy", strategy)
 				}()
-
-				gcCtx, c := context.WithCancel(context.Background())
-				cancel = c
 
 				go func() { // garbage collection loop for cids to reprovide
 					defer close(done)


### PR DESCRIPTION
Addresses ipfs/kubo#11292.

## Problem

The OnStart-level keystore-sync goroutine captured `ctx`, the fx OnStart context. That context is torn down once OnStart returns, and if the sync was still walking the DAG it continued running against a datastore that the `ensureProviderClosesBeforeKeystore` hook later closed, producing `pebble: closed` panics from in-flight Pebble `NewIter` calls during `^C` shutdown.

Representative panic from the issue:
```
panic: pebble: closed
github.com/cockroachdb/pebble/v2.(*DB).newIter
github.com/ipfs/go-ds-pebble.(*Datastore).Query
```

## Fix

Create `gcCtx` first and use it for both the startup sync goroutine and the reprovide loop. `OnStop`'s `cancel()` now tears both paths down before the datastore closes, so `syncKeystore` returns cleanly on interrupt.

## Test

`go build ./core/node/...` and `go vet ./core/node/...` clean.