### PR TITLE
fix(daemon): return config errors instead of calling log.Fatal

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -461,7 +461,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		}
 	}
 
-	if key, _ := repo.SwarmKey(); key != nil || pnet.ForcePrivateNetwork {
+	if isPrivateNetwork {
 		// Private setups can't leverage peers returned by default IPNIs (Routing.Type=auto)
 		// To avoid breaking existing setups, switch them to DHT-only.
 		if routingOption == routingOptionAutoKwd {
@@ -531,6 +531,14 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		version.SetUserAgentSuffix(versionSuffix)
 	}
 
+	if err := validateDaemonConfig(cfg, routingOption, isPrivateNetwork); err != nil {
+		return err
+	}
+
+	if err := validateDaemonEnvironment(); err != nil {
+		return err
+	}
+
 	node, err := core.NewNode(req.Context, ncfg)
 	if err != nil {
 		return err
@@ -540,40 +548,6 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	if node.PNetFingerprint != nil {
 		fmt.Println("Swarm is limited to private network of peers with the swarm key")
 		fmt.Printf("Swarm key fingerprint: %x\n", node.PNetFingerprint)
-	}
-
-	if (pnet.ForcePrivateNetwork || node.PNetFingerprint != nil) && (routingOption == routingOptionAutoKwd || routingOption == routingOptionAutoClientKwd) {
-		// This should never happen, but better safe than sorry
-		log.Fatal("Private network does not work with Routing.Type=auto. Update your config to Routing.Type=dht (or none, and do manual peering)")
-	}
-	// Check for deprecated Provider/Reprovider configuration after migration
-	// This should never happen for regular users, but is useful error for people who have Docker orchestration
-	// that blindly sets config keys (overriding automatic Kubo migration).
-	//nolint:staticcheck // intentionally checking deprecated fields
-	if cfg.Provider.Enabled != config.Default || !cfg.Provider.Strategy.IsDefault() || !cfg.Provider.WorkerCount.IsDefault() {
-		log.Fatal("Deprecated configuration detected. Manually migrate 'Provider' fields to 'Provide' and remove 'Provider' from your config. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#provide")
-	}
-	//nolint:staticcheck // intentionally checking deprecated fields
-	if !cfg.Reprovider.Interval.IsDefault() || !cfg.Reprovider.Strategy.IsDefault() {
-		log.Fatal("Deprecated configuration detected. Manually migrate 'Reprovider' fields to 'Provide': Reprovider.Strategy -> Provide.Strategy, Reprovider.Interval -> Provide.DHT.Interval. Remove 'Reprovider' from your config. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#provide")
-	}
-	// Check for deprecated "flat" strategy (should have been migrated to "all")
-	if cfg.Provide.Strategy.WithDefault("") == "flat" {
-		log.Fatal("Provide.Strategy='flat' is no longer supported. Use 'all' instead. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy")
-	}
-	if cfg.Experimental.StrategicProviding {
-		log.Fatal("Experimental.StrategicProviding was removed. Remove it from your config. Documentation: https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md#strategic-providing")
-	}
-	// Check for invalid MaxWorkers=0 with SweepEnabled
-	if cfg.Provide.DHT.SweepEnabled.WithDefault(config.DefaultProvideDHTSweepEnabled) &&
-		cfg.Provide.DHT.MaxWorkers.WithDefault(config.DefaultProvideDHTMaxWorkers) == 0 {
-		log.Fatal("Invalid configuration: Provide.DHT.MaxWorkers cannot be 0 when Provide.DHT.SweepEnabled=true. Set Provide.DHT.MaxWorkers to a positive value (e.g., 16) to control resource usage. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#providedhtmaxworkers")
-	}
-	if routingOption == routingOptionDelegatedKwd {
-		// Delegated routing is read-only mode - content providing must be disabled
-		if cfg.Provide.Enabled.WithDefault(config.DefaultProvideEnabled) {
-			log.Fatal("Routing.Type=delegated does not support content providing. Set Provide.Enabled=false in your config.")
-		}
 	}
 
 	printLibp2pPorts(node)
@@ -806,11 +780,6 @@ take effect.
 		})
 	}
 
-	// Hard deprecation notice if someone still uses IPFS_REUSEPORT
-	if flag := os.Getenv("IPFS_REUSEPORT"); flag != "" {
-		log.Fatal("Support for IPFS_REUSEPORT was removed. Use LIBP2P_TCP_REUSEPORT instead.")
-	}
-
 	unmountErrc := make(chan error)
 	context.AfterFunc(node.Context(), func() {
 		<-node.Context().Done()
@@ -986,6 +955,46 @@ func rewriteMaddrToUseLocalhostIfItsAny(maddr ma.Multiaddr) ma.Multiaddr {
 	default:
 		return maddr // not ip
 	}
+}
+
+func validateDaemonConfig(cfg *config.Config, routingOption string, privateNetwork bool) error {
+	if privateNetwork && (routingOption == routingOptionAutoKwd || routingOption == routingOptionAutoClientKwd) {
+		return errors.New("private network does not work with Routing.Type=auto. Update your config to Routing.Type=dht (or none, and do manual peering)")
+	}
+
+	// Check for deprecated Provider/Reprovider configuration after migration.
+	// This should never happen for regular users, but is useful error for people who have Docker orchestration
+	// that blindly sets config keys (overriding automatic Kubo migration).
+	//nolint:staticcheck // intentionally checking deprecated fields
+	if cfg.Provider.Enabled != config.Default || !cfg.Provider.Strategy.IsDefault() || !cfg.Provider.WorkerCount.IsDefault() {
+		return errors.New("deprecated configuration detected. Manually migrate 'Provider' fields to 'Provide' and remove 'Provider' from your config. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#provide")
+	}
+	//nolint:staticcheck // intentionally checking deprecated fields
+	if !cfg.Reprovider.Interval.IsDefault() || !cfg.Reprovider.Strategy.IsDefault() {
+		return errors.New("deprecated configuration detected. Manually migrate 'Reprovider' fields to 'Provide': Reprovider.Strategy -> Provide.Strategy, Reprovider.Interval -> Provide.DHT.Interval. Remove 'Reprovider' from your config. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#provide")
+	}
+	if cfg.Provide.Strategy.WithDefault("") == "flat" {
+		return errors.New("Provide.Strategy='flat' is no longer supported. Use 'all' instead. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy")
+	}
+	if cfg.Experimental.StrategicProviding {
+		return errors.New("Experimental.StrategicProviding was removed. Remove it from your config. Documentation: https://github.com/ipfs/kubo/blob/master/docs/experimental-features.md#strategic-providing")
+	}
+	if cfg.Provide.DHT.SweepEnabled.WithDefault(config.DefaultProvideDHTSweepEnabled) &&
+		cfg.Provide.DHT.MaxWorkers.WithDefault(config.DefaultProvideDHTMaxWorkers) == 0 {
+		return errors.New("invalid configuration: Provide.DHT.MaxWorkers cannot be 0 when Provide.DHT.SweepEnabled=true. Set Provide.DHT.MaxWorkers to a positive value (e.g., 16) to control resource usage. Documentation: https://github.com/ipfs/kubo/blob/master/docs/config.md#providedhtmaxworkers")
+	}
+	if routingOption == routingOptionDelegatedKwd && cfg.Provide.Enabled.WithDefault(config.DefaultProvideEnabled) {
+		return errors.New("Routing.Type=delegated does not support content providing. Set Provide.Enabled=false in your config")
+	}
+
+	return nil
+}
+
+func validateDaemonEnvironment() error {
+	if flag := os.Getenv("IPFS_REUSEPORT"); flag != "" {
+		return errors.New("support for IPFS_REUSEPORT was removed. Use LIBP2P_TCP_REUSEPORT instead")
+	}
+	return nil
 }
 
 // printLibp2pPorts prints which ports are opened to facilitate swarm connectivity.

--- a/cmd/ipfs/kubo/daemon_config_test.go
+++ b/cmd/ipfs/kubo/daemon_config_test.go
@@ -1,0 +1,129 @@
+package kubo
+
+import (
+	"testing"
+
+	"github.com/ipfs/kubo/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDaemonConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            func() *config.Config
+		routingOption  string
+		privateNetwork bool
+		errContains    string
+	}{
+		{
+			name:          "default config is valid",
+			cfg:           func() *config.Config { return &config.Config{} },
+			routingOption: routingOptionAutoKwd,
+		},
+		{
+			name:           "private network rejects auto routing",
+			cfg:            func() *config.Config { return &config.Config{} },
+			routingOption:  routingOptionAutoKwd,
+			privateNetwork: true,
+			errContains:    "private network does not work with Routing.Type=auto",
+		},
+		{
+			name: "deprecated Provider config is rejected",
+			cfg: func() *config.Config {
+				return &config.Config{
+					Provider: config.Provider{
+						Enabled: config.True,
+					},
+				}
+			},
+			routingOption: routingOptionAutoKwd,
+			errContains:   "Manually migrate 'Provider' fields",
+		},
+		{
+			name: "deprecated Reprovider config is rejected",
+			cfg: func() *config.Config {
+				return &config.Config{
+					Reprovider: config.Reprovider{
+						Strategy: config.NewOptionalString("all"),
+					},
+				}
+			},
+			routingOption: routingOptionAutoKwd,
+			errContains:   "Manually migrate 'Reprovider' fields",
+		},
+		{
+			name: "flat provide strategy is rejected",
+			cfg: func() *config.Config {
+				return &config.Config{
+					Provide: config.Provide{
+						Strategy: config.NewOptionalString("flat"),
+					},
+				}
+			},
+			routingOption: routingOptionAutoKwd,
+			errContains:   "Provide.Strategy='flat' is no longer supported",
+		},
+		{
+			name: "strategic providing is rejected",
+			cfg: func() *config.Config {
+				return &config.Config{
+					Experimental: config.Experiments{
+						StrategicProviding: true,
+					},
+				}
+			},
+			routingOption: routingOptionAutoKwd,
+			errContains:   "Experimental.StrategicProviding was removed",
+		},
+		{
+			name: "sweep provider rejects zero max workers",
+			cfg: func() *config.Config {
+				return &config.Config{
+					Provide: config.Provide{
+						DHT: config.ProvideDHT{
+							MaxWorkers: config.NewOptionalInteger(0),
+						},
+					},
+				}
+			},
+			routingOption: routingOptionAutoKwd,
+			errContains:   "Provide.DHT.MaxWorkers cannot be 0",
+		},
+		{
+			name:          "delegated routing rejects enabled providing",
+			cfg:           func() *config.Config { return &config.Config{} },
+			routingOption: routingOptionDelegatedKwd,
+			errContains:   "Routing.Type=delegated does not support content providing",
+		},
+		{
+			name: "delegated routing allows disabled providing",
+			cfg: func() *config.Config {
+				return &config.Config{
+					Provide: config.Provide{
+						Enabled: config.False,
+					},
+				}
+			},
+			routingOption: routingOptionDelegatedKwd,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateDaemonConfig(test.cfg(), test.routingOption, test.privateNetwork)
+			if test.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.errContains)
+			}
+		})
+	}
+}
+
+func TestValidateDaemonEnvironmentRejectsRemovedReuseport(t *testing.T) {
+	t.Setenv("IPFS_REUSEPORT", "true")
+
+	err := validateDaemonEnvironment()
+
+	require.ErrorContains(t, err, "IPFS_REUSEPORT was removed")
+}

--- a/cmd/ipfs/kubo/daemon_config_test.go
+++ b/cmd/ipfs/kubo/daemon_config_test.go
@@ -43,6 +43,7 @@ func TestValidateDaemonConfig(t *testing.T) {
 			name: "deprecated Reprovider config is rejected",
 			cfg: func() *config.Config {
 				return &config.Config{
+					//nolint:staticcheck // intentionally checking deprecated fields
 					Reprovider: config.Reprovider{
 						Strategy: config.NewOptionalString("all"),
 					},

--- a/cmd/ipfs/kubo/daemon_config_test.go
+++ b/cmd/ipfs/kubo/daemon_config_test.go
@@ -31,6 +31,7 @@ func TestValidateDaemonConfig(t *testing.T) {
 			name: "deprecated Provider config is rejected",
 			cfg: func() *config.Config {
 				return &config.Config{
+					//nolint:staticcheck // intentionally checking deprecated fields
 					Provider: config.Provider{
 						Enabled: config.True,
 					},

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -12,6 +12,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 - [🔦 Highlights](#-highlights)
   - [🛜 One-time notice when behind CGNAT](#-one-time-notice-when-behind-cgnat)
   - [🕳️ Clearer error when hole punching is misconfigured](#-clearer-error-when-hole-punching-is-misconfigured)
+  - [Daemon configuration errors no longer exit abruptly](#daemon-configuration-errors-no-longer-exit-abruptly)
   - [🔑 `ipfs config replace` keeps PeerID and private key in sync](#-ipfs-config-replace-keeps-peerid-and-private-key-in-sync)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
@@ -42,6 +43,10 @@ Silence the notice with [`Internal.CGNATCheck`](https://github.com/ipfs/kubo/blo
 #### 🕳️ Clearer error when hole punching is misconfigured
 
 Setting [`Swarm.EnableHolePunching`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmenableholepunching) to `true` while [`Swarm.RelayClient.Enabled`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmrelayclientenabled) is `false` is an unsupported combination: hole punching needs the relay client to coordinate the upgrade from a relayed to a direct connection. Kubo now refuses to start with an error that names both settings, instead of exiting abruptly.
+
+#### Daemon configuration errors no longer exit abruptly
+
+Invalid daemon configuration now returns startup errors through the normal command path instead of calling `log.Fatal`. This covers deprecated provider settings, removed providing options, delegated routing with providing enabled, private-network auto routing, and the removed `IPFS_REUSEPORT` environment variable.
 
 #### 🔑 `ipfs config replace` keeps PeerID and private key in sync
 


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Similar to #11365, this replaces daemon startup `log.Fatal` calls for invalid configuration with errors returned through the normal command path.

The affected checks now run before `core.NewNode` is constructed and cover:
- private-network auto routing
- deprecated Provider/Reprovider config
- removed `Provide.Strategy=flat`
- removed `Experimental.StrategicProviding`
- invalid `Provide.DHT.MaxWorkers=0` with sweep enabled
- delegated routing with content providing enabled
- removed `IPFS_REUSEPORT`

This avoids abrupt `os.Exit(1)` behavior and makes these checks directly testable.
