### PR TITLE
fix: avoid redundant cidset in dag stat

### DIFF
--- a/core/commands/dag/stat.go
+++ b/core/commands/dag/stat.go
@@ -37,7 +37,18 @@ func dagStat(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) 
 
 	nodeGetter := mdag.NewSession(req.Context, api.Dag())
 
-	cidSet := cid.NewSet()
+	// boxo's Traverse (SkipDuplicates below) keeps its own per-root "seen" set,
+	// so within a single root it never visits the same CID twice. A command-level
+	// cidSet is needed only to dedup *across* multiple roots, for the global
+	// UniqueBlocks and TotalSize counts. With one root it would hold a second
+	// copy of every CID the traversal already tracks, doubling the memory spent
+	// just on remembering which CIDs were seen. On very large DAGs that second
+	// copy has OOM-killed daemons running `dag stat` over multi-hundred-GiB
+	// UnixFS roots, so allocate it only when there is more than one root.
+	var cidSet *cid.Set
+	if len(req.Arguments) > 1 {
+		cidSet = cid.NewSet()
+	}
 	dagStatSummary := &DagStatSummary{DagStatsArray: []*DagStat{}}
 	for _, a := range req.Arguments {
 		p, err := cmdutils.PathOrCidPath(a)
@@ -65,11 +76,15 @@ func dagStat(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) 
 				currentNodeSize := uint64(len(current.Node.RawData()))
 				dagstats.Size += currentNodeSize
 				dagstats.NumBlocks++
-				if !cidSet.Has(current.Node.Cid()) {
+				// With a single root, boxo's SkipDuplicates guarantees each CID is
+				// visited exactly once, so every block counts toward the global
+				// unique total. With multiple roots, cidSet tracks which CIDs were
+				// already counted under a previous root (Visit reports true the
+				// first time a CID is seen).
+				if cidSet == nil || cidSet.Visit(current.Node.Cid()) {
 					dagStatSummary.incrementTotalSize(currentNodeSize)
 				}
 				dagStatSummary.incrementRedundantSize(currentNodeSize)
-				cidSet.Add(current.Node.Cid())
 				if progressive {
 					if err := res.Emit(dagStatSummary); err != nil {
 						return err
@@ -85,7 +100,15 @@ func dagStat(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) 
 		}
 	}
 
-	dagStatSummary.UniqueBlocks = cidSet.Len()
+	if cidSet != nil {
+		dagStatSummary.UniqueBlocks = cidSet.Len()
+	} else {
+		// Single root: boxo deduplicated within the traversal, so the number of
+		// unique blocks equals the number of blocks visited.
+		for _, ds := range dagStatSummary.DagStatsArray {
+			dagStatSummary.UniqueBlocks += int(ds.NumBlocks)
+		}
+	}
 	dagStatSummary.calculateSummary()
 
 	if err := res.Emit(dagStatSummary); err != nil {

--- a/test/cli/dag_test.go
+++ b/test/cli/dag_test.go
@@ -110,6 +110,38 @@ func TestDag(t *testing.T) {
 		stat := node.RunIPFS("dag", "stat", "--progress=false", node1Cid, node2Cid)
 		assert.Equal(t, content, stat.Stdout.Bytes())
 	})
+
+	t.Run("ipfs dag stat single root", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init().StartDaemon()
+		defer node.StopDaemon()
+
+		r, err := os.Open(fixtureFile)
+		assert.NoError(t, err)
+		defer r.Close()
+		err = node.IPFSDagImport(r, fixtureCid)
+		assert.NoError(t, err)
+
+		// Stat a single root. boxo dedups shared blocks during the traversal, so
+		// the result reports no redundancy: SharedSize is 0 and Ratio is 1.
+		stat := node.RunIPFS("dag", "stat", "--progress=false", "--enc=json", fixtureCid)
+		var data Data
+		err = json.Unmarshal(stat.Stdout.Bytes(), &data)
+		assert.NoError(t, err)
+
+		// root (95B) + node1 (46B) + node2 (46B) + shared child (7B) = 4 blocks, 194B
+		assert.Equal(t, 4, data.UniqueBlocks)
+		assert.Equal(t, 194, data.TotalSize)
+		assert.Equal(t, 0, data.SharedSize)
+		assert.Equal(t, float64(1), data.Ratio)
+
+		// With one root, every counted block is unique, so the summary totals
+		// match that root's own block count and size.
+		require.Len(t, data.DagStats, 1)
+		assert.Equal(t, fixtureCid, data.DagStats[0].Cid)
+		assert.Equal(t, data.UniqueBlocks, data.DagStats[0].NumBlocks)
+		assert.Equal(t, data.TotalSize, data.DagStats[0].Size)
+	})
 }
 
 func TestDagImportCARv2(t *testing.T) {


### PR DESCRIPTION
> [!NOTE]
> Low priority, one of easy wins where we can lower memory use by simply dropping redundant CID set used for deduplication


## Problem

`ipfs dag stat` walks a DAG and keeps a list of every block it has seen, so it never counts the same block twice. Trouble is, the library doing the walk (boxo) already keeps that exact list. So for one DAG we held two copies of every block CID. On a huge DAG (hundreds of GB) each copy is big, and the second one was enough to run the daemon on low power devices out of memory and kill it mid-scan.

## Fix

- Keep our own list only when you ask for more than one DAG at once, the one case where it's actually needed (to catch blocks shared between them).
- For a single DAG, drop it and trust the list boxo already keeps.

The reported numbers come out the same either way. This roughly halves the memory used for the common single-DAG case. It doesn't put a cap on memory for truly giant DAGs; that needs a boxo change (ipfs/boxo#1168) and is tracked separately (non-memory-bound cid set implementation is exercise for future PR, once that boxo lands, not blocking this one).