### PR TITLE
feat(cli): accept native ipfs:// and ipns:// URIs

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -128,8 +128,12 @@ jobs:
       #
       # We run aegir directly (instead of helia-interop binary) because only aegir
       # supports the --grep/--invert flags needed to exclude specific tests.
+      # --exit: the node interop specs spawn kubo daemons (via ipfsd-ctl +
+      # KUBO_BINARY) whose libp2p/RPC handles keep Node's event loop alive after
+      # the run, so mocha prints its summary and then hangs until the job timeout.
+      # Force exit once the run completes. (helia-interop's own bin does not set it.)
       - name: Run helia-interop tests (excluding IPIP-499 incompatible test)
-        run: npx aegir test -t node --bail -- --grep 'should have the same CID after creating a file' --invert
+        run: npx aegir test -t node --bail -- --grep 'should have the same CID after creating a file' --invert --exit
         env:
           KUBO_BINARY: ${{ github.workspace }}/cmd/ipfs/ipfs
         working-directory: node_modules/@helia/interop

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -88,6 +88,32 @@ jobs:
       - name: Install @helia/interop
         if: steps.helia-cache.outputs.cache-hit != 'true'
         run: npm install @helia/interop
+      # Recurring @helia/interop regression: the package periodically ships
+      # without .aegir.js in its published "files", so `aegir test` has no config
+      # and discovers no spec files. It slipped in once around ipfs/helia#1001 and
+      # was fixed by ipfs/helia#1003 (titled "fix: restore aegir file in interop
+      # suite"), then regressed again in ipfs/helia#1049 ("feat!: make libp2p
+      # optional"), which dropped the file in the v11 major (first broken release
+      # 11.0.0 on 2026-06-29; 11.0.1 and 11.0.2 inherit it).
+      #
+      # We write a minimal config rather than fetching helia's own .aegir.js from
+      # the matching interop-v<version> tag: that file globs its tests at TypeScript
+      # sources (./src/*.spec.ts), which Node refuses to run from inside node_modules
+      # (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING, no tsconfig is shipped), and the
+      # rest of it is browser-only setup skipped under `-t node`. Pointing at the
+      # prebuilt ./dist/src is all the node run needs, and is what helia's own
+      # helia-interop bin runs. This keeps coming back, so it is the cheapest fix
+      # for now; it writes into node_modules and is fragile if helia's dist layout
+      # shifts. Drop it once helia ships .aegir.js in a published release again.
+      - name: Work around missing @helia/interop/.aegir.js (ipfs/helia#1049)
+        run: |
+          config=node_modules/@helia/interop/.aegir.js
+          if [ ! -f "$config" ]; then
+            echo "export default { test: { files: './dist/src/*.spec.js' } }" > "$config"
+            echo "injected minimal $config"
+          else
+            echo "$config already present, no workaround needed"
+          fi
       # TODO(IPIP-499): Remove --grep --invert workaround once helia implements IPIP-499
       # Tracking issue: https://github.com/ipfs/helia/issues/941
       #

--- a/core/commands/cmdutils/utils.go
+++ b/core/commands/cmdutils/utils.go
@@ -69,10 +69,11 @@ func ValidatePinName(name string) error {
 	return nil
 }
 
-// PathOrCidPath returns a path.Path built from the argument. It keeps the old
-// behaviour by building a path from a CID string.
+// PathOrCidPath returns a path.Path built from the argument. It accepts a
+// content path (/ipfs/cid), a native IPFS URI (ipfs://cid, ipns://name, and the
+// schemeless ipfs:cid / ipns:name forms), or a bare CID string.
 func PathOrCidPath(str string) (path.Path, error) {
-	p, err := path.NewPath(str)
+	p, err := path.NewPathFromURI(str)
 	if err == nil {
 		return p, nil
 	}
@@ -86,6 +87,34 @@ func PathOrCidPath(str string) (path.Path, error) {
 
 	// Send back original err.
 	return nil, originalErr
+}
+
+// CidFromArg parses a user-supplied argument into a [cid.Cid]. Besides a bare
+// CID, it accepts a content path (/ipfs/cid) and a native IPFS URI (ipfs://cid,
+// ipfs:cid), returning the root CID. An argument that points below the root
+// (e.g. ipfs://cid/sub) is rejected, since these commands operate on a single CID.
+func CidFromArg(arg string) (cid.Cid, error) {
+	// Fast path: a bare CID with no scheme or path components.
+	if c, err := cid.Decode(arg); err == nil {
+		return c, nil
+	}
+
+	p, err := PathOrCidPath(arg)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	imm, err := path.NewImmutablePath(p)
+	if err != nil {
+		// A mutable path (e.g. /ipns/name) has no static root CID.
+		return cid.Undef, err
+	}
+
+	if len(imm.Segments()) > 2 {
+		return cid.Undef, fmt.Errorf("%q points below a root CID, expected a single CID", arg)
+	}
+
+	return imm.RootCid(), nil
 }
 
 // CloneAddrInfo returns a copy of the AddrInfo with a cloned Addrs slice.

--- a/core/commands/cmdutils/utils_test.go
+++ b/core/commands/cmdutils/utils_test.go
@@ -30,6 +30,21 @@ func TestPathOrCidPath(t *testing.T) {
 		assert.Equal(t, validPath, p.String())
 	})
 
+	t.Run("native IPFS URIs are accepted", func(t *testing.T) {
+		cid := "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+		for src, want := range map[string]string{
+			"ipfs://" + cid:           "/ipfs/" + cid,
+			"ipfs:" + cid:             "/ipfs/" + cid,
+			"ipfs://" + cid + "/file": "/ipfs/" + cid + "/file",
+			"ipns://example.com":      "/ipns/example.com",
+			"ipns:example.com":        "/ipns/example.com",
+		} {
+			p, err := PathOrCidPath(src)
+			require.NoErrorf(t, err, "input %q", src)
+			assert.Equalf(t, want, p.String(), "input %q", src)
+		}
+	})
+
 	t.Run("returns original error when both attempts fail", func(t *testing.T) {
 		invalidInput := "invalid!@#path"
 		_, err := PathOrCidPath(invalidInput)
@@ -96,6 +111,39 @@ func TestPathOrCidPath(t *testing.T) {
 				assert.Equal(t, "/ipfs/"+cidWithPath, p.String())
 			})
 		}
+	})
+}
+
+func TestCidFromArg(t *testing.T) {
+	cidStr := "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+
+	t.Run("accepts bare CID, content path, and native URIs", func(t *testing.T) {
+		for _, src := range []string{
+			cidStr,
+			"/ipfs/" + cidStr,
+			"ipfs://" + cidStr,
+			"ipfs:" + cidStr,
+		} {
+			c, err := CidFromArg(src)
+			require.NoErrorf(t, err, "input %q", src)
+			assert.Equalf(t, cidStr, c.String(), "input %q", src)
+		}
+	})
+
+	t.Run("rejects a path that points below the root CID", func(t *testing.T) {
+		_, err := CidFromArg("ipfs://" + cidStr + "/file.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "points below a root CID")
+	})
+
+	t.Run("rejects a mutable IPNS reference", func(t *testing.T) {
+		_, err := CidFromArg("ipns://example.com")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a non-CID, non-path string", func(t *testing.T) {
+		_, err := CidFromArg("not a cid")
+		require.Error(t, err)
 	})
 }
 

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/core/commands/cmdenv"
+	"github.com/ipfs/kubo/core/commands/cmdutils"
 	"github.com/ipfs/kubo/core/node"
 	fsrepo "github.com/ipfs/kubo/repo/fsrepo"
 
@@ -247,7 +248,7 @@ var filesStatCmd = &cmds.Command{
 			return err
 		}
 
-		path, err := checkPath(req.Arguments[0])
+		path, err := checkContentOrMfsPath(req.Arguments[0])
 		if err != nil {
 			return err
 		}
@@ -514,7 +515,7 @@ being GC'ed.
 			return err
 		}
 
-		src, err := checkPath(req.Arguments[0])
+		src, err := checkContentOrMfsPath(req.Arguments[0])
 		if err != nil {
 			return err
 		}
@@ -600,22 +601,28 @@ being GC'ed.
 }
 
 func getNodeFromPath(ctx context.Context, node *core.IpfsNode, api iface.CoreAPI, p string) (ipld.Node, error) {
-	switch {
-	case strings.HasPrefix(p, "/ipfs/"):
-		pth, err := path.NewPath(p)
-		if err != nil {
-			return nil, err
-		}
-
+	// A content path or native IPFS URI (/ipfs/cid, ipfs://cid, /ipns/name, ...)
+	// is resolved through the DAG. Anything else is treated as an MFS path.
+	if pth, err := path.NewPathFromURI(p); err == nil {
 		return api.ResolveNode(ctx, pth)
-	default:
-		fsn, err := mfs.Lookup(node.FilesRoot, p)
-		if err != nil {
-			return nil, err
-		}
-
-		return fsn.GetNode()
 	}
+
+	fsn, err := mfs.Lookup(node.FilesRoot, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return fsn.GetNode()
+}
+
+// checkContentOrMfsPath validates an argument that may be an MFS path, a content
+// path (/ipfs/cid), or a native IPFS URI (ipfs://cid). A URI is rewritten to its
+// canonical content-path form; anything else is validated as an MFS path.
+func checkContentOrMfsPath(arg string) (string, error) {
+	if p, err := path.NewPathFromURI(arg); err == nil {
+		return p.String(), nil
+	}
+	return checkPath(arg)
 }
 
 func unlinkNodeIfExists(node *core.IpfsNode, path string) error {
@@ -1715,7 +1722,7 @@ Examples:
 		var newRootCid cid.Cid
 		if len(req.Arguments) > 0 {
 			var err error
-			newRootCid, err = cid.Decode(req.Arguments[0])
+			newRootCid, err = cmdutils.CidFromArg(req.Arguments[0])
 			if err != nil {
 				return fmt.Errorf("invalid CID %q: %w", req.Arguments[0], err)
 			}

--- a/core/commands/filestore.go
+++ b/core/commands/filestore.go
@@ -10,9 +10,8 @@ import (
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	core "github.com/ipfs/kubo/core"
 	cmdenv "github.com/ipfs/kubo/core/commands/cmdenv"
+	"github.com/ipfs/kubo/core/commands/cmdutils"
 	e "github.com/ipfs/kubo/core/commands/e"
-
-	"github.com/ipfs/go-cid"
 )
 
 var FileStoreCmd = &cmds.Command{
@@ -264,7 +263,7 @@ func getFilestore(env cmds.Environment) (*core.IpfsNode, *filestore.Filestore, e
 
 func listByArgs(ctx context.Context, res cmds.ResponseEmitter, fs *filestore.Filestore, args []string, removeBadBlocks bool) error {
 	for _, arg := range args {
-		c, err := cid.Decode(arg)
+		c, err := cmdutils.CidFromArg(arg)
 		if err != nil {
 			ret := &filestore.ListRes{
 				Status:   filestore.StatusOtherError,

--- a/core/commands/name/ipns.go
+++ b/core/commands/name/ipns.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/ipfs/boxo/namesys"
@@ -120,10 +119,6 @@ Resolve the value of a dnslink:
 				return errors.New("DHT timeout value must be >= 0")
 			}
 			opts = append(opts, options.Name.ResolveOption(namesys.ResolveWithDhtTimeout(d)))
-		}
-
-		if !strings.HasPrefix(name, "/ipns/") {
-			name = "/ipns/" + name
 		}
 
 		if !stream {

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -348,7 +348,7 @@ func lsRemote(ctx context.Context, req *cmds.Request, c *pinclient.Client, out c
 		cidsRawArr := cidsRaw.([]string)
 		var parsedCIDs []cid.Cid
 		for _, rawCID := range cidsRawArr {
-			parsedCID, err := cid.Decode(rawCID)
+			parsedCID, err := cmdutils.CidFromArg(rawCID)
 			if err != nil {
 				close(out)
 				return fmt.Errorf("CID %q cannot be parsed: %v", rawCID, err)

--- a/core/commands/provide.go
+++ b/core/commands/provide.go
@@ -19,6 +19,7 @@ import (
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core/commands/cmdenv"
+	"github.com/ipfs/kubo/core/commands/cmdutils"
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
 	"github.com/libp2p/go-libp2p-kad-dht/provider"
 	"github.com/libp2p/go-libp2p-kad-dht/provider/buffered"
@@ -224,7 +225,7 @@ a final count is printed at the end.
 		// processRoot validates a root CID against the local blockstore and
 		// announces either just that CID or every block reachable from it.
 		processRoot := func(arg string) error {
-			c, err := cid.Decode(arg)
+			c, err := cmdutils.CidFromArg(arg)
 			if err != nil {
 				return fmt.Errorf("invalid CID %q: %w", arg, err)
 			}

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -81,6 +81,12 @@ Resolve the value of an IPFS DAG path:
 		name := req.Arguments[0]
 		recursive, _ := req.Options[resolveRecursiveOptionName].(bool)
 
+		// Accept native IPFS URIs (ipfs://cid, ipns://name) by rewriting them to
+		// their canonical content-path form before the namespace checks below.
+		if p, err := path.NewPathFromURI(name); err == nil {
+			name = p.String()
+		}
+
 		// the case when ipns is resolved step by step
 		if strings.HasPrefix(name, "/ipns/") && !recursive {
 			rc, rcok := req.Options[resolveDhtRecordCountOptionName].(uint)

--- a/core/commands/routing.go
+++ b/core/commands/routing.go
@@ -79,7 +79,7 @@ var findProvidersRoutingCmd = &cmds.Command{
 			return errors.New("number of providers must be greater than 0")
 		}
 
-		c, err := cid.Parse(req.Arguments[0])
+		c, err := cmdutils.CidFromArg(req.Arguments[0])
 		if err != nil {
 			return err
 		}
@@ -210,7 +210,7 @@ Prefer 'ipfs provide once' for new scripts and any large input.
 
 		var cids []cid.Cid
 		for _, arg := range req.Arguments {
-			c, err := cid.Decode(arg)
+			c, err := cmdutils.CidFromArg(arg)
 			if err != nil {
 				return err
 			}

--- a/core/coreapi/name.go
+++ b/core/coreapi/name.go
@@ -125,13 +125,24 @@ func (api *NameAPI) Search(ctx context.Context, name string, opts ...caopts.Name
 		}
 	}
 
-	if !strings.HasPrefix(name, "/ipns/") {
-		name = "/ipns/" + name
-	}
-
-	p, err := path.NewPath(name)
+	// Accept a bare IPNS name (key or DNSLink), an /ipns/ path, or a native IPNS
+	// URI (ipns://name, ipns:name).
+	p, err := path.NewPathFromURI(name)
 	if err != nil {
-		return nil, err
+		// Wrap a bare name (no leading slash) as an /ipns/ path. Anything already
+		// in path form that failed to parse keeps its original error rather than
+		// being mangled by a second "/ipns/" prefix.
+		if strings.HasPrefix(name, "/") {
+			return nil, err
+		}
+		p, err = path.NewPath("/ipns/" + name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// name resolution is IPNS-only; reject immutable /ipfs and /ipld inputs.
+	if p.Namespace() != path.IPNSNamespace {
+		return nil, fmt.Errorf("%q is not an IPNS name", name)
 	}
 
 	out := make(chan coreiface.IpnsResult)

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -10,6 +10,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
+  - [🔗 Native `ipfs://` and `ipns://` URIs work as input](#-native-ipfs-and-ipns-uris-work-as-input)
   - [🛜 One-time notice when behind CGNAT](#-one-time-notice-when-behind-cgnat)
   - [🕳️ Clearer error when hole punching is misconfigured](#-clearer-error-when-hole-punching-is-misconfigured)
   - [🔑 `ipfs config replace` keeps PeerID and private key in sync](#-ipfs-config-replace-keeps-peerid-and-private-key-in-sync)
@@ -20,6 +21,14 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 ### Overview
 
 ### 🔦 Highlights
+
+#### 🔗 Native `ipfs://` and `ipns://` URIs work as input
+
+Commands that take a path or CID now also accept native IPFS URIs: `ipfs://<cid>`, `ipns://<name>`, and the shorter `ipfs:<cid>` and `ipns:<name>` forms. `ipfs cat ipfs://<cid>` now behaves the same as `ipfs cat /ipfs/<cid>` or `ipfs cat <cid>`.
+
+`ipfs://` and `ipns://` are how web browsers, browser extensions, and many non-IPFS apps link to and share IPFS content. Before, you had to rewrite such an address into an `/ipfs/` path before Kubo would take it. Now you can copy a URI from a browser address bar and paste it straight into the CLI or the RPC API.
+
+This works wherever a path or CID is accepted, including `cat`, `get`, `ls`, `refs`, `dag`, `block`, `pin`, `files`, and `name resolve`. The scheme is case-insensitive, and the CID or name after it is left untouched.
 
 #### 🛜 One-time notice when behind CGNAT
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.4
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.41.0
+	github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/multiformats/go-multiaddr v0.16.1

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.4
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4
+	github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/multiformats/go-multiaddr v0.16.1

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -273,8 +273,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.41.0 h1:diKlFosOG2e1mgSO1CXqcMSnHvtn6ubUvaCf9iF8AIY=
-github.com/ipfs/boxo v0.41.0/go.mod h1:1Fo36UVVvq3XAZwMDD82Cm4JTUi5x1k3AsJlg9DttOY=
+github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 h1:tVWa0S/ynBNVcrmfIjtk1TGs90SK6NOTpHorLgsVv+k=
+github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -273,8 +273,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 h1:tVWa0S/ynBNVcrmfIjtk1TGs90SK6NOTpHorLgsVv+k=
-github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
+github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb h1:jLhqcb0bTDtpFJJ4lZhHiv9QRfuVw699DsnE6jVuexk=
+github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.41.0
+	github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4
 	github.com/ipfs/go-block-format v0.2.3
 	github.com/ipfs/go-cid v0.6.1
 	github.com/ipfs/go-cidutil v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4
+	github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb
 	github.com/ipfs/go-block-format v0.2.3
 	github.com/ipfs/go-cid v0.6.1
 	github.com/ipfs/go-cidutil v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 h1:tVWa0S/ynBNVcrmfIjtk1TGs90SK6NOTpHorLgsVv+k=
-github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
+github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb h1:jLhqcb0bTDtpFJJ4lZhHiv9QRfuVw699DsnE6jVuexk=
+github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.41.0 h1:diKlFosOG2e1mgSO1CXqcMSnHvtn6ubUvaCf9iF8AIY=
-github.com/ipfs/boxo v0.41.0/go.mod h1:1Fo36UVVvq3XAZwMDD82Cm4JTUi5x1k3AsJlg9DttOY=
+github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 h1:tVWa0S/ynBNVcrmfIjtk1TGs90SK6NOTpHorLgsVv+k=
+github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/test/cli/path_uri_test.go
+++ b/test/cli/path_uri_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNativeIPFSURIs checks that commands accept native IPFS URIs (ipfs://cid,
+// ipns://name, and the schemeless ipfs:cid / ipns:name forms) anywhere a content
+// path or CID is accepted, so a value copied from a browser works as-is.
+func TestNativeIPFSURIs(t *testing.T) {
+	t.Parallel()
+
+	node := harness.NewT(t).NewNode().Init()
+	const content = "hello ipfs uri"
+	fileCID := node.IPFSAddStr(content, "--cid-version=1")
+
+	t.Run("cat accepts every form the same as a bare CID", func(t *testing.T) {
+		for _, arg := range []string{
+			fileCID,
+			"/ipfs/" + fileCID,
+			"ipfs://" + fileCID,
+			"ipfs:" + fileCID,
+		} {
+			assert.Equalf(t, content, node.IPFS("cat", arg).Stdout.Trimmed(), "cat %q", arg)
+		}
+	})
+
+	t.Run("block stat accepts a URI", func(t *testing.T) {
+		assert.Contains(t, node.IPFS("block", "stat", "ipfs://"+fileCID).Stdout.String(), fileCID)
+	})
+
+	t.Run("ls and sub-paths work through a URI", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0o644))
+		dirCID := node.IPFS("add", "-Q", "-r", "--cid-version=1", dir).Stdout.Trimmed()
+
+		assert.Contains(t, node.IPFS("ls", "ipfs://"+dirCID).Stdout.String(), "a.txt")
+		assert.Equal(t, "a", node.IPFS("cat", "ipfs://"+dirCID+"/a.txt").Stdout.String())
+	})
+
+	t.Run("name publish and resolve accept URIs", func(t *testing.T) {
+		var published struct{ Name string }
+		out := node.IPFS("name", "publish", "--allow-offline", "--enc=json", "ipfs://"+fileCID).Stdout.Bytes()
+		require.NoError(t, json.Unmarshal(out, &published))
+
+		want := "/ipfs/" + fileCID
+		for _, arg := range []string{
+			published.Name,
+			"/ipns/" + published.Name,
+			"ipns://" + published.Name,
+			"ipns:" + published.Name,
+		} {
+			assert.Equalf(t, want, node.IPFS("name", "resolve", "--offline", arg).Stdout.Trimmed(), "name resolve %q", arg)
+		}
+
+		// A URI also resolves transitively through cat.
+		assert.Equal(t, content, node.IPFS("cat", "--offline", "ipns://"+published.Name).Stdout.Trimmed())
+
+		// name resolve stays IPNS-only: an ipfs:// URI is rejected, not echoed back.
+		assert.NotEqual(t, 0, node.RunIPFS("name", "resolve", "--offline", "ipfs://"+fileCID).ExitCode())
+	})
+
+	t.Run("an invalid CID in a URI is rejected", func(t *testing.T) {
+		res := node.RunIPFS("cat", "ipfs://not-a-cid")
+		assert.NotEqual(t, 0, res.ExitCode())
+	})
+}

--- a/test/cli/telemetry_test.go
+++ b/test/cli/telemetry_test.go
@@ -48,8 +48,8 @@ func TestTelemetry(t *testing.T) {
 		// Get daemon output
 		output := stdout.String() + stderr.String()
 
-		// Check that telemetry is disabled
-		assert.Contains(t, output, "telemetry disabled via opt-out", "Expected telemetry disabled message")
+		// Check that telemetry collection is skipped
+		assert.Contains(t, output, "telemetry collection skipped: opted out", "Expected telemetry skipped message")
 
 		// Stop daemon
 		node.StopDaemon()
@@ -90,8 +90,7 @@ func TestTelemetry(t *testing.T) {
 		// Get daemon output
 		output := stdout.String() + stderr.String()
 
-		// Check that telemetry is disabled
-		assert.Contains(t, output, "telemetry disabled via opt-out", "Expected telemetry disabled message")
+		// Check that telemetry collection is skipped
 		assert.Contains(t, output, "telemetry collection skipped: opted out", "Expected telemetry skipped message")
 
 		// Stop daemon

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.41.0 // indirect
+	github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.3 // indirect
 	github.com/ipfs/go-cid v0.6.1 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 // indirect
+	github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.3 // indirect
 	github.com/ipfs/go-cid v0.6.1 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -299,8 +299,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.41.0 h1:diKlFosOG2e1mgSO1CXqcMSnHvtn6ubUvaCf9iF8AIY=
-github.com/ipfs/boxo v0.41.0/go.mod h1:1Fo36UVVvq3XAZwMDD82Cm4JTUi5x1k3AsJlg9DttOY=
+github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 h1:tVWa0S/ynBNVcrmfIjtk1TGs90SK6NOTpHorLgsVv+k=
+github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.3 h1:mpCuDaNXJ4wrBJLrtEaGFGXkferrw5eqVvzaHhtFKQk=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -299,8 +299,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4 h1:tVWa0S/ynBNVcrmfIjtk1TGs90SK6NOTpHorLgsVv+k=
-github.com/ipfs/boxo v0.41.1-0.20260701000848-2f2424b347a4/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
+github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb h1:jLhqcb0bTDtpFJJ4lZhHiv9QRfuVw699DsnE6jVuexk=
+github.com/ipfs/boxo v0.41.1-0.20260701041656-8a6d1d21a6fb/go.mod h1:mnR769LN1W7rDI6z1GBLmD15x4pvMdW0oWxik8j3y6g=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.3 h1:mpCuDaNXJ4wrBJLrtEaGFGXkferrw5eqVvzaHhtFKQk=


### PR DESCRIPTION
Commands now accept native IPFS URIs like `ipfs://cid` and `ipns://name` (and the schemeless `ipfs:cid` / `ipns:name` forms), so you can paste a link straight from a browser or another tool instead of rewriting it into an `/ipfs/` path first.

This is backward-compatible: `/ipfs/cid` paths and bare CIDs still work exactly as they did before, and a URI is just one more accepted form. Each URI is normalized to the equivalent content path at the input boundary, so most commands need no change and the diff here is small. 



Thus PR depends only on the boxo `NewPathFromURI` added in 
- ipfs/boxo#1182