### PR TITLE
chore: start v0.44.0 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Kubo Changelogs
 
+- [v0.44](docs/changelogs/v0.44.md)
 - [v0.43](docs/changelogs/v0.43.md)
 - [v0.42](docs/changelogs/v0.42.md)
 - [v0.41](docs/changelogs/v0.41.md)

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -1,0 +1,18 @@
+# Kubo changelog v0.44
+
+- [v0.44.0](#v0440)
+
+## v0.44.0
+
+- [Overview](#overview)
+- [🔦 Highlights](#-highlights)
+- [📝 Changelog](#-changelog)
+- [👨‍👩‍👧‍👦 Contributors](#-contributors)
+
+### Overview
+
+### 🔦 Highlights
+
+### 📝 Changelog
+
+### 👨‍👩‍👧‍👦 Contributors

--- a/version.go
+++ b/version.go
@@ -28,7 +28,7 @@ var buildOrigin string
 const upstreamModulePath = "github.com/ipfs/kubo"
 
 // CurrentVersionNumber is the current application's version literal.
-const CurrentVersionNumber = "0.43.0-dev"
+const CurrentVersionNumber = "0.44.0-dev"
 
 const ApiVersion = "/kubo/" + CurrentVersionNumber + "/" //nolint
 


### PR DESCRIPTION
Opens development for the next release after v0.43.

- version.go -> 0.44.0-dev
- add docs/changelogs/v0.44.md stub and link it in CHANGELOG.md

