### PR TITLE
docs: clarify open vs NoFetch gateway recipes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1634,74 +1634,10 @@ ipfs config --json Gateway.PublicGateways '{"localhost": null }'
 
 ### `Gateway` recipes
 
-Below is a list of the most common gateway setups.
-
-> [!IMPORTANT]
-> See [Reverse Proxy Caveats](gateway.md#reverse-proxy) if running behind nginx or another reverse proxy.
-
-- Public [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway) at `http://{cid}.ipfs.dweb.link` (each content root gets its own Origin)
-
-   ```console
-   $ ipfs config --json Gateway.PublicGateways '{
-       "dweb.link": {
-         "UseSubdomains": true,
-         "Paths": ["/ipfs", "/ipns"]
-       }
-     }'
-   ```
-
-  - **Performance:** Consider enabling `Routing.AcceleratedDHTClient=true` to improve content routing lookups. Separately, gateway operators should decide if the gateway node should also co-host and provide (announce) fetched content to the DHT. If providing content, enable `Provide.DHT.SweepEnabled=true` for efficient announcements. If announcements are still not fast enough, adjust `Provide.DHT.MaxWorkers`. For a read-only gateway that doesn't announce content, use `Provide.Enabled=false`.
-  - **Backward-compatible:** this feature enables automatic redirects from content paths to subdomains:
-
-     `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.dweb.link`
-
-  - **X-Forwarded-Proto:** if you run Kubo behind a reverse proxy that provides TLS, make it add a `X-Forwarded-Proto: https` HTTP header to ensure users are redirected to `https://`, not `http://`. It will also ensure DNSLink names are inlined to fit in a single DNS label, so they work fine with a wildcard TLS cert ([details](https://github.com/ipfs/in-web-browsers/issues/169)). The NGINX directive is `proxy_set_header X-Forwarded-Proto "https";`.:
-
-     `http://dweb.link/ipfs/{cid}` → `https://{cid}.ipfs.dweb.link`
-
-     `http://dweb.link/ipns/your-dnslink.site.example.com` → `https://your--dnslink-site-example-com.ipfs.dweb.link`
-
-  - **X-Forwarded-Host:** we also support `X-Forwarded-Host: example.com` if you want to override subdomain gateway host from the original request:
-
-     `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.example.com`
-
-- Public [path gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway) at `http://ipfs.io/ipfs/{cid}` (no Origin separation)
-
-   ```console
-   $ ipfs config --json Gateway.PublicGateways '{
-       "ipfs.io": {
-         "UseSubdomains": false,
-         "Paths": ["/ipfs", "/ipns"]
-       }
-     }'
-   ```
-
-  - **Performance:** Consider enabling `Routing.AcceleratedDHTClient=true` to improve content routing lookups. When running an open, recursive gateway, decide if the gateway should also co-host and provide (announce) fetched content to the DHT. If providing content, enable `Provide.DHT.SweepEnabled=true` for efficient announcements. If announcements are still not fast enough, adjust `Provide.DHT.MaxWorkers`. For a read-only gateway that doesn't announce content, use `Provide.Enabled=false`.
-
-- Public [DNSLink](https://dnslink.io/) gateway resolving every hostname passed in `Host` header.
-
-  ```console
-  ipfs config --json Gateway.NoDNSLink false
-  ```
-
-  - Note that `NoDNSLink: false` is the default (it works out of the box unless set to `true` manually)
-
-- Hardened, site-specific [DNSLink gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#dnslink-gateway).
-
-  Disable fetching of remote data (`NoFetch: true`) and resolving DNSLink at unknown hostnames (`NoDNSLink: true`).
-  Then, enable DNSLink gateway only for the specific hostname (for which data
-  is already present on the node), without exposing any content-addressing `Paths`:
-
-   ```console
-   $ ipfs config --json Gateway.NoFetch true
-   $ ipfs config --json Gateway.NoDNSLink true
-   $ ipfs config --json Gateway.PublicGateways '{
-       "en.wikipedia-on-ipfs.org": {
-         "NoDNSLink": false,
-         "Paths": []
-       }
-     }'
-   ```
+Common gateway setups are documented in the gateway guide under
+[Gateway recipes](gateway.md#gateway-recipes): the choice between serving any
+content from the network and serving only your own content (`Gateway.NoFetch`),
+plus the subdomain, path, and DNSLink URL styles.
 
 ## `Identity`
 

--- a/docs/content-blocking.md
+++ b/docs/content-blocking.md
@@ -8,6 +8,15 @@
 
 Kubo ships with built-in support for denylist format from [IPIP-383](https://specs.ipfs.tech/ipips/ipip-0383/).
 
+> [!TIP]
+> Denylists are reactive: you block bad content after it appears and keep adding
+> entries as more shows up, which turns into whack-a-mole. If your gateway only
+> needs to serve a known set of content, an allowlist is simpler and stronger.
+> Run it with [`Gateway.NoFetch=true`](gateway.md#serve-only-your-own-content-gatewaynofetchtrue)
+> so it serves only the content you host and returns `404 Not Found` for
+> everything else, instead of fetching any CID on request and then having to
+> block the bad ones.
+
 ## Default behavior
 
 Official Kubo build does not ship with any denylists enabled by default.
@@ -79,7 +88,6 @@ Paths with unicode and whitespace need to be percent-encoded:
 ```
 
 Sensitive content paths can be double-hashed to block without revealing them.
-Double-hashed list example: https://badbits.dwebops.pub/badbits.deny
 
 See [IPIP-383](https://specs.ipfs.tech/ipips/ipip-0383/) for detailed format specification and more examples.
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -2,13 +2,34 @@
 
 An IPFS Gateway acts as a bridge between traditional web browsers and IPFS.
 Through the gateway, users can browse files and websites stored in IPFS as if
-they were stored in a traditional web server. 
+they were stored in a traditional web server.
 
 [More about Gateways](https://docs.ipfs.tech/concepts/ipfs-gateway/) and [addressing IPFS on the web](https://docs.ipfs.tech/how-to/address-ipfs-on-web/).
 
 Kubo's Gateway implementation follows [IPFS Gateway Specifications](https://specs.ipfs.tech/http-gateways/) and is tested with [Gateway Conformance Test Suite](https://github.com/ipfs/gateway-conformance).
 
-### Local gateway
+## Table of contents
+
+- [Local gateway](#local-gateway)
+- [Public gateways](#public-gateways)
+- [Gateway recipes](#gateway-recipes)
+  - [Serve only your own content (`Gateway.NoFetch=true`)](#serve-only-your-own-content-gatewaynofetchtrue)
+  - [Serve any content from the network (`Gateway.NoFetch=false`)](#serve-any-content-from-the-network-gatewaynofetchfalse)
+  - [URL-style recipes](#url-style-recipes)
+    - [Subdomain gateway](#subdomain-gateway)
+    - [Path gateway](#path-gateway)
+    - [DNSLink gateway](#dnslink-gateway)
+    - [Hardened DNSLink gateway](#hardened-dnslink-gateway)
+- [Configuration](#configuration)
+- [Running in Production](#running-in-production)
+- [Directories](#directories)
+- [Static Websites](#static-websites)
+- [Filenames](#filenames)
+- [Downloads](#downloads)
+- [Response Format](#response-format)
+- [Content-Types](#content-types)
+
+## Local gateway
 
 By default, Kubo nodes run
 a [path gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway) at `http://127.0.0.1:8080/`
@@ -26,21 +47,196 @@ and a [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#sub
 
 Additional listening addresses and gateway behaviors can be set in the [config](#configuration) file.
 
-### Public gateways
+## Public gateways
 
-IPFS Foundation [provides public gateways](https://docs.ipfs.tech/concepts/public-utilities/) at
-`https://ipfs.io` ([path](https://specs.ipfs.tech/http-gateways/path-gateway/)),
-`https://dweb.link` ([subdomain](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway)),
-and `https://trustless-gateway.link` ([trustless](https://specs.ipfs.tech/http-gateways/trustless-gateway/) only).
-If you've ever seen a link in the form `https://ipfs.io/ipfs/Qm...`, that's being served from a *public goods* gateway.
+For public gateways available as a public good, see the
+[public utilities](https://docs.ipfs.tech/concepts/public-utilities/) page; for a
+broader community-maintained list, see the
+[public gateway checker](https://ipfs.github.io/public-gateway-checker/).
 
-There is a list of third-party public gateways provided by the IPFS community at https://ipfs.github.io/public-gateway-checker/
+Treat public gateways as a convenience for casual use; they are provided on a
+best-effort basis. For anything you depend on, run your own gateway
+([recipes](#gateway-recipes) below) or retrieve content over IPFS directly
+instead of through someone else's gateway. The guide
+[Replace public gateways with self-hosted IPFS](https://docs.ipfs.tech/how-to/replace-public-gateways-with-self-hosted-ipfs/)
+covers the options.
+
+## Gateway recipes
+
+Before you pick a URL style (subdomain, path, or DNSLink, in the
+[URL-style recipes](#url-style-recipes) below), decide the bigger question:
+when a visitor asks for content this node does not have, should the gateway go
+and fetch it from the network, or just answer "not found"?
+
+> [!IMPORTANT]
+> See [Reverse Proxy Caveats](#reverse-proxy) if running behind nginx or another reverse proxy.
+
+> [!CAUTION]
+> An open public gateway fetches and serves any content a visitor asks for,
+> even content you have never seen. That means a stranger can pull illegal or
+> abusive material through your server and your internet connection, and you
+> are the one who has to handle the complaints and takedown requests. Unless
+> you are running a shared public service on purpose, it is safer to
+> [serve only your own content](#serve-only-your-own-content-gatewaynofetchtrue)
+> with `Gateway.NoFetch=true`. If you do run an
+> [open public gateway](#serve-any-content-from-the-network-gatewaynofetchfalse),
+> first set up a way to block and take down bad content, using
+> [content blocking](content-blocking.md).
+
+### Serve only your own content (`Gateway.NoFetch=true`)
+
+The node only shares content it already has. It never downloads missing content
+from other peers, so anything this node does not have returns `404 Not Found`.
+
+This is the safest way to put your own content (a website, a dataset, some
+files) on a public gateway, and the recommended setup for most people.
+
+```console
+$ ipfs config --json Gateway.NoFetch true
+```
+
+- The gateway only serves content already stored on this node: anything you
+  added with `ipfs add`, pinned, or put in MFS. Anything else returns
+  `404 Not Found` right away, without touching the network.
+- Because the node never fetches anything for a visitor, no stranger can make it
+  download content you did not choose, so there is little room for abuse.
+- Pin the content you serve (`ipfs pin add`) so garbage collection does not
+  remove it. Unpinned content can be deleted when garbage collection runs, after
+  which it stops resolving and returns `404`.
+- Pick how URLs map to your content with one of the
+  [URL-style recipes](#url-style-recipes) below.
+- A gateway serves content over HTTP, so it does not need to announce that
+  content to the IPFS network (so other peers can discover it here) for the
+  gateway to work. If the content is already announced by another node (for
+  example, you also pinned it elsewhere), or you want this node to spend its
+  resources on serving instead of announcing, turn announcements off with
+  [`Provide.Enabled=false`](config.md#provideenabled). That drops the ongoing
+  announcing work.
+- `NoFetch` does not stop your node from helping other peers find *their*
+  content. If you want it to act only as a client and not help route for others,
+  set [`Routing.Type=autoclient`](config.md#routingtype).
+- To limit this to a single DNSLink website, see the
+  [hardened DNSLink recipe](#hardened-dnslink-gateway) below.
+
+### Serve any content from the network (`Gateway.NoFetch=false`)
+
+This is the default, and how a large shared public gateway works. The gateway
+looks up and downloads any content a visitor asks for, fetching it from the
+network. Only run it this way if you mean to offer that kind of public service,
+and set it up carefully first.
+
+- **Block and take down abuse.** Sooner or later, someone will ask an open
+  gateway to serve illegal or abusive content. Set up
+  [content blocking](content-blocking.md) so you can respond to takedown
+  requests: Kubo blocks content listed in
+  [IPIP-383](https://specs.ipfs.tech/ipips/ipip-0383/) denylists and returns
+  `410 Gone` for it. Blocking stops your node from serving the content, but
+  [not from helping other peers find it](content-blocking.md#scope-of-denylists)
+  on the network; to stop that too, set
+  [`Routing.Type=autoclient`](content-blocking.md#how-to-stop-facilitating-routing-for-blocked-content).
+- **Do not become free web hosting.** Set
+  [`Gateway.DeserializedResponses=false`](config.md#gatewaydeserializedresponses) so the
+  gateway returns only verifiable data, not ready-to-view web pages. People can
+  no longer use it to host random websites, while apps that verify data
+  themselves (like [@helia/verified-fetch](https://www.npmjs.com/package/@helia/verified-fetch))
+  keep working.
+- **Protect your bandwidth.** Review
+  [`Gateway.MaxRangeRequestFileSize`](config.md#gatewaymaxrangerequestfilesize),
+  [`Gateway.MaxConcurrentRequests`](config.md#gatewaymaxconcurrentrequests), and the
+  [Running in Production](#running-in-production) notes on timeouts,
+  reverse proxy, and CDN behavior.
+- **Speed.** Consider [`Routing.AcceleratedDHTClient=true`](config.md#routingaccelerateddhtclient)
+  for faster lookups. Decide whether this gateway should also announce the
+  content it fetches so others can find it: if yes, turn on
+  [`Provide.DHT.SweepEnabled=true`](config.md#providedhtsweepenabled) (and raise
+  [`Provide.DHT.MaxWorkers`](config.md#providedhtmaxworkers) if announcements are slow);
+  if no, set [`Provide.Enabled=false`](config.md#provideenabled).
+- Pick how URLs map to content with one of the
+  [URL-style recipes](#url-style-recipes) below.
+
+### URL-style recipes
+
+These decide how a request URL maps to content. They work the same whether or
+not `Gateway.NoFetch` is set.
+
+#### Subdomain gateway
+
+A [subdomain gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway)
+serves each content root from its own subdomain
+(`http://{cid}.ipfs.subdomain-gw.example.com`), so every root gets its own Origin.
+
+```console
+$ ipfs config --json Gateway.PublicGateways '{
+    "subdomain-gw.example.com": {
+      "UseSubdomains": true,
+      "Paths": ["/ipfs", "/ipns"]
+    }
+  }'
+```
+
+- **Backward-compatible:** content paths redirect to subdomains:
+
+   `http://subdomain-gw.example.com/ipfs/{cid}` → `http://{cid}.ipfs.subdomain-gw.example.com`
+
+- **X-Forwarded-Proto:** if you run Kubo behind a reverse proxy that provides TLS, make it add an `X-Forwarded-Proto: https` header so users are redirected to `https://`, not `http://`. It also inlines DNSLink names into a single DNS label, so they work with a wildcard TLS cert ([details](https://github.com/ipfs/in-web-browsers/issues/169)). The NGINX directive is `proxy_set_header X-Forwarded-Proto "https";`:
+
+   `http://subdomain-gw.example.com/ipfs/{cid}` → `https://{cid}.ipfs.subdomain-gw.example.com`
+
+   `http://subdomain-gw.example.com/ipns/your-dnslink.example.org` → `https://your--dnslink-example-org.ipns.subdomain-gw.example.com`
+
+- **X-Forwarded-Host:** override the gateway host from the request with `X-Forwarded-Host: example.net`:
+
+   `http://subdomain-gw.example.com/ipfs/{cid}` → `http://{cid}.ipfs.example.net`
+
+#### Path gateway
+
+A [path gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#path-gateway)
+serves content under a path (`http://path-gw.example.com/ipfs/{cid}`), with no
+Origin separation between content roots.
+
+```console
+$ ipfs config --json Gateway.PublicGateways '{
+    "path-gw.example.com": {
+      "UseSubdomains": false,
+      "Paths": ["/ipfs", "/ipns"]
+    }
+  }'
+```
+
+#### DNSLink gateway
+
+A [DNSLink gateway](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#dnslink-gateway)
+resolves the DNSLink name in the `Host` header of each request. It is on by
+default (`NoDNSLink: false`):
+
+```console
+ipfs config --json Gateway.NoDNSLink false
+```
+
+#### Hardened DNSLink gateway
+
+To serve a single DNSLink site and nothing else, combine `NoFetch` and
+`NoDNSLink`. Disable fetching remote data (`NoFetch: true`) and DNSLink at
+unknown hostnames (`NoDNSLink: true`), then enable DNSLink for one hostname
+whose data is already on the node, without exposing any content-addressing
+`Paths`:
+
+```console
+$ ipfs config --json Gateway.NoFetch true
+$ ipfs config --json Gateway.NoDNSLink true
+$ ipfs config --json Gateway.PublicGateways '{
+    "dnslink-site.example.com": {
+      "NoDNSLink": false,
+      "Paths": []
+    }
+  }'
+```
 
 ## Configuration
 
-The `Gateway.*` configuration options are (briefly) described in the
-[config](https://github.com/ipfs/kubo/blob/master/docs/config.md#gateway)
-documentation, including a list of common [gateway recipes](https://github.com/ipfs/kubo/blob/master/docs/config.md#gateway-recipes).
+The `Gateway.*` configuration options are described in the
+[config documentation](config.md#gateway). See [Gateway recipes](#gateway-recipes)
+above for common setups.
 
 ### Debug
 The gateway's log level can be changed with this command:
@@ -129,11 +325,11 @@ When deploying Kubo's gateway in production, be aware of these important conside
 For convenience, the gateway (mostly) acts like a normal web-server when serving
 a directory:
 
-1. If the directory contains an `index.html` file:
-  1. If the path does not end in a `/`, append a `/` and redirect. This helps
-     avoid serving duplicate content from different paths.<sup>&dagger;</sup>
-  2. Otherwise, serve the `index.html` file.
-2. Dynamically build and serve a listing of the contents of the directory.
+1. If the path does not end in a `/`, append a `/` and redirect. This applies to
+   any directory request and helps avoid serving duplicate content from
+   different paths.<sup>&dagger;</sup>
+2. If the directory contains an `index.html` file, serve it.
+3. Otherwise, dynamically build and serve a listing of the directory contents.
 
 <sub><sup>&dagger;</sup>This redirect is skipped if the query string contains a
 `go-get=1` parameter. See [PR#3963](https://github.com/ipfs/kubo/pull/3963)
@@ -155,9 +351,9 @@ file (with no containing directory), the final component is just a CID
 To work around this issue, you can add a `filename=some_filename` parameter to
 your query string to explicitly specify the filename. For example:
 
-> https://ipfs.io/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG?filename=hello_world.txt
+> http://127.0.0.1:8080/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG?filename=hello_world.txt
 
-When you try to save above page, you browser will use passed `filename` instead of a CID.
+When you try to save the page above, your browser will use the passed `filename` instead of a CID.
 
 ## Downloads
 
@@ -165,7 +361,7 @@ It is possible to skip browser rendering of supported filetypes (plain text,
 images, audio, video, PDF) and trigger immediate "save as" dialog by appending
 `&download=true`:
 
-> https://ipfs.io/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG?filename=hello_world.txt&download=true
+> http://127.0.0.1:8080/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG?filename=hello_world.txt&download=true
 
 ## Response Format
 
@@ -186,7 +382,7 @@ Returns a byte array for a single `raw` block.
 Sending such requests for `/ipfs/{cid}` allows for efficient fetch of blocks with data
 encoded in custom format, without the need for deserialization and traversal on the gateway.
 
-This is equivalent of `ipfs block get`.
+This is the equivalent of `ipfs block get`.
 
 ### `application/vnd.ipld.car`
 


### PR DESCRIPTION
Moves the gateway recipes into `gateway.md` and puts the main choice up front: run an open gateway that fetches any CID (and needs content blocking and a takedown path) or serve only the content you host with `Gateway.NoFetch=true`.