### PR TITLE
chore: go 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # The default below is what `docker build .` (without --build-arg) uses, and
 # `.github/workflows/docker-check.yml` lints that this default stays in sync
 # with go.mod. When bumping Go, update both go.mod and this default together.
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.4
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:${GO_VERSION} AS builder
 
 ARG TARGETOS TARGETARCH

--- a/docs/changelogs/v0.42.md
+++ b/docs/changelogs/v0.42.md
@@ -116,6 +116,7 @@ The Prometheus endpoint no longer emits the `otel_scope_info` metric. Each metri
 
 #### 📦️ Dependency updates
 
+- update Go to [1.26.4](https://go.dev/doc/devel/release#go1.26.4)
 - update `go-libp2p-pubsub` to [v0.16.0](https://github.com/libp2p/go-libp2p-pubsub/releases/tag/v0.16.0)
 - update `go-libp2p-kad-dht` to [v0.40.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.40.0) (incl. [v0.39.2](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.39.2))
 - update `go-fuse/v2` to [v2.10.1](https://github.com/hanwen/go-fuse/releases/tag/v2.10.1)

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/kubo/examples/kubo-as-a-library
 
-go 1.26.2
+go 1.26.4
 
 // Used to keep this in sync with the current version of kubo. You should remove
 // this if you copy this example.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/kubo
 
-go 1.26.2
+go 1.26.4
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/kubo/test/dependencies
 
-go 1.26.2
+go 1.26.4
 
 replace github.com/ipfs/kubo => ../../
 


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.2 to 1.26.4 