### PR TITLE
feat(autotls): skip issuance when broker is down

### DIFF
--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -162,7 +162,7 @@ Removing files through the selection toolbar left their pins behind. It now offe
 - update `go-libp2p` to a pre-release pinned at [95be6665](https://github.com/libp2p/go-libp2p/commit/95be6665b014e3e29bdb639ec10f8944d141969d), ahead of v0.48.0 (no tagged release yet)
 - update `go-libp2p-pubsub` to [v0.17.0](https://github.com/libp2p/go-libp2p-pubsub/releases/tag/v0.17.0)
 - update `go-libp2p-kad-dht` to [v0.41.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.41.0)
-- update `p2p-forge/client` to [v0.9.1](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.9.1) (incl. [v0.9.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.9.0), [v0.8.1](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.8.1))
+- update `p2p-forge/client` to [v0.10.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.10.0) (incl. [v0.9.1](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.9.1), [v0.9.0](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.9.0), [v0.8.1](https://github.com/ipshipyard/p2p-forge/releases/tag/v0.8.1))
 - update `go-ds-pebble` to [v0.5.12](https://github.com/ipfs/go-ds-pebble/releases/tag/v0.5.12)
   - updates `github.com/cockroachdb/pebble` to [v2.1.6](https://github.com/cockroachdb/pebble/releases/tag/v2.1.6)
 

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -12,6 +12,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 - [🔦 Highlights](#-highlights)
   - [🔗 Native `ipfs://` and `ipns://` URIs work as input](#-native-ipfs-and-ipns-uris-work-as-input)
   - [🛜 One-time notice when behind CGNAT](#-one-time-notice-when-behind-cgnat)
+  - [🩺 AutoTLS checks broker health before registration](#-autotls-checks-broker-health-before-registration)
   - [🐛 IPNS publishing validates lifetime and TTL](#-ipns-publishing-validates-lifetime-and-ttl)
   - [🛑 Clearer errors for invalid config at startup](#-clearer-errors-for-invalid-config-at-startup)
   - [🗂️ `ipfs files` no longer hangs when garbage collection runs](#-ipfs-files-no-longer-hangs-when-garbage-collection-runs)
@@ -48,6 +49,12 @@ Kubo now logs a one-time notice to stderr at startup when it detects it is behin
 Detection is best-effort and conservative: it fires only when a private or shared-range (`100.64.0.0/10`, RFC 6598) address appears as a NAT-mapped WAN address (via UPnP/NAT-PMP/PCP) that is not one of the node's own interfaces. Kubo ignores addresses on a local interface, so VPN and overlay tools that use `100.64.0.0/10` (such as Tailscale) do not trigger it; when the upstream address is hidden, the node looks like any ordinary NAT and Kubo stays quiet. `ipfs swarm addrs autonat` reports the current classification in its `nat` field (`--enc=json`).
 
 Silence the notice with [`Internal.CGNATCheck`](https://github.com/ipfs/kubo/blob/master/docs/config.md#internalcgnatcheck)`=false`. The dead-listener diagnostic added in v0.42 can now be toggled too, with [`Internal.DeadListenerCheck`](https://github.com/ipfs/kubo/blob/master/docs/config.md#internaldeadlistenercheck).
+
+#### 🩺 AutoTLS checks broker health before registration
+
+AutoTLS certificate issuance depends on the ACME DNS-01 broker at [`AutoTLS.RegistrationEndpoint`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotlsregistrationendpoint) (`registration.libp2p.direct` by default). Before, a publicly reachable node without a certificate would attempt ACME issuance even when that broker was unreachable (offline network, firewall, service outage) and keep retrying in the background for days, filling logs with errors that could not resolve themselves.
+
+Now the broker's health endpoint is checked right before the first registration attempt, after the registration delay (1h by default, none when `AutoTLS.Enabled=true` is set explicitly) and once the node is publicly reachable. While the broker keeps failing the check, certificate setup is postponed with a single ERROR in the log and one cheap re-check per hour, and issuance starts automatically once the broker recovers. Nodes that already have a certificate are unaffected, and short-lived nodes (such as CI runners) produce no broker traffic at all.
 
 #### 🐛 IPNS publishing validates lifetime and TTL
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -774,6 +774,7 @@ When activated, together with [`AutoTLS.AutoWSS`](#autotlsautowss) (default) or 
 **Note:**
 
 - This feature requires a publicly reachable node. If behind NAT, manual port forwarding or UPnP (`Swarm.DisableNatPortMap=false`) is required.
+- On a node without a certificate yet, broker health is confirmed before the first registration attempt (HTTP GET of `/v1/health` at [`AutoTLS.RegistrationEndpoint`](#autotlsregistrationendpoint) must return HTTP 204). The check runs after [`AutoTLS.RegistrationDelay`](#autotlsregistrationdelay), once the node is publicly reachable. While the broker keeps failing the check, certificate setup is postponed and health is re-checked hourly; issuance starts automatically once the broker recovers.
 - The first time AutoTLS is used, it may take 5-15 minutes + [`AutoTLS.RegistrationDelay`](#autotlsregistrationdelay) before `/ws` listener is added. Be patient.
 - Avoid manual configuration. [`AutoTLS.AutoWSS=true`](#autotlsautowss) should automatically add `/ws` listener to existing, firewall-forwarded `/tcp` ports.
 - To troubleshoot, use `GOLOG_LOG_LEVEL="error,autotls=debug` for detailed logs, or `GOLOG_LOG_LEVEL="error,autotls=info` for quieter output.

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect
 	github.com/ipld/go-ipld-prime v0.24.0 // indirect
-	github.com/ipshipyard/p2p-forge v0.9.1 // indirect
+	github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect
 	github.com/ipld/go-ipld-prime v0.24.0 // indirect
-	github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 // indirect
+	github.com/ipshipyard/p2p-forge v0.10.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -352,8 +352,8 @@ github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG36
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 h1:cqNk8PEwHnK0vqWln+U/YZhQc9h2NB3KjUjDPZo5Q2s=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:ZEUdra3CoqRVRYgAX/jAJO9aZGz6SKtKEG628fHHktY=
-github.com/ipshipyard/p2p-forge v0.9.1 h1:xHiauwYsHv8R6jIaXDV6e89xAeSS6tN++uMQuAC41Jw=
-github.com/ipshipyard/p2p-forge v0.9.1/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
+github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 h1:UE8fyZHRkeBc8Vlmrs/B6WTP8gWzVqUQZnG85yfJy0k=
+github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -352,8 +352,8 @@ github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG36
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 h1:cqNk8PEwHnK0vqWln+U/YZhQc9h2NB3KjUjDPZo5Q2s=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:ZEUdra3CoqRVRYgAX/jAJO9aZGz6SKtKEG628fHHktY=
-github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 h1:UE8fyZHRkeBc8Vlmrs/B6WTP8gWzVqUQZnG85yfJy0k=
-github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
+github.com/ipshipyard/p2p-forge v0.10.0 h1:OcfcyjoHkeiIskhT4fHN/N82HfpgAteb1Eg3ZNAGE/U=
+github.com/ipshipyard/p2p-forge v0.10.0/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/ipld/go-car/v2 v2.17.0
 	github.com/ipld/go-codec-dagpb v1.7.0
 	github.com/ipld/go-ipld-prime v0.24.0
-	github.com/ipshipyard/p2p-forge v0.9.1
+	github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/libp2p/go-doh-resolver v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/ipld/go-car/v2 v2.17.0
 	github.com/ipld/go-codec-dagpb v1.7.0
 	github.com/ipld/go-ipld-prime v0.24.0
-	github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456
+	github.com/ipshipyard/p2p-forge v0.10.0
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/libp2p/go-doh-resolver v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG36
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 h1:cqNk8PEwHnK0vqWln+U/YZhQc9h2NB3KjUjDPZo5Q2s=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:ZEUdra3CoqRVRYgAX/jAJO9aZGz6SKtKEG628fHHktY=
-github.com/ipshipyard/p2p-forge v0.9.1 h1:xHiauwYsHv8R6jIaXDV6e89xAeSS6tN++uMQuAC41Jw=
-github.com/ipshipyard/p2p-forge v0.9.1/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
+github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 h1:UE8fyZHRkeBc8Vlmrs/B6WTP8gWzVqUQZnG85yfJy0k=
+github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG36
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 h1:cqNk8PEwHnK0vqWln+U/YZhQc9h2NB3KjUjDPZo5Q2s=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:ZEUdra3CoqRVRYgAX/jAJO9aZGz6SKtKEG628fHHktY=
-github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 h1:UE8fyZHRkeBc8Vlmrs/B6WTP8gWzVqUQZnG85yfJy0k=
-github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
+github.com/ipshipyard/p2p-forge v0.10.0 h1:OcfcyjoHkeiIskhT4fHN/N82HfpgAteb1Eg3ZNAGE/U=
+github.com/ipshipyard/p2p-forge v0.10.0/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=

--- a/test/cli/autotls_test.go
+++ b/test/cli/autotls_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ipfs/kubo/config"
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// autotlsPostponedMsg is the marker of the ERROR the p2p-forge client logs
+// when its pre-issuance broker health check fails and certificate setup is
+// postponed until the broker recovers.
+const autotlsPostponedMsg = "certificate setup postponed"
+
+// wssWildcardFragment appears in swarm listen addrs only when the AutoTLS
+// machinery was wired up (AutoWSS appended the wildcard WSS listener).
+const wssWildcardFragment = "/tls/sni/"
+
+// unroutableURL is guaranteed to refuse connections without depending on the
+// state of any real port (port 0 is never connectable).
+const unroutableURL = "http://127.0.0.1:0"
+
+// countingBroker is a fake p2p-forge broker that records /v1/health probes.
+func countingBroker(t *testing.T, status int) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var probes atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/health" {
+			probes.Add(1)
+			w.WriteHeader(status)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &probes
+}
+
+// autotlsNode inits a node with AutoTLS explicitly enabled against the given
+// broker URL. Forced public reachability plus an announced public address
+// satisfy the conditions the p2p-forge client waits for before it contacts
+// the broker, so the pre-issuance health check can be observed in an
+// isolated test. CAEndpoint points at an unroutable address so no test can
+// ever reach a real ACME CA, even when issuance starts. GOLOG env is pinned
+// so stderr assertions do not depend on ambient GOLOG_* variables.
+func autotlsNode(t *testing.T, brokerURL string) *harness.Node {
+	node := harness.NewT(t).NewNode().Init("--profile=test")
+	node.Runner.Env["GOLOG_LOG_LEVEL"] = "error"
+	node.Runner.Env["GOLOG_OUTPUT"] = "stderr"
+	node.UpdateConfig(func(cfg *config.Config) {
+		cfg.AutoTLS.Enabled = config.True
+		cfg.AutoTLS.RegistrationEndpoint = config.NewOptionalString(brokerURL)
+		cfg.AutoTLS.CAEndpoint = config.NewOptionalString(unroutableURL)
+		cfg.Internal.Libp2pForceReachability = config.NewOptionalString("public")
+		cfg.Addresses.Announce = []string{"/ip4/1.2.3.4/tcp/4001"}
+	})
+	return node
+}
+
+func TestAutoTLSBrokerHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registration delay defers any broker traffic", func(t *testing.T) {
+		t.Parallel()
+		broker, probes := countingBroker(t, http.StatusNoContent)
+
+		node := autotlsNode(t, broker.URL)
+		node.UpdateConfig(func(cfg *config.Config) {
+			// implicit enable: the default 1h registration delay applies, so
+			// an ephemeral node like this one must produce no broker traffic
+			// at all, even while it looks publicly reachable
+			cfg.AutoTLS.Enabled = config.Default
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		require.Never(t, func() bool { return probes.Load() > 0 }, 2*time.Second, 100*time.Millisecond,
+			"daemon must not contact broker before the registration delay")
+		require.NotContains(t, node.Daemon.Stderr.String(), autotlsPostponedMsg)
+	})
+
+	t.Run("postpones issuance while broker is unhealthy", func(t *testing.T) {
+		t.Parallel()
+		broker, probes := countingBroker(t, http.StatusServiceUnavailable)
+
+		node := autotlsNode(t, broker.URL)
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.AutoTLS.RegistrationDelay = config.NewOptionalDuration(1 * time.Second)
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		require.True(t, waitForLogMessage(node.Daemon.Stderr, autotlsPostponedMsg, 15*time.Second),
+			"p2p-forge client should postpone certificate setup when broker is unhealthy")
+		require.GreaterOrEqual(t, probes.Load(), int32(1))
+	})
+
+	t.Run("proceeds with issuance when broker is healthy", func(t *testing.T) {
+		t.Parallel()
+		broker, probes := countingBroker(t, http.StatusNoContent)
+
+		node := autotlsNode(t, broker.URL)
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.AutoTLS.RegistrationDelay = config.NewOptionalDuration(1 * time.Second)
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		require.Eventually(t, func() bool { return probes.Load() >= 1 }, 15*time.Second, 100*time.Millisecond,
+			"p2p-forge client should probe broker health before issuance")
+		require.NotContains(t, node.Daemon.Stderr.String(), autotlsPostponedMsg)
+
+		// AutoTLS machinery is wired up: AutoWSS added the wildcard listener
+		listenAddrs := node.IPFS("swarm", "addrs", "listen").Stdout.String()
+		require.Contains(t, listenAddrs, wssWildcardFragment)
+	})
+
+	t.Run("explicit enable goes through the same health check", func(t *testing.T) {
+		t.Parallel()
+		broker, probes := countingBroker(t, http.StatusServiceUnavailable)
+
+		// AutoTLS.Enabled=true with no custom delay means a zero registration
+		// delay: the health check runs as soon as the node looks publicly
+		// reachable, through the same code path as the delayed flow
+		node := autotlsNode(t, broker.URL)
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		require.True(t, waitForLogMessage(node.Daemon.Stderr, autotlsPostponedMsg, 15*time.Second),
+			"explicitly enabled AutoTLS should postpone certificate setup when broker is unhealthy")
+		require.GreaterOrEqual(t, probes.Load(), int32(1))
+	})
+}

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect
 	github.com/ipld/go-ipld-prime v0.24.0 // indirect
-	github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 // indirect
+	github.com/ipshipyard/p2p-forge v0.10.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jgautheron/goconst v1.7.1 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect
 	github.com/ipld/go-ipld-prime v0.24.0 // indirect
-	github.com/ipshipyard/p2p-forge v0.9.1 // indirect
+	github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jgautheron/goconst v1.7.1 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -357,8 +357,8 @@ github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG36
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 h1:cqNk8PEwHnK0vqWln+U/YZhQc9h2NB3KjUjDPZo5Q2s=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:ZEUdra3CoqRVRYgAX/jAJO9aZGz6SKtKEG628fHHktY=
-github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 h1:UE8fyZHRkeBc8Vlmrs/B6WTP8gWzVqUQZnG85yfJy0k=
-github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
+github.com/ipshipyard/p2p-forge v0.10.0 h1:OcfcyjoHkeiIskhT4fHN/N82HfpgAteb1Eg3ZNAGE/U=
+github.com/ipshipyard/p2p-forge v0.10.0/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -357,8 +357,8 @@ github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG36
 github.com/ipld/go-ipld-prime v0.24.0/go.mod h1:DYZxr/5caLNFbcuU6zLOgwSW7CgUEoC4wJiZMEU8Zhs=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714 h1:cqNk8PEwHnK0vqWln+U/YZhQc9h2NB3KjUjDPZo5Q2s=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714/go.mod h1:ZEUdra3CoqRVRYgAX/jAJO9aZGz6SKtKEG628fHHktY=
-github.com/ipshipyard/p2p-forge v0.9.1 h1:xHiauwYsHv8R6jIaXDV6e89xAeSS6tN++uMQuAC41Jw=
-github.com/ipshipyard/p2p-forge v0.9.1/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
+github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456 h1:UE8fyZHRkeBc8Vlmrs/B6WTP8gWzVqUQZnG85yfJy0k=
+github.com/ipshipyard/p2p-forge v0.9.2-0.20260717121503-3b0a9470e456/go.mod h1:1keK1MRRCu5oNe9uFKfNIIZXOFEF9hgD1iK1DUsjsXQ=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=


### PR DESCRIPTION
## Problem

When the AutoTLS broker (`registration.libp2p.direct`) is unreachable, because of an outage on its side or a firewall on yours, a node that doesn't have its certificate yet still runs full ACME issuance and then retries with backoff for up to 30 days. That's days of alarming ERRORs in your logs for something that can't succeed, and during an outage every cert-less node piles onto the struggling broker at once.

## Fix

- bumps p2p-forge to ipshipyard/p2p-forge#91: before the first issuance attempt, the client waits for the broker to answer `GET /v1/health` with HTTP 204
- while it doesn't, certificate setup is postponed: one ERROR in the log and one small request per hour (respects `Retry-After`), then issuance starts on its own once the broker recovers
- short-lived nodes (CI runners) still send the broker no traffic at all, and nodes that already have a certificate aren't affected