### PR TITLE
fix: resolve wildcard swarm in http provides

### DIFF
--- a/core/node/libp2p/routingopt.go
+++ b/core/node/libp2p/routingopt.go
@@ -340,7 +340,9 @@ var _ confirmedAddrsHost = (*basichost.BasicHost)(nil)
 // Resolution logic:
 //   - If Announce is set, use it as a static override (no dynamic resolution).
 //   - Otherwise, prefer AutoNAT V2 confirmed reachable addresses when available,
-//     falling back to static Swarm addresses (filtered by NoAnnounce).
+//     falling back to host.Addrs() which resolves 0.0.0.0/:: Swarm binds to
+//     concrete interface addresses and applies the libp2p AddrsFactory
+//     (Addresses.NoAnnounce CIDR filters and Swarm.AddrFilters).
 //   - AppendAnnounce addresses are always appended.
 func httpRouterAddrFunc(h host.Host, cfgAddrs config.Addresses) func() []ma.Multiaddr {
 	appendAddrs := parseMultiaddrs(cfgAddrs.AppendAnnounce)
@@ -350,23 +352,6 @@ func httpRouterAddrFunc(h host.Host, cfgAddrs config.Addresses) func() []ma.Mult
 		staticAddrs := slices.Concat(parseMultiaddrs(cfgAddrs.Announce), appendAddrs)
 		return func() []ma.Multiaddr { return staticAddrs }
 	}
-
-	// Precompute fallback: Swarm minus NoAnnounce plus AppendAnnounce.
-	fallbackStrs := cfgAddrs.Swarm
-	if len(cfgAddrs.NoAnnounce) > 0 {
-		noAnnounce := map[string]struct{}{}
-		for _, a := range cfgAddrs.NoAnnounce {
-			noAnnounce[a] = struct{}{}
-		}
-		filtered := make([]string, 0, len(fallbackStrs))
-		for _, a := range fallbackStrs {
-			if _, skip := noAnnounce[a]; !skip {
-				filtered = append(filtered, a)
-			}
-		}
-		fallbackStrs = filtered
-	}
-	fallbackResult := slices.Concat(parseMultiaddrs(fallbackStrs), appendAddrs)
 
 	ch, hasConfirmed := h.(confirmedAddrsHost)
 	return func() []ma.Multiaddr {
@@ -379,7 +364,14 @@ func httpRouterAddrFunc(h host.Host, cfgAddrs config.Addresses) func() []ma.Mult
 				return slices.Concat(reachable, appendAddrs)
 			}
 		}
-		return fallbackResult
+		// Fallback: host.Addrs() resolves wildcard binds (0.0.0.0, ::) to
+		// concrete interface addresses and applies the libp2p AddrsFactory,
+		// which is where Addresses.NoAnnounce CIDR filtering happens.
+		hostAddrs := h.Addrs()
+		if len(appendAddrs) == 0 {
+			return hostAddrs
+		}
+		return slices.Concat(hostAddrs, appendAddrs)
 	}
 }
 

--- a/core/node/libp2p/routingopt_test.go
+++ b/core/node/libp2p/routingopt_test.go
@@ -206,10 +206,12 @@ func TestEndpointCapabilitiesReadWriteLogic(t *testing.T) {
 }
 
 // stubHost is a minimal host.Host stub for testing httpRouterAddrFunc.
-// Only the methods checked via type assertion (confirmedAddrsHost) matter;
-// all other methods panic if called.
+// reachable mocks ConfirmedAddrs (AutoNAT V2 result); hostAddrs mocks
+// Addrs(), which in a real host returns wildcard-resolved interface
+// addresses after the AddrsFactory filters (NoAnnounce/AddrFilters).
 type stubHost struct {
 	reachable []ma.Multiaddr
+	hostAddrs []ma.Multiaddr
 }
 
 func (h *stubHost) ConfirmedAddrs() (reachable, unreachable, unknown []ma.Multiaddr) {
@@ -217,7 +219,7 @@ func (h *stubHost) ConfirmedAddrs() (reachable, unreachable, unknown []ma.Multia
 }
 
 func (h *stubHost) ID() peer.ID                                         { panic("unused") }
-func (h *stubHost) Addrs() []ma.Multiaddr                               { panic("unused") }
+func (h *stubHost) Addrs() []ma.Multiaddr                               { return h.hostAddrs }
 func (h *stubHost) Peerstore() peerstore.Peerstore                      { panic("unused") }
 func (h *stubHost) Network() network.Network                            { panic("unused") }
 func (h *stubHost) Mux() protocol.Switch                                { panic("unused") }
@@ -235,44 +237,65 @@ func (h *stubHost) ConnManager() connmgr.ConnManager { panic("unused") }
 func (h *stubHost) EventBus() event.Bus              { panic("unused") }
 
 func TestHttpRouterAddrFunc(t *testing.T) {
+	// hostAddrs simulates what host.Addrs() returns in a running daemon:
+	// wildcard Swarm binds resolved to concrete interfaces, with the
+	// libp2p AddrsFactory (NoAnnounce/AddrFilters) already applied.
+	resolvedAddrs := []string{
+		"/ip4/192.168.1.10/tcp/4001",
+		"/ip4/192.168.1.10/udp/4001/quic-v1",
+	}
+
 	tests := []struct {
 		name      string
 		reachable []string // autonat confirmed addrs (nil = none)
+		hostAddrs []string // host.Addrs() output (nil = none)
 		cfg       config.Addresses
 		want      []string
 	}{
 		{
-			name:      "prefers autonat confirmed reachable addrs over swarm fallback",
+			name:      "prefers autonat confirmed reachable addrs over host.Addrs fallback",
 			reachable: []string{"/ip4/1.2.3.4/tcp/4001", "/ip4/1.2.3.4/udp/4001/quic-v1"},
+			hostAddrs: resolvedAddrs,
 			cfg:       config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001", "/ip4/0.0.0.0/udp/4001/quic-v1"}},
 			want:      []string{"/ip4/1.2.3.4/tcp/4001", "/ip4/1.2.3.4/udp/4001/quic-v1"},
 		},
 		{
-			name: "falls back to swarm when autonat has no confirmed addrs",
-			cfg:  config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001"}},
-			want: []string{"/ip4/0.0.0.0/tcp/4001"},
+			name:      "falls back to host.Addrs when autonat has no confirmed addrs",
+			hostAddrs: resolvedAddrs,
+			cfg:       config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001", "/ip4/0.0.0.0/udp/4001/quic-v1"}},
+			want:      resolvedAddrs,
 		},
 		{
-			name:      "Announce overrides autonat and swarm",
+			name:      "Announce overrides autonat and host.Addrs",
 			reachable: []string{"/ip4/1.2.3.4/tcp/4001"},
+			hostAddrs: resolvedAddrs,
 			cfg:       config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001"}, Announce: []string{"/ip4/5.6.7.8/tcp/4001"}},
 			want:      []string{"/ip4/5.6.7.8/tcp/4001"},
 		},
 		{
 			name:      "AppendAnnounce added to autonat addrs",
 			reachable: []string{"/ip4/1.2.3.4/tcp/4001"},
+			hostAddrs: resolvedAddrs,
 			cfg:       config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001"}, AppendAnnounce: []string{"/ip4/10.0.0.1/tcp/4001"}},
 			want:      []string{"/ip4/1.2.3.4/tcp/4001", "/ip4/10.0.0.1/tcp/4001"},
 		},
 		{
-			name: "AppendAnnounce added to swarm fallback",
-			cfg:  config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001"}, AppendAnnounce: []string{"/ip4/10.0.0.1/tcp/4001"}},
-			want: []string{"/ip4/0.0.0.0/tcp/4001", "/ip4/10.0.0.1/tcp/4001"},
+			name:      "AppendAnnounce added to host.Addrs fallback",
+			hostAddrs: resolvedAddrs,
+			cfg:       config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001"}, AppendAnnounce: []string{"/ip4/10.0.0.1/tcp/4001"}},
+			want:      append(append([]string{}, resolvedAddrs...), "/ip4/10.0.0.1/tcp/4001"),
 		},
 		{
-			name: "NoAnnounce filters swarm fallback",
-			cfg:  config.Addresses{Swarm: []string{"/ip4/0.0.0.0/tcp/4001", "/ip4/0.0.0.0/udp/4001/quic-v1"}, NoAnnounce: []string{"/ip4/0.0.0.0/tcp/4001"}},
-			want: []string{"/ip4/0.0.0.0/udp/4001/quic-v1"},
+			// NoAnnounce (including server profile CIDR ranges) is applied by the
+			// libp2p AddrsFactory before host.Addrs() returns, so httpRouterAddrFunc
+			// itself performs no filtering on the fallback.
+			name:      "NoAnnounce filtering happens upstream in host.Addrs",
+			hostAddrs: []string{"/ip4/192.168.1.10/tcp/4001"}, // already filtered by addrFactory
+			cfg: config.Addresses{
+				Swarm:      []string{"/ip4/0.0.0.0/tcp/4001"},
+				NoAnnounce: []string{"/ip4/127.0.0.0/ipcidr/8"},
+			},
+			want: []string{"/ip4/192.168.1.10/tcp/4001"},
 		},
 		{
 			name: "AppendAnnounce added to Announce",
@@ -282,7 +305,10 @@ func TestHttpRouterAddrFunc(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := &stubHost{reachable: parseMultiaddrs(tt.reachable)}
+			h := &stubHost{
+				reachable: parseMultiaddrs(tt.reachable),
+				hostAddrs: parseMultiaddrs(tt.hostAddrs),
+			}
 			fn := httpRouterAddrFunc(h, tt.cfg)
 			assert.Equal(t, parseMultiaddrs(tt.want), fn())
 		})

--- a/test/cli/delegated_routing_v1_http_client_test.go
+++ b/test/cli/delegated_routing_v1_http_client_test.go
@@ -274,4 +274,27 @@ func TestHTTPDelegatedRoutingProviderAddrs(t *testing.T) {
 		require.NotEmpty(t, addrs, "provider record should contain addresses")
 		assert.Contains(t, addrs, "/ip4/5.6.7.8/tcp/4001", "AppendAnnounce address should be present")
 	})
+
+	t.Run("provider records resolve 0.0.0.0 Swarm bind to interface addresses", func(t *testing.T) {
+		t.Parallel()
+		srv, getAddrs := captureProviderAddrs(t)
+
+		// Default Addresses.Swarm binds to /ip4/0.0.0.0/... If httpRouterAddrFunc
+		// forwards those verbatim, HTTP routers receive useless unroutable entries.
+		// See https://github.com/ipfs/kubo/issues/11213.
+		node := harness.NewT(t).NewNode().Init()
+		node.SetIPFSConfig("Routing", customRoutingConf(srv.URL))
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		cidStr := node.IPFSAddStr(time.Now().String())
+		node.IPFS("routing", "provide", cidStr)
+
+		addrs := getAddrs()
+		require.NotEmpty(t, addrs, "provider record should contain addresses")
+		for _, a := range addrs {
+			assert.NotContains(t, a, "/ip4/0.0.0.0/", "unresolved 0.0.0.0 in provider record: %s", a)
+			assert.NotContains(t, a, "/ip6/::/", "unresolved :: in provider record: %s", a)
+		}
+	})
 }


### PR DESCRIPTION
This is a fix for http-only users like [Plebbit](https://plebbit.com/), likely more relevant in the future as we want to have first-class support for http-only support.

0.41.0's `httpRouterAddrFunc` only resolved `0.0.0.0/::` when AutoNATv2 had a confirmed reachable address. Otherwise it forwarded raw `Addresses.Swarm` strings to HTTP routers, so isolated or LAN-only nodes published unreachable provider records.

- Fixes #11213

## Changes

- core/node/libp2p/routingopt.go: fallback now calls `host.Addrs()`, which resolves wildcard binds to concrete interface addrs and applies the libp2p `AddrsFactory` (`NoAnnounce` CIDR, `Swarm.AddrFilters`); matches the DHT provide path (`core/node/provider.go` `selfAddrsFunc`)
- core/node/libp2p/routingopt_test.go: `stubHost.Addrs` is configurable; cases rewritten around resolved host addrs, with a new case pinning that NoAnnounce CIDR filtering belongs upstream in host.Addrs
- test/cli/delegated_routing_v1_http_client_test.go: new end-to-end case asserts provider records sent over HTTP never contain 0.0.0.0 or :: when Addresses.Swarm uses the default wildcard bind

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
