### PR TITLE
docs: clarify optimistic provide is default-on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,21 @@ ipfs shutdown              # graceful shutdown via API
 
 Kill dangling daemons before re-running tests: `pkill -f "ipfs daemon"`
 
+### Use Non-Default Ports for Manual Experiments
+
+A real IPFS node may already be running on the host using the default ports: swarm `4001`, RPC API `5001`, and gateway `8080`. Any manual experiment, PoC, or benchmark daemon you start MUST use non-default ports (and its own `IPFS_PATH`) so it does not collide with or disrupt that node. Binding a default port fails with `address already in use`, and reusing another node's API can interfere with it.
+
+```bash
+export IPFS_PATH="$(mktemp -d)"
+ipfs init >/dev/null
+ipfs config --json Addresses.Swarm '["/ip4/0.0.0.0/tcp/4101","/ip4/0.0.0.0/udp/4101/quic-v1"]'
+ipfs config Addresses.API /ip4/127.0.0.1/tcp/5101
+ipfs config Addresses.Gateway /ip4/127.0.0.1/tcp/8181
+ipfs daemon
+```
+
+Target your own node explicitly with `ipfs --api=/ip4/127.0.0.1/tcp/5101 ...`. Shut down only the daemons you started (track their PIDs); do not `pkill` indiscriminately when another node may be running on the host.
+
 ### Testing AutoTLS Locally
 
 AutoTLS only requests a `*.libp2p.direct` certificate once libp2p confirms the node is publicly reachable on a TCP port. For a local test the node must be able to open that port, so enable UPnP/NAT-PMP (the `server` init profile disables it via `Swarm.DisableNatPortMap: true`):

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -491,7 +491,11 @@ Stable, enabled by default
 
 ### State
 
-Experimental, disabled by default.
+Enabled by default since Kubo 0.39.
+
+The sweep provider has been the default since Kubo 0.39, and it turns optimistic provide on for you. So most nodes already use it. Optimistic provide speeds up the immediate announcement of a root CID when you run `ipfs add`. Scheduled reprovides do not use it; they go through the sweep provider.
+
+You only need the `Experimental.OptimisticProvide` flag if you run the legacy provider ([`Provide.DHT.SweepEnabled=false`](https://github.com/ipfs/kubo/blob/master/docs/config.md#providedhtsweepenabled)). Set it to `true` there to turn optimistic provide on.
 
 When the Amino DHT client tries to store a provider in the DHT, it typically searches for the 20 peers that are closest to the
 target key. However, this process can be time-consuming, as the search terminates only after no closer peers are found
@@ -535,17 +539,21 @@ than the classic client.
 
 For more information, see:
 
+- ProbeLab measurements and explainer: https://probelab.io/blog/optimistic-provide/
 - Project doc: https://protocollabs.notion.site/Optimistic-Provide-2c79745820fa45649d48de038516b814
 - go-libp2p-kad-dht: https://github.com/libp2p/go-libp2p-kad-dht/pull/783
 
 ### Configuring
-To enable:
+
+With the default sweep provider, optimistic provide is already enabled and there is nothing to configure. The settings below only matter when running the legacy provider (`Provide.DHT.SweepEnabled=false`).
+
+To enable optimistic provide for the legacy provider:
 
 ```
 ipfs config --json Experimental.OptimisticProvide true
 ```
 
-If you want to change the `OptimisticProvideJobsPoolSize` setting from its default of 60:
+To change the `OptimisticProvideJobsPoolSize` setting from its default of 60:
 
 ```
 ipfs config --json Experimental.OptimisticProvideJobsPoolSize 120


### PR DESCRIPTION
Clarifies that optimistic provide has been enabled by default since Kubo v0.39 (it rides on the default sweep provider) and that the `Experimental.OptimisticProvide` flag now only matters for the legacy provider, with a link to the ProbeLab explainer.

(+ small improvement to AGENTS.md so they run tests in proper isolation)