### PR TITLE
fix: return error instead of log.Fatal in HolePunching

### DIFF
--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -2,6 +2,7 @@ package libp2p
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ipfs/kubo/config"
 	"github.com/libp2p/go-libp2p"
@@ -109,10 +110,10 @@ func HolePunching(flag config.Flag, hasRelayClient bool) func() (opts Libp2pOpts
 	return func() (opts Libp2pOpts, err error) {
 		if flag.WithDefault(true) {
 			if !hasRelayClient {
-				// If hole punching is explicitly enabled but the relay client is disabled then panic,
-				// otherwise just silently disable hole punching
+				// If hole punching is explicitly enabled but the relay client is disabled,
+				// return an error; otherwise just silently disable hole punching.
 				if flag != config.Default {
-					log.Fatal("Failed to enable `Swarm.EnableHolePunching`, it requires `Swarm.RelayClient.Enabled` to be true.")
+					err = fmt.Errorf("failed to enable Swarm.EnableHolePunching: it requires Swarm.RelayClient.Enabled to be true")
 				} else {
 					log.Info("HolePunching has been disabled due to the RelayClient being disabled.")
 				}

--- a/core/node/libp2p/relay_test.go
+++ b/core/node/libp2p/relay_test.go
@@ -1,0 +1,33 @@
+package libp2p
+
+import (
+	"testing"
+
+	"github.com/ipfs/kubo/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHolePunching(t *testing.T) {
+	t.Run("explicitly enabled without a relay client fails startup", func(t *testing.T) {
+		_, err := HolePunching(config.True, false)()
+		require.Error(t, err)
+	})
+
+	t.Run("left at default without a relay client is silently disabled", func(t *testing.T) {
+		opts, err := HolePunching(config.Default, false)()
+		require.NoError(t, err)
+		require.Empty(t, opts.Opts)
+	})
+
+	t.Run("explicitly disabled without a relay client is a no-op", func(t *testing.T) {
+		opts, err := HolePunching(config.False, false)()
+		require.NoError(t, err)
+		require.Empty(t, opts.Opts)
+	})
+
+	t.Run("enabled with a relay client adds the libp2p option", func(t *testing.T) {
+		opts, err := HolePunching(config.True, true)()
+		require.NoError(t, err)
+		require.Len(t, opts.Opts, 1)
+	})
+}

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -45,4 +45,6 @@ Silence the notice with [`Internal.CGNATCheck`](https://github.com/ipfs/kubo/blo
 
 ### 📝 Changelog
 
+- Replace `log.Fatal` with a proper error return in `HolePunching` when `Swarm.EnableHolePunching` is explicitly set but `Swarm.RelayClient.Enabled` is false. The daemon now fails to start with a descriptive error instead of abruptly terminating the process.
+
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -11,6 +11,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [🛜 One-time notice when behind CGNAT](#-one-time-notice-when-behind-cgnat)
+  - [🕳️ Clearer error when hole punching is misconfigured](#-clearer-error-when-hole-punching-is-misconfigured)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
@@ -37,6 +38,10 @@ Silence the notice with [`Internal.CGNATCheck`](https://github.com/ipfs/kubo/blo
 > [!IMPORTANT]
 > The daemon now refuses to start when [`Ipns.RecordLifetime`](https://github.com/ipfs/kubo/blob/master/docs/config.md#ipnsrecordlifetime) is shorter than [`Ipns.RepublishPeriod`](https://github.com/ipfs/kubo/blob/master/docs/config.md#ipnsrepublishperiod): records would expire before the republisher refreshes them, leaving the name unresolvable. Raise `Ipns.RecordLifetime` or lower `Ipns.RepublishPeriod` so the lifetime is at least the period.
 
+#### 🕳️ Clearer error when hole punching is misconfigured
+
+Setting [`Swarm.EnableHolePunching`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmenableholepunching) to `true` while [`Swarm.RelayClient.Enabled`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmrelayclientenabled) is `false` is an unsupported combination: hole punching needs the relay client to coordinate the upgrade from a relayed to a direct connection. Kubo now refuses to start with an error that names both settings, instead of exiting abruptly.
+
 #### 📦️ Dependency updates
 
 - update `p2p-forge/client` to [v0.9.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.9.0) (incl. [v0.8.1](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.8.1))
@@ -44,7 +49,5 @@ Silence the notice with [`Internal.CGNATCheck`](https://github.com/ipfs/kubo/blo
   - updates `github.com/cockroachdb/pebble` to [v2.1.6](https://github.com/cockroachdb/pebble/releases/tag/v2.1.6)
 
 ### 📝 Changelog
-
-- Replace `log.Fatal` with a proper error return in `HolePunching` when `Swarm.EnableHolePunching` is explicitly set but `Swarm.RelayClient.Enabled` is false. The daemon now fails to start with a descriptive error instead of abruptly terminating the process.
 
 ### 👨‍👩‍👧‍👦 Contributors


### PR DESCRIPTION
The HolePunching function in core/node/libp2p/relay.go calls log.Fatal when Swarm.EnableHolePunching is explicitly enabled but Swarm.RelayClient.Enabled is not true. log.Fatal immediately terminates the process with os.Exit(1), which bypasses normal shutdown hooks and prevents the fx framework from handling the failure gracefully. The function already has a named err return value, so returning an error is the correct Go idiom.

Replace log.Fatal(...) with err = fmt.Errorf(...) so the error propagates through fx's provider chain. This gives users a descriptive startup error message instead of an abrupt process termination. No behavioral change for the default case (where Swarm.EnableHolePunching is not explicitly set) — hole punching is still silently disabled when relay client is off.

