### PR TITLE
feat: add goroutine-leak collector to 'ipfs diag profile'

### DIFF
--- a/core/commands/profile.go
+++ b/core/commands/profile.go
@@ -48,6 +48,8 @@ Privacy Notice:
 The output file includes:
 
 - A list of running goroutines.
+- Stack traces of leaked goroutines, if the goroutine-leak collector is
+  requested (requires a build with GOEXPERIMENT=goroutineleakprofile).
 - A CPU profile.
 - A heap inuse profile.
 - A heap allocation profile.

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -13,6 +13,10 @@
 
 ### 🔦 Highlights
 
+#### Goroutine leak detection in `ipfs diag profile`
+
+`ipfs diag profile` gained an opt-in `goroutine-leak` collector (`ipfs diag profile --collectors goroutine-leak`) that captures Go's goroutine leak profile (`goroutineleak.pprof`) when the daemon binary was built with `GOEXPERIMENT=goroutineleakprofile` (a Go 1.26 experiment, expected to be enabled by default in Go 1.27). It detects goroutines blocked on channels, mutexes, or conditions that can never unblock. Collecting the profile triggers a goroutine-leak-detection GC cycle, which is why it is not part of the default collector set; requesting it on a build without the experiment returns an error. The same profile is also served at `/debug/pprof/goroutineleak` on the RPC API port. ([#11191](https://github.com/ipfs/kubo/issues/11191))
+
 ### 📝 Changelog
 
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/debug-guide.md
+++ b/docs/debug-guide.md
@@ -29,6 +29,8 @@ If you feel intrepid, you can dump this information and investigate it yourself:
 
 - goroutine dump
   - `curl localhost:5001/debug/pprof/goroutine\?debug=2 > ipfs.stacks`
+- goroutine leak profile (only when kubo was built with `GOEXPERIMENT=goroutineleakprofile`)
+  - `curl localhost:5001/debug/pprof/goroutineleak > ipfs.goroutineleak`
 - 30 second cpu profile
   - `curl localhost:5001/debug/pprof/profile > ipfs.cpuprof`
 - heap trace dump

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -21,6 +22,7 @@ import (
 const (
 	CollectorGoroutinesStack = "goroutines-stack"
 	CollectorGoroutinesPprof = "goroutines-pprof"
+	CollectorGoroutineLeak   = "goroutine-leak"
 	CollectorVersion         = "version"
 	CollectorHeap            = "heap"
 	CollectorAllocs          = "allocs"
@@ -41,6 +43,11 @@ type collector struct {
 	isExecutable bool
 	collectFunc  func(ctx context.Context, opts Options, writer io.Writer) error
 	enabledFunc  func(opts Options) bool
+	// availableFunc, when set, reports whether this collector can run in the
+	// current build. It is checked synchronously before any collector starts,
+	// so an unavailable collector fails the whole request up front instead of
+	// aborting mid-run with a partially written archive.
+	availableFunc func() error
 }
 
 func (p *collector) outputFileName() string {
@@ -63,6 +70,17 @@ var collectors = map[string]collector{
 		outputFile:  "goroutines.pprof",
 		collectFunc: goroutineStacksProto,
 		enabledFunc: func(opts Options) bool { return true },
+	},
+	CollectorGoroutineLeak: {
+		// Deliberately not part of the CLI default collector set: collecting
+		// this profile forces a goroutine-leak-detection GC cycle, and the
+		// profile only exists when the binary was built with
+		// GOEXPERIMENT=goroutineleakprofile. Requesting it on a build without
+		// the experiment returns an error instead of silently skipping.
+		outputFile:    "goroutineleak.pprof",
+		collectFunc:   goroutineLeakProfile,
+		enabledFunc:   func(opts Options) bool { return true },
+		availableFunc: goroutineLeakAvailable,
 	},
 	CollectorVersion: {
 		outputFile:  "version.json",
@@ -147,6 +165,17 @@ func (p *profiler) runProfile(ctx context.Context) error {
 		collectorsToRun[i] = c
 	}
 
+	// All names are valid; now confirm every requested collector can run in
+	// this build, before any collection starts. Keeping this a separate pass
+	// makes validation errors deterministic across build variants.
+	for _, c := range collectorsToRun {
+		if c.availableFunc != nil {
+			if err := c.availableFunc(); err != nil {
+				return err
+			}
+		}
+	}
+
 	results := make(chan profileResult, len(p.opts.Collectors))
 	wg := sync.WaitGroup{}
 	for _, c := range collectorsToRun {
@@ -204,6 +233,26 @@ func goroutineStacksText(ctx context.Context, _ Options, w io.Writer) error {
 
 func goroutineStacksProto(ctx context.Context, _ Options, w io.Writer) error {
 	return pprof.Lookup("goroutine").WriteTo(w, 0)
+}
+
+// goroutineLeakAvailable reports whether the runtime registered the
+// goroutineleak profile. The profile is only present when the binary was
+// built with GOEXPERIMENT=goroutineleakprofile (a Go 1.26 experiment,
+// expected to be enabled by default in Go 1.27).
+func goroutineLeakAvailable() error {
+	if pprof.Lookup("goroutineleak") == nil {
+		return errors.New("goroutineleak profile is not available in this build (requires GOEXPERIMENT=goroutineleakprofile)")
+	}
+	return nil
+}
+
+// goroutineLeakProfile writes the goroutineleak profile registered by the
+// runtime. Collecting it triggers a goroutine-leak-detection GC cycle.
+func goroutineLeakProfile(ctx context.Context, _ Options, w io.Writer) error {
+	if err := goroutineLeakAvailable(); err != nil {
+		return err
+	}
+	return pprof.Lookup("goroutineleak").WriteTo(w, 0)
 }
 
 func heapProfile(ctx context.Context, _ Options, w io.Writer) error {

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -4,12 +4,18 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// goroutineLeakEnabled reports whether this test binary was built with
+// GOEXPERIMENT=goroutineleakprofile, which is when the runtime registers the
+// goroutineleak profile.
+var goroutineLeakEnabled = goroutineLeakAvailable() == nil
 
 func TestProfiler(t *testing.T) {
 	allCollectors := []string{
@@ -23,6 +29,9 @@ func TestProfiler(t *testing.T) {
 		CollectorMutex,
 		CollectorBlock,
 		CollectorTrace,
+	}
+	if goroutineLeakEnabled {
+		allCollectors = append(allCollectors, CollectorGoroutineLeak)
 	}
 
 	cases := []struct {
@@ -40,7 +49,7 @@ func TestProfiler(t *testing.T) {
 				MutexProfileFraction: 4,
 				BlockProfileRate:     50 * time.Nanosecond,
 			},
-			expectFiles: []string{
+			expectFiles: withLeakProfile([]string{
 				"goroutines.stacks",
 				"goroutines.pprof",
 				"version.json",
@@ -51,7 +60,7 @@ func TestProfiler(t *testing.T) {
 				"mutex.pprof",
 				"block.pprof",
 				"trace",
-			},
+			}),
 		},
 		{
 			name: "windows",
@@ -62,7 +71,7 @@ func TestProfiler(t *testing.T) {
 				BlockProfileRate:     50 * time.Nanosecond,
 			},
 			goos: "windows",
-			expectFiles: []string{
+			expectFiles: withLeakProfile([]string{
 				"goroutines.stacks",
 				"goroutines.pprof",
 				"version.json",
@@ -73,7 +82,7 @@ func TestProfiler(t *testing.T) {
 				"mutex.pprof",
 				"block.pprof",
 				"trace",
-			},
+			}),
 		},
 		{
 			name: "sampling profiling disabled",
@@ -82,14 +91,14 @@ func TestProfiler(t *testing.T) {
 				MutexProfileFraction: 4,
 				BlockProfileRate:     50 * time.Nanosecond,
 			},
-			expectFiles: []string{
+			expectFiles: withLeakProfile([]string{
 				"goroutines.stacks",
 				"goroutines.pprof",
 				"version.json",
 				"heap.pprof",
 				"allocs.pprof",
 				"ipfs",
-			},
+			}),
 		},
 		{
 			name: "Mutex profiling disabled",
@@ -98,7 +107,7 @@ func TestProfiler(t *testing.T) {
 				ProfileDuration:  1 * time.Millisecond,
 				BlockProfileRate: 50 * time.Nanosecond,
 			},
-			expectFiles: []string{
+			expectFiles: withLeakProfile([]string{
 				"goroutines.stacks",
 				"goroutines.pprof",
 				"version.json",
@@ -108,7 +117,7 @@ func TestProfiler(t *testing.T) {
 				"cpu.pprof",
 				"block.pprof",
 				"trace",
-			},
+			}),
 		},
 		{
 			name: "block profiling disabled",
@@ -118,7 +127,7 @@ func TestProfiler(t *testing.T) {
 				MutexProfileFraction: 4,
 				BlockProfileRate:     0,
 			},
-			expectFiles: []string{
+			expectFiles: withLeakProfile([]string{
 				"goroutines.stacks",
 				"goroutines.pprof",
 				"version.json",
@@ -128,7 +137,7 @@ func TestProfiler(t *testing.T) {
 				"cpu.pprof",
 				"mutex.pprof",
 				"trace",
-			},
+			}),
 		},
 		{
 			name: "single collector",
@@ -180,4 +189,59 @@ func TestProfiler(t *testing.T) {
 			}
 		})
 	}
+}
+
+// withLeakProfile appends the goroutine leak profile output file when the
+// runtime registered the goroutineleak profile, so the same expectations work
+// with and without GOEXPERIMENT=goroutineleakprofile.
+func withLeakProfile(files []string) []string {
+	if goroutineLeakEnabled {
+		return append(files, "goroutineleak.pprof")
+	}
+	return files
+}
+
+func TestUnknownCollectorBeatsAvailability(t *testing.T) {
+	// The unknown-name error must win regardless of whether the goroutineleak
+	// profile is available, keeping validation deterministic across builds.
+	err := WriteProfiles(t.Context(), zip.NewWriter(&bytes.Buffer{}), Options{
+		Collectors: []string{CollectorGoroutineLeak, "bogus"},
+	})
+	require.ErrorContains(t, err, "unknown collector 'bogus'")
+}
+
+func TestGoroutineLeakProfile(t *testing.T) {
+	// Request the collector together with another one: on builds without the
+	// experiment the whole request must fail up front with a clear error and
+	// no partially written archive, not silently drop the requested profile.
+	buf := &bytes.Buffer{}
+	archive := zip.NewWriter(buf)
+	err := WriteProfiles(t.Context(), archive, Options{
+		Collectors: []string{CollectorVersion, CollectorGoroutineLeak},
+	})
+
+	if !goroutineLeakEnabled {
+		require.ErrorContains(t, err, "goroutineleak profile is not available")
+		require.NoError(t, archive.Close())
+		zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		require.NoError(t, err)
+		assert.Empty(t, zr.File, "no collector output should be written when an unavailable collector is requested")
+		return
+	}
+
+	require.NoError(t, err)
+	require.NoError(t, archive.Close())
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, zr.File, 2)
+
+	f, err := zr.Open("goroutineleak.pprof")
+	require.NoError(t, err)
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 2)
+	// The profile is written in gzip-compressed protobuf format.
+	assert.Equal(t, []byte{0x1f, 0x8b}, data[:2])
 }


### PR DESCRIPTION
Adds an opt-in `goroutine-leak` collector to `ipfs diag profile`, backed by Go 1.26's experimental goroutine leak profiler (`GOEXPERIMENT=goroutineleakprofile`).

### What

- New `goroutine-leak` collector in `profile/profile.go` that writes `goroutineleak.pprof` (proto format, like the other pprof-backed collectors).
- Requesting it on a build without the experiment fails up front with `goroutineleak profile is not available in this build (requires GOEXPERIMENT=goroutineleakprofile)`. Availability is validated synchronously, after name validation and before any collector starts, so a mixed request cannot leave a partially written archive, and the `unknown collector` error deterministically wins over the availability error across build variants.
- `/debug/pprof/goroutineleak` needs no route changes: the daemon mounts `net/http/pprof`'s handlers, which serve any registered runtime profile by name. Documented in `docs/debug-guide.md`.
- The privacy notice in the command help mentions the leaked-goroutine stack traces; changelog entry added under v0.44 Highlights.

### Design decisions (flagging for review)

- **Opt-in, not part of the default collector set.** Collecting this profile triggers a goroutine-leak-detection GC cycle. Putting it in the default set would silently add that cost to every default `ipfs diag profile` run the moment kubo builds move to a toolchain with the experiment enabled by default (expected in Go 1.27). That seemed like a decision a maintainer should make deliberately, so the collector is explicit-request only for now; promoting it to the default set later is a two-line change. Happy to flip it in this PR if you would rather have it on by default.
- **Error, not silent skip, when unavailable.** Sampling collectors (cpu/mutex/block) skip silently when their options disable them, but a collector the caller explicitly named that cannot run in this build should fail loudly rather than return a successful archive missing the one thing that was asked for.
- Collector name `goroutine-leak` follows the issue text; renaming to `goroutines-leak` for symmetry with the existing `goroutines-*` collectors is a one-liner if preferred.

### Tests

- `TestProfiler` covers the gating in the standard suite: `goroutine-leak` joins the collector list and the expected archive contents only when the profile is available, so the same assertions run under both build modes (the exact-file-count check proves absence on standard builds).
- `TestGoroutineLeakProfile` uses a mixed request (`version` + `goroutine-leak`): on standard builds it asserts the up-front error and that zero archive entries were written; on experiment builds it asserts both files are present and `goroutineleak.pprof` is valid gzip-compressed proto.
- `TestUnknownCollectorBeatsAvailability` pins the validation order across build variants.
- Verified locally on macOS/arm64 (Go 1.26.5): `go test ./profile/...` green with and without `GOEXPERIMENT=goroutineleakprofile`; `test/sharness/t0152-profile.sh` passes all 26; `TestCommandDocsWidth` green; exercised end-to-end against a live daemon in both build modes (default run unchanged; explicit request collects on experiment builds and errors on standard builds; `/debug/pprof/goroutineleak` returns 200 with gzip proto on experiment builds).

### Notes

- CI never sets `GOEXPERIMENT`, so the experiment-enabled halves of these tests do not run in CI today. If you want that coverage, I can add a small experiment-enabled `go test ./profile/...` job in a follow-up; I did not touch `.github/` here per AGENTS.md.
- Pre-existing and unchanged: on any synchronous validation error (including `unknown collector` on master today), the CLI leaves an empty zip skeleton at the `-o` path because the output file is created before collection starts. Can address separately if worth fixing.

## References

- Closes https://github.com/ipfs/kubo/issues/11191

🤖 Generated with [Claude Code](https://claude.com/claude-code)
