### PR TITLE
docs: clarify blockstore cache sizing and flatfs sharding

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -966,25 +966,43 @@ Type: `bool`
 
 ### `Datastore.BloomFilterSize`
 
-A number representing the size in bytes of the blockstore's [bloom
-filter](https://en.wikipedia.org/wiki/Bloom_filter). A value of zero represents
-the feature is disabled.
+The size in **bytes** of the blockstore's [bloom filter](https://en.wikipedia.org/wiki/Bloom_filter).
+A value of `0` disables the feature.
 
-This site generates useful graphs for various bloom filter values:
-<https://hur.st/bloomfilter/?n=1e6&p=0.01&m=&k=7> You may use it to find a
-preferred optimal value, where `m` is `BloomFilterSize` in bits. Remember to
-convert the value `m` from bits, into bytes for use as `BloomFilterSize` in the
-config file. For example, for 1,000,000 blocks, expecting a 1% false-positive
-rate, you'd end up with a filter size of 9592955 bits, so for `BloomFilterSize`
-we'd want to use 1199120 bytes. As of writing, [7 hash
-functions](https://github.com/ipfs/go-ipfs-blockstore/blob/547442836ade055cc114b562a3cc193d4e57c884/caching.go#L22)
-are used, so the constant `k` is 7 in the formula.
+The bloom filter answers "does the blockstore *not* have this CID?" from RAM
+without touching the datastore. A negative answer is exact (no false negatives);
+a positive answer is probabilistic and falls through to the underlying
+blockstore for verification. This is most useful on nodes that respond to many
+bitswap wantlists for content they don't host (public gateways, peers asking
+for opportunistically-cached content, etc.).
 
-Enabling the BloomFilter can provide performance improvements specially when
-responding to many requests for inexistent blocks. It however requires a full
-sweep of all the datastore keys on daemon start. On very large datastores this
-can be a very taxing operation, particularly if the datastore does not support
-querying existing keys without reading their values at the same time (blocks).
+The complementary cache for the *positive* path (block exists, look up its
+size) is [`Datastore.BlockKeyCacheSize`](#datastoreblockkeycachesize).
+
+#### Sizing
+
+[hur.st/bloomfilter](https://hur.st/bloomfilter/?n=1e6&p=0.01&m=&k=7) generates
+graphs for various values; use it to pick `m` (in bits) for your expected
+number of blocks `n` and target false-positive rate `p`. The `BloomFilterSize`
+config value is `m / 8` (the kubo blockstore uses `k=7` hash functions).
+
+Worked example: for `n=1,000,000` blocks at `p=1%` FPR, you need
+`m=9,592,955` bits, so `BloomFilterSize: 1199120`.
+
+The filter is fixed-size and stops being useful once the number of inserted
+CIDs grows past its design `n`: the false-positive rate climbs and eventually
+saturates near 100%, at which point every "maybe" hits the datastore anyway.
+Resize the filter as your blockstore grows.
+
+#### Startup cost
+
+The filter is rebuilt on every daemon start by walking all datastore keys
+(`AllKeysChan`). On very large blockstores or slow disks this can take many
+minutes, during which `Has()` falls through to the datastore and the filter
+provides no benefit. The filter is not persisted across restarts. Datastores
+that cannot enumerate keys without reading values (block content) make this
+much more expensive; flatfs and pebble both support keys-only iteration, so
+the rebuild cost is proportional to the keyset, not to data volume.
 
 Default: `0` (disabled)
 
@@ -1011,16 +1029,38 @@ Type: `bool`
 
 ### `Datastore.BlockKeyCacheSize`
 
-A number representing the maximum size in bytes of the blockstore's Two-Queue
-cache, which caches block-cids and their block-sizes. Use `0` to disable.
+The maximum **number of entries** held in the blockstore's Two-Queue cache. The
+cache stores per-CID metadata (existence and block size) but never block
+content. Use `0` to disable.
 
-This cache, once primed, can greatly speed up operations like `ipfs repo stat`
-as there is no need to read full blocks to know their sizes. Size should be
-adjusted depending on the number of CIDs on disk (`NumObjects in`ipfs repo stat`).
+A cache hit answers `Has` and `GetSize` from RAM and skips the underlying
+datastore lookup. This includes the per-block `os.Stat` flatfs does to learn a
+block's size, which is the dominant cost on bitswap servers responding to peer
+wantlists.
 
-Default: `65536` (64KiB)
+The cache uses a [Two-Queue (2Q) replacement policy](https://pkg.go.dev/github.com/hashicorp/golang-lru/v2#TwoQueueCache):
+items have to be touched twice before they get promoted to the frequently-used
+tier. A long one-shot scan (reprovider walking the blockstore, GC, `ipfs repo
+verify`) does not evict the hot entries that bitswap is repeatedly serving.
 
-Type: `optionalInteger` (non-negative, bytes)
+#### Sizing
+
+Memory usage is approximately the entry count times the per-entry overhead of
+the 2Q cache, the multihash key bytes, and the cached value. As a rough
+estimate, budget ~200 bytes per entry, so `1048576` (1M entries) is on the
+order of ~200 MB resident. The cache only needs to cover your **hot working
+set** of CIDs (the ones repeatedly hit by inbound bitswap, gateway, or
+DAG-resolution traffic), not the entire blockstore.
+
+The default of `65536` is sized for small dev/desktop nodes. Operators running
+public gateways, pinning clusters, or any node serving non-trivial bitswap
+traffic should size this against the active working set, see
+[`Datastore.BloomFilterSize`](#datastorebloomfiltersize) for the
+complementary negative-`Has()` short-circuit that pairs well with this cache.
+
+Default: `65536` (entries)
+
+Type: `optionalInteger` (non-negative, number of entries)
 
 ### `Datastore.Spec`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -973,15 +973,14 @@ The bloom filter answers "does the blockstore *not* have this CID?" from RAM
 without touching the datastore. A negative answer is exact (no false
 negatives, so blocks are never falsely reported missing); a positive answer
 is probabilistic and falls through to the underlying blockstore for
-verification. The probability that the filter says "maybe present" for a CID
-that is not actually in the blockstore is its **false-positive rate (FPR)**.
-A false positive costs one wasted datastore lookup, no more; it never causes
-data loss or incorrect retrieval. The smaller the FPR, the larger the
-fraction of inbound `Has()` calls the filter can answer from RAM alone.
+verification. The chance of a false "maybe present" is the filter's
+**false-positive rate (FPR)**. A false positive costs one wasted datastore
+lookup; it never causes data loss or incorrect retrieval. The lower the FPR,
+the more `Has()` calls the filter answers from RAM alone.
 
-This caching is most useful on nodes that respond to many bitswap wantlists
-for content they don't host (public gateways, peers asking for
-opportunistically-cached content, etc.).
+This cache pays off most on nodes that field many requests for content they
+don't host: public gateways, mirrors, and peers asked to serve
+opportunistically-cached blocks.
 
 The complementary cache for the *positive* path (block exists, look up its
 size) is [`Datastore.BlockKeyCacheSize`](#datastoreblockkeycachesize).
@@ -1001,9 +1000,11 @@ sizing:
    power-of-two byte counts: 1 MiB, 2 MiB, 4 MiB, ..., 256 MiB, 512 MiB,
    1 GiB.
 2. **Fixed `k=7`.** With seven hash positions, FPR for a filter of `m`
-   bits and `n` inserted entries is `(1 - exp(-7n/m))^7`. Memory cost
-   is roughly ~1.2 bytes per entry at ~1% FPR, ~1.9 bytes per entry at
-   ~0.1% FPR, and ~2.8 bytes per entry at ~0.01% FPR.
+   bits and `n` inserted entries is `(1 - exp(-7n/m))^7`. To hit a
+   target FPR, budget roughly ~1.8 bytes per entry at ~1% FPR, ~2.8
+   bytes per entry at ~0.1% FPR, and ~4.2 bytes per entry at ~0.01%
+   FPR. These figures already include the average ~1.5x penalty from
+   the power-of-two rounding above; the worst case is ~2x.
 
 #### Reference sizing
 
@@ -1012,12 +1013,11 @@ FPR you can expect at the design point and at 2× growth:
 
 | Expected blocks (`n`) | `BloomFilterSize` | FPR at `n` | FPR at 2× `n` |
 |---:|---:|---:|---:|
-| 10,000,000  | `16777216`   (16 MiB)  | ~0.18% | ~5%  |
-| 25,000,000  | `33554432`   (32 MiB)  | ~0.58% | ~11% |
-| 50,000,000  | `67108864`   (64 MiB)  | ~0.58% | ~11% |
-| 100,000,000 | `134217728`  (128 MiB) | ~0.58% | ~11% |
-| 200,000,000 | `268435456`  (256 MiB) | ~0.58% | ~11% |
-| 500,000,000 | `1073741824` (1 GiB)   | ~0.07% | ~1.7% |
+| 10,000,000  | `16777216`  (16 MiB)  | ~0.18% | ~5%  |
+| 25,000,000  | `33554432`  (32 MiB)  | ~0.58% | ~11% |
+| 50,000,000  | `67108864`  (64 MiB)  | ~0.58% | ~11% |
+| 100,000,000 | `134217728` (128 MiB) | ~0.58% | ~11% |
+| 200,000,000 | `268435456` (256 MiB) | ~0.58% | ~11% |
 
 For a tighter FPR at the design point, step up to the next power of two.
 
@@ -1042,10 +1042,10 @@ behavior with a filter sized for ~0.6% FPR at its design point:
 - At ~`8 × n` or more: above ~95% FPR. Effectively saturated. The
   filter answers "maybe" for nearly every CID and provides no benefit.
 
-Plan the filter for **expected steady-state size, not current size**, and
-re-tune when you cross the design point. There is no in-place way to
-grow a bloom filter; raising `BloomFilterSize` and restarting the daemon
-rebuilds it from scratch.
+Size for **expected steady-state, not today's count**, and re-tune after
+crossing the design point. Bloom filters cannot grow in place; raising
+`BloomFilterSize` and restarting the daemon rebuilds the filter from
+scratch.
 
 #### Risks of an undersized filter
 
@@ -1053,31 +1053,29 @@ A poorly-sized filter is **never a correctness issue**. Bloom filters
 have no false negatives, so blocks are never falsely reported missing.
 The risks are operational:
 
-- **Wasted RAM and CPU.** Every `Has()` runs the seven-position lookup.
-  Once the filter saturates those cycles are paid with nothing to show
-  for them.
+- **Wasted RAM and CPU.** Every `Has()` still runs all seven hash
+  positions. Once the filter saturates, those cycles return nothing.
 - **Silent regression as the pinset grows.** A filter sized for last
-  year's data can drift past the saturation threshold without any
-  metric screaming "your filter is useless"; you just stop seeing the
-  negative-`Has` short-circuit benefit.
-- **Recurring startup tax.** The filter is rebuilt on every daemon
-  restart (see below). On slow disks this is minutes of `AllKeysChan`
-  walking, paid in full even if the resulting filter is too small to
-  help.
+  year's data can drift past saturation without warning; the
+  negative-`Has` short-circuit benefit just quietly disappears.
+- **Recurring startup tax.** The filter rebuilds on every daemon
+  restart (see below). On slow disks this means minutes of
+  `AllKeysChan` walking, paid in full even when the resulting filter
+  is too small to help.
 
-Quick health check: if `BloomFilterSize` divided by your current block
-count is much below `1` byte/block, the filter is past its design
-point. Below ~`0.5` bytes/block it is effectively saturated.
+Quick health check: divide `BloomFilterSize` by your current block count.
+Below ~`1` byte/block the filter is past its design point; below
+~`0.5` bytes/block it is effectively saturated.
 
 #### Startup cost
 
-The filter is rebuilt on every daemon start by walking all datastore keys
-(`AllKeysChan`). On very large blockstores or slow disks this can take many
-minutes, during which `Has()` falls through to the datastore and the filter
-provides no benefit. The filter is not persisted across restarts. Datastores
-that cannot enumerate keys without reading values (block content) make this
-much more expensive; flatfs and pebble both support keys-only iteration, so
-the rebuild cost is proportional to the keyset, not to data volume.
+The filter is not persisted across restarts. Every daemon start rebuilds it
+by walking all datastore keys (`AllKeysChan`). On very large blockstores or
+slow disks this can take many minutes, during which `Has()` falls through
+to the datastore and the filter provides no benefit. Datastores that cannot
+enumerate keys without reading values (block content) pay even more here;
+flatfs and pebble both support keys-only iteration, so the rebuild cost
+scales with the keyset, not data volume.
 
 Default: `0` (disabled)
 
@@ -1114,22 +1112,22 @@ block's size, which is the dominant cost on bitswap servers responding to peer
 wantlists.
 
 The cache uses a [Two-Queue (2Q) replacement policy](https://pkg.go.dev/github.com/hashicorp/golang-lru/v2#TwoQueueCache):
-items have to be touched twice before they get promoted to the frequently-used
-tier. A long one-shot scan (reprovider walking the blockstore, GC, `ipfs repo
-verify`) does not evict the hot entries that bitswap is repeatedly serving.
+an entry must be touched twice before it is promoted to the frequently-used
+tier. A long one-shot scan (reprovider, GC, `ipfs repo verify`) therefore
+does not evict the hot entries that bitswap repeatedly serves.
 
 #### Sizing
 
-Memory usage is approximately the entry count times the per-entry overhead of
-the 2Q cache, the multihash key bytes, and the cached value. As a rough
-estimate, budget ~200 bytes per entry, so `1048576` (1M entries) is on the
-order of ~200 MB resident. The cache only needs to cover your **hot working
-set** of CIDs (the ones repeatedly hit by inbound bitswap, gateway, or
-DAG-resolution traffic), not the entire blockstore.
+Memory usage is roughly the entry count times the per-entry overhead, which
+combines 2Q bookkeeping, the multihash key bytes, and the cached value. As a
+rough estimate, budget ~200 bytes per entry, so `1048576` (1M entries) is on
+the order of ~200 MB resident. The cache only needs to cover the **hot
+working set** of CIDs (the ones repeatedly hit by inbound bitswap, gateway,
+or DAG-resolution traffic), not the entire blockstore.
 
-The default of `65536` is sized for small dev/desktop nodes. Operators running
-public gateways, pinning clusters, or any node serving non-trivial bitswap
-traffic should size this against the active working set, see
+The default of `65536` is sized for small dev/desktop nodes. Operators
+running public gateways, pinning clusters, or any node serving non-trivial
+bitswap traffic should size this against the active working set. See
 [`Datastore.BloomFilterSize`](#datastorebloomfiltersize) for the
 complementary negative-`Has()` short-circuit that pairs well with this cache.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -970,11 +970,18 @@ The size in **bytes** of the blockstore's [bloom filter](https://en.wikipedia.or
 A value of `0` disables the feature.
 
 The bloom filter answers "does the blockstore *not* have this CID?" from RAM
-without touching the datastore. A negative answer is exact (no false negatives);
-a positive answer is probabilistic and falls through to the underlying
-blockstore for verification. This is most useful on nodes that respond to many
-bitswap wantlists for content they don't host (public gateways, peers asking
-for opportunistically-cached content, etc.).
+without touching the datastore. A negative answer is exact (no false
+negatives, so blocks are never falsely reported missing); a positive answer
+is probabilistic and falls through to the underlying blockstore for
+verification. The probability that the filter says "maybe present" for a CID
+that is not actually in the blockstore is its **false-positive rate (FPR)**.
+A false positive costs one wasted datastore lookup, no more; it never causes
+data loss or incorrect retrieval. The smaller the FPR, the larger the
+fraction of inbound `Has()` calls the filter can answer from RAM alone.
+
+This caching is most useful on nodes that respond to many bitswap wantlists
+for content they don't host (public gateways, peers asking for
+opportunistically-cached content, etc.).
 
 The complementary cache for the *positive* path (block exists, look up its
 size) is [`Datastore.BlockKeyCacheSize`](#datastoreblockkeycachesize).

--- a/docs/config.md
+++ b/docs/config.md
@@ -979,20 +979,88 @@ for opportunistically-cached content, etc.).
 The complementary cache for the *positive* path (block exists, look up its
 size) is [`Datastore.BlockKeyCacheSize`](#datastoreblockkeycachesize).
 
-#### Sizing
+#### How kubo's bloom filter is sized
 
-[hur.st/bloomfilter](https://hur.st/bloomfilter/?n=1e6&p=0.01&m=&k=7) generates
-graphs for various values; use it to pick `m` (in bits) for your expected
-number of blocks `n` and target false-positive rate `p`. The `BloomFilterSize`
-config value is `m / 8` (the kubo blockstore uses `k=7` hash functions).
+Kubo wires the underlying [`ipfs/bbloom`](https://github.com/ipfs/bbloom)
+filter with `k=7` hash positions. Two kubo-specific behaviors matter for
+sizing:
 
-Worked example: for `n=1,000,000` blocks at `p=1%` FPR, you need
-`m=9,592,955` bits, so `BloomFilterSize: 1199120`.
+1. **Power-of-two bit-count rounding.** bbloom rounds the requested bit
+   count up to the next power of two, so a `BloomFilterSize` value that is
+   not itself a power of two in bits silently allocates more memory than
+   configured. For example, `BloomFilterSize: 1199120` (~1.14 MiB)
+   actually allocates a `16,777,216`-bit (= 2 MiB) filter internally. For
+   predictable behavior, pick `BloomFilterSize` values that are
+   power-of-two byte counts: 1 MiB, 2 MiB, 4 MiB, ..., 256 MiB, 512 MiB,
+   1 GiB.
+2. **Fixed `k=7`.** With seven hash positions, FPR for a filter of `m`
+   bits and `n` inserted entries is `(1 - exp(-7n/m))^7`. Memory cost
+   is roughly ~1.2 bytes per entry at ~1% FPR, ~1.9 bytes per entry at
+   ~0.1% FPR, and ~2.8 bytes per entry at ~0.01% FPR.
 
-The filter is fixed-size and stops being useful once the number of inserted
-CIDs grows past its design `n`: the false-positive rate climbs and eventually
-saturates near 100%, at which point every "maybe" hits the datastore anyway.
-Resize the filter as your blockstore grows.
+#### Reference sizing
+
+Power-of-two `BloomFilterSize` values for common blockset sizes, with the
+FPR you can expect at the design point and at 2× growth:
+
+| Expected blocks (`n`) | `BloomFilterSize` | FPR at `n` | FPR at 2× `n` |
+|---:|---:|---:|---:|
+| 10,000,000  | `16777216`   (16 MiB)  | ~0.18% | ~5%  |
+| 25,000,000  | `33554432`   (32 MiB)  | ~0.58% | ~11% |
+| 50,000,000  | `67108864`   (64 MiB)  | ~0.58% | ~11% |
+| 100,000,000 | `134217728`  (128 MiB) | ~0.58% | ~11% |
+| 200,000,000 | `268435456`  (256 MiB) | ~0.58% | ~11% |
+| 500,000,000 | `1073741824` (1 GiB)   | ~0.07% | ~1.7% |
+
+For a tighter FPR at the design point, step up to the next power of two.
+
+The [hur.st/bloomfilter](https://hur.st/bloomfilter/?n=10e6&p=0.01&m=&k=7)
+calculator works as a reference for exploring `(n, p, m)` combinations
+(remember kubo uses `k=7`); just keep in mind that the `m` it suggests
+is the optimal-fit value, while bbloom rounds up to the next power of
+two on top of that.
+
+#### Saturation as the repo grows
+
+A bloom filter is fixed-size after creation. As more CIDs are inserted
+past its design `n`, the false-positive rate climbs steeply. Rough
+behavior with a filter sized for ~0.6% FPR at its design point:
+
+- At `n`: ~0.6% FPR. Every "definitely not" reliably saves a datastore
+  lookup.
+- At ~`2 × n`: ~11% FPR. Most negatives still save lookups, but tail
+  latency rises because each "maybe" still hits the datastore.
+- At ~`4 × n`: ~58% FPR. Most "maybe" answers fall through. The filter
+  is mostly paying CPU and RAM cost without short-circuiting much.
+- At ~`8 × n` or more: above ~95% FPR. Effectively saturated. The
+  filter answers "maybe" for nearly every CID and provides no benefit.
+
+Plan the filter for **expected steady-state size, not current size**, and
+re-tune when you cross the design point. There is no in-place way to
+grow a bloom filter; raising `BloomFilterSize` and restarting the daemon
+rebuilds it from scratch.
+
+#### Risks of an undersized filter
+
+A poorly-sized filter is **never a correctness issue**. Bloom filters
+have no false negatives, so blocks are never falsely reported missing.
+The risks are operational:
+
+- **Wasted RAM and CPU.** Every `Has()` runs the seven-position lookup.
+  Once the filter saturates those cycles are paid with nothing to show
+  for them.
+- **Silent regression as the pinset grows.** A filter sized for last
+  year's data can drift past the saturation threshold without any
+  metric screaming "your filter is useless"; you just stop seeing the
+  negative-`Has` short-circuit benefit.
+- **Recurring startup tax.** The filter is rebuilt on every daemon
+  restart (see below). On slow disks this is minutes of `AllKeysChan`
+  walking, paid in full even if the resulting filter is too small to
+  help.
+
+Quick health check: if `BloomFilterSize` divided by your current block
+count is much below `1` byte/block, the filter is past its design
+point. Below ~`0.5` bytes/block it is effectively saturated.
 
 #### Startup cost
 

--- a/docs/datastores.md
+++ b/docs/datastores.md
@@ -16,7 +16,9 @@ Stores each key-value pair as a file on the filesystem.
 
 The shardFunc is prefixed with `/repo/flatfs/shard/v1` then followed by a descriptor of the sharding strategy. Some example values are:
 - `/repo/flatfs/shard/v1/next-to-last/2`
-  - Shards on the two next to last characters of the key
+  - Shards on the two next-to-last base32 characters of the key (~1024 directories)
+- `/repo/flatfs/shard/v1/next-to-last/3`
+  - Shards on the three next-to-last base32 characters of the key (~32,768 directories)
 - `/repo/flatfs/shard/v1/prefix/2`
   - Shards based on the two-character prefix of the key
 
@@ -32,6 +34,35 @@ The shardFunc is prefixed with `/repo/flatfs/shard/v1` then followed by a descri
 - `sync`: Flush every write to disk before continuing. Setting this to false is safe as kubo will automatically flush writes to disk before and after performing critical operations like pinning. However, you can set this to true to be extra-safe (at the cost of a slowdown when adding files).
 
 NOTE: flatfs must only be used as a block store (mounted at `/blocks`) as it only partially implements the datastore interface. You can mount flatfs for /blocks only using the mount datastore (described below).
+
+### Choosing a `shardFunc` for large blockstores
+
+The `next-to-last/N` shard depth controls how many directories the blockstore
+is spread across. Each shard becomes a single directory under `blocks/`, and
+every block file lives directly inside its shard. The cost of any operation
+that does a `readdir` or per-file `stat` on a shard scales with the number of
+files in that shard.
+
+Two depths in common use:
+
+| `shardFunc`              | Shard count | At 60M blocks | Notes                                    |
+|--------------------------|------------:|--------------:|------------------------------------------|
+| `next-to-last/2`         | ~1,024      | ~58k files/dir| default; fine for small/medium nodes     |
+| `next-to-last/3`         | ~32,768     | ~1.8k files/dir| recommended for large pinning/gateway nodes |
+
+For nodes expected to grow past a few million blocks (most pinning clusters,
+public gateways, mirrors), prefer `next-to-last/3`. The deeper sharding keeps
+per-directory file counts in a range modern filesystems handle well, and it
+significantly reduces the per-operation cost of `Stat`, `readdir`, and bulk
+enumeration (used by GC, [`Datastore.BloomFilterSize`](config.md#datastorebloomfiltersize)
+rebuild on startup, and `Provide.Strategy=all` reprovide cycles). On nodes
+backed by rotational disks the difference can be the gap between healthy
+operation and IOPS-saturated iowait.
+
+The shard depth is fixed at `ipfs init` time. Existing repos cannot be
+re-sharded in place; migrating to a different depth requires exporting and
+re-importing the blockstore, so pick conservatively for the expected steady
+state of the node.
 
 ## levelds
 

--- a/docs/datastores.md
+++ b/docs/datastores.md
@@ -45,10 +45,10 @@ files in that shard.
 
 Two depths in common use:
 
-| `shardFunc`              | Shard count | At 60M blocks | Notes                                    |
-|--------------------------|------------:|--------------:|------------------------------------------|
-| `next-to-last/2`         | ~1,024      | ~58k files/dir| default; fine for small/medium nodes     |
-| `next-to-last/3`         | ~32,768     | ~1.8k files/dir| recommended for large pinning/gateway nodes |
+| `shardFunc`              | Shard count | At 60M blocks   | Notes                                       |
+|--------------------------|------------:|----------------:|---------------------------------------------|
+| `next-to-last/2`         | ~1,024      | ~58k files/dir  | default; fine for small/medium nodes        |
+| `next-to-last/3`         | ~32,768     | ~1.8k files/dir | recommended for large pinning/gateway nodes |
 
 For nodes expected to grow past a few million blocks (most pinning clusters,
 public gateways, mirrors), prefer `next-to-last/3`. The deeper sharding keeps
@@ -59,10 +59,10 @@ rebuild on startup, and `Provide.Strategy=all` reprovide cycles). On nodes
 backed by rotational disks the difference can be the gap between healthy
 operation and IOPS-saturated iowait.
 
-The shard depth is fixed at `ipfs init` time. Existing repos cannot be
-re-sharded in place; migrating to a different depth requires exporting and
-re-importing the blockstore, so pick conservatively for the expected steady
-state of the node.
+The shard depth is fixed at `ipfs init` time. Kubo ships no in-place
+re-sharding tool, so switching depth on an existing repo means exporting
+and re-importing the blockstore. Pick conservatively for the expected
+steady state of the node.
 
 ## levelds
 


### PR DESCRIPTION
Documenting some poorly documented knobs that we recently tuned in collab cluser in https://github.com/ipshipyard/waterworks-infra/pull/964 (+ ipfs/bbloom learnings from https://github.com/ipfs/boxo/pull/1124)


## Summary

Docs-only update for two operationally important blockstore knobs and the flatfs sharding choice.

- `Datastore.BlockKeyCacheSize`: corrects the unit (entries, not bytes) and explains 2Q semantics, sizing against the hot working set, and the pairing with the bloom filter.
- `Datastore.BloomFilterSize`: explains the negative-`Has()` short-circuit, kubo's fixed `k=7`, bbloom's power-of-two rounding, saturation as the repo grows, startup rebuild cost, and a power-of-two reference table. Byte/entry guidance now folds in the average ~1.5x rounding penalty (worst case ~2x).
- `docs/datastores.md`: documents `next-to-last/3` for large pinning/gateway nodes, with a shard-count comparison and a note that switching depth requires export/import.

## Test plan

- [x] Render `docs/config.md` and `docs/datastores.md` on GitHub and confirm tables, anchors, and cross-links resolve.
- [x] Spot-check FPR figures against the [hur.st calculator](https://hur.st/bloomfilter/?n=10e6&p=0.01&m=&k=7) at `k=7`. (accounting for rounding up)