### PR TITLE
fix(libp2p): drop empty addrs in AddrsFactory

### DIFF
--- a/core/node/libp2p/addrs.go
+++ b/core/node/libp2p/addrs.go
@@ -88,6 +88,14 @@ func makeAddrsFactory(announce []string, appendAnnounce []string, noAnnounce []s
 
 		var out []ma.Multiaddr
 		for _, maddr := range addrs {
+			// Drop empty multiaddrs. Since go-multiaddr v0.15 made
+			// Multiaddr a slice type, a zero-value Multiaddr encodes to
+			// zero bytes and would otherwise reach the host's signed peer
+			// record, where peers render it as "/" and reject the address.
+			// See https://github.com/libp2p/js-libp2p/issues/3478#issuecomment-4322093929
+			if len(maddr) == 0 {
+				continue
+			}
 			// check for exact matches
 			ok := noAnnAddrs[string(maddr.Bytes())]
 			// check for /ipcidr matches

--- a/core/node/libp2p/addrs_test.go
+++ b/core/node/libp2p/addrs_test.go
@@ -1,0 +1,37 @@
+package libp2p
+
+import (
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// makeAddrsFactory must drop empty multiaddrs from the input list.
+// A zero-component Multiaddr would otherwise reach the host's signed
+// peer record and propagate to peers as "/" when they decode the wire
+// bytes.
+//
+// See https://github.com/libp2p/js-libp2p/issues/3478#issuecomment-4322093929
+func TestMakeAddrsFactoryDropsEmptyMultiaddrs(t *testing.T) {
+	factory, err := makeAddrsFactory(nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	good, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := []ma.Multiaddr{nil, good, {}, good}
+	out := factory(in)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 addrs after factory filter, got %d: %v", len(out), out)
+	}
+	for i, a := range out {
+		if len(a) == 0 {
+			t.Fatalf("factory returned an empty multiaddr at index %d", i)
+		}
+	}
+}


### PR DESCRIPTION
A zero-value `Multiaddr` (since go-multiaddr v0.15 is a slice type) encodes to zero bytes on the wire. `AddrsFactory` was passing such empty entries through to the host's signed peer record, where peers that skip the empty-input check render them as `"/"` and reject the address. js-libp2p autonatv2 first flagged this against a `kubo/0.39.0/2896aed/docker agent.`

`AddrsFactory` is the central chokepoint for kubo's announced addresses, so filtering here scrubs every downstream consumer until the upstream go-libp2p fix lands.

- See https://github.com/libp2p/js-libp2p/issues/3478#issuecomment-4322093929

I also opened PR upstream:
- https://github.com/libp2p/go-libp2p/pull/3494

but my current policy for libp2p regressions is "belt and suspenders" so this PR  will ship anyway so Kubo release cycle is not blocked by libp2p (if possible)

<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
