### PR TITLE
fix: harden CAR streaming and truncation

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -190,15 +190,28 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('ipfs-webui/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
-      # On cache miss: download browsers and install OS dependencies
+      # Only chromium is needed: ipfs-webui's playwright config declares no
+      # projects, so Playwright runs its default browser. Installing OS
+      # dependencies for all three pulls in the ffmpeg stack that firefox and
+      # webkit need, which has taken longer than this job's whole budget when
+      # the Ubuntu mirror is slow.
+      # On cache miss: download the browser and install OS dependencies
       - name: Install Playwright with dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
+        timeout-minutes: 8
         working-directory: ipfs-webui
-      # On cache hit: only ensure OS dependencies are present (fast, idempotent)
+      # On cache hit: top up OS dependencies, best effort. The runner image
+      # already ships what headless chromium needs, so this is belt and
+      # braces. It runs apt-get update first, which has taken over four
+      # minutes at 39 kB/s when the Ubuntu mirror is slow, so cap it and carry
+      # on. A library that really is missing shows up when the browser fails
+      # to launch, which names the problem far better than a stalled install.
       - name: Install Playwright OS dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps
+        run: npx playwright install-deps chromium
+        timeout-minutes: 4
+        continue-on-error: true
         working-directory: ipfs-webui
       # Cache test build output
       - name: Cache test build

--- a/core/commands/dag/export.go
+++ b/core/commands/dag/export.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -86,6 +87,18 @@ func dagExport(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment
 				errCh <- fmt.Errorf("stream flush failed: %s", err)
 			}
 			close(errCh)
+		}()
+
+		// Traversal decodes blocks with whatever codec their CID names, so it
+		// runs third-party code. This goroutine is detached from the request,
+		// and a panic on it would end the daemon rather than the command.
+		// Registered after the close above so it runs first, while errCh is
+		// still open.
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Errorf("recovered from panic exporting %s: %v\n%s", c, rec, debug.Stack())
+				errCh <- errors.New("internal error during CAR export")
+			}
 		}()
 
 		if localOnly {

--- a/core/commands/dag/get.go
+++ b/core/commands/dag/get.go
@@ -1,8 +1,10 @@
 package dagcmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"runtime/debug"
 
 	"github.com/ipfs/boxo/path"
 	ipldlegacy "github.com/ipfs/go-ipld-legacy"
@@ -68,6 +70,15 @@ func dagGet(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) e
 	r, w := io.Pipe()
 	go func() {
 		defer w.Close()
+		// Encoding runs the codec named by the node's CID, so it runs
+		// third-party code. This goroutine is detached from the request, and a
+		// panic on it would end the daemon rather than the command.
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Errorf("recovered from panic encoding %s as %s: %v\n%s", p, codec, rec, debug.Stack())
+				_ = w.CloseWithError(errors.New("internal error encoding node"))
+			}
+		}()
 		if err := encoder(finalNode, w); err != nil {
 			_ = w.CloseWithError(err)
 		}

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -168,6 +169,16 @@ The JSON output contains type information.
 			results := make(chan iface.DirEntry)
 			lsErr := make(chan error, 1)
 			go func() {
+				// Listing decodes blocks with whatever codec their CID names.
+				// This goroutine is detached from the request, and a panic on it
+				// would end the daemon rather than the command. Ls closes
+				// results on its way out, so the reader below still terminates.
+				defer func() {
+					if rec := recover(); rec != nil {
+						log.Errorf("recovered from panic listing %s: %v\n%s", pth, rec, debug.Stack())
+						lsErr <- fmt.Errorf("internal error listing %s", pth)
+					}
+				}()
 				lsErr <- api.Unixfs().Ls(lsCtx, pth, results,
 					options.Unixfs.ResolveChildren(resolveSize || resolveType))
 			}()

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -26,6 +26,7 @@ This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
   - [📛 Unified IPNS record storage](#-unified-ipns-record-storage)
   - [🧪 Tests use new go-test and rand v2](#-tests-use-new-go-test-and-rand-v2)
   - [🖥️ WebUI Improvements](#-webui-improvements)
+  - [🧵 A truncated CAR response now says so](#-a-truncated-car-response-now-says-so)
   - [🔒 Security fixes: update recommended](#-security-fixes-update-recommended)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
@@ -163,6 +164,10 @@ Share Link only ever produced a public gateway URL, so everything you shared dep
 Through Docker or a reverse proxy, the Web UI handed out dead links built from [`Addresses.Gateway`](https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesgateway), usually `/ip4/0.0.0.0/tcp/8080`. The new "Local HTTP Gateway" field takes a URL your browser can reach.
 
 Removing files through the selection toolbar left their pins behind. It now offers the "Also remove local pin (recommended)" checkbox.
+
+#### 🧵 A truncated CAR response now says so
+
+A CAR response that stopped partway through used to look exactly like a complete one, so a client could accept a short DAG as the whole thing. Such a response now ends with `[Gateway Error: CAR stream truncated, response is incomplete]`, which makes the trailing bytes invalid CAR: a reader stops with an error instead of trusting what it got. If you run a gateway behind a reverse proxy or a CDN, a short response now identifies itself instead of leaving you to guess which hop dropped it.
 
 #### 🔒 Security fixes: update recommended
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.42.0
+	github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.48.1-0.20260709142922-ec408fcc60c9
 	github.com/multiformats/go-multiaddr v0.16.1
@@ -92,13 +92,13 @@ require (
 	github.com/ipfs/go-ipfs-redirects-file v0.1.2 // indirect
 	github.com/ipfs/go-ipld-cbor v0.3.0 // indirect
 	github.com/ipfs/go-ipld-format v0.6.4 // indirect
-	github.com/ipfs/go-ipld-git v0.1.2 // indirect
+	github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938 // indirect
 	github.com/ipfs/go-ipld-legacy v0.3.0 // indirect
 	github.com/ipfs/go-libdht v0.5.0 // indirect
 	github.com/ipfs/go-log/v2 v2.9.2 // indirect
 	github.com/ipfs/go-metrics-interface v0.3.0 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.3 // indirect
-	github.com/ipfs/go-unixfsnode v1.10.5 // indirect
+	github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e // indirect
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect
 	github.com/ipld/go-ipld-prime v0.24.0 // indirect

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c
+	github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.48.1-0.20260709142922-ec408fcc60c9
 	github.com/multiformats/go-multiaddr v0.16.1
@@ -92,13 +92,13 @@ require (
 	github.com/ipfs/go-ipfs-redirects-file v0.1.2 // indirect
 	github.com/ipfs/go-ipld-cbor v0.3.0 // indirect
 	github.com/ipfs/go-ipld-format v0.6.4 // indirect
-	github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938 // indirect
+	github.com/ipfs/go-ipld-git v0.1.3 // indirect
 	github.com/ipfs/go-ipld-legacy v0.3.0 // indirect
 	github.com/ipfs/go-libdht v0.5.0 // indirect
 	github.com/ipfs/go-log/v2 v2.9.2 // indirect
 	github.com/ipfs/go-metrics-interface v0.3.0 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.3 // indirect
-	github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e // indirect
+	github.com/ipfs/go-unixfsnode v1.10.6 // indirect
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect
 	github.com/ipld/go-ipld-prime v0.24.0 // indirect

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -268,8 +268,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.0 h1:081LA7V9orgvGsCHMpxAjPz51JSDZtUaptZ9FwMcqP4=
-github.com/ipfs/boxo v0.42.0/go.mod h1:YoQNNShPIELwAGxmxemjZ/g7gqPUT8WDVO4ehPJU4Zg=
+github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c h1:V7Jr4IiGPj3P24r3pOTPndpKBdg+2QznrBAe+wbEtqI=
+github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c/go.mod h1:ZHZwi6WrrP4JEwf8N98oWMo+p2WHnZTWPdppmiPvALg=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -317,8 +317,8 @@ github.com/ipfs/go-ipld-cbor v0.3.0 h1:oYksX360/YPa+XfC7eciqDSLyLLrJ9MdiWiSFOE7N
 github.com/ipfs/go-ipld-cbor v0.3.0/go.mod h1:wQZ/Rz7ZsxboluciiI0i8OcVYEl8cawN3wmK5EQJPIA=
 github.com/ipfs/go-ipld-format v0.6.4 h1:NikmzItTDyQO0WkJI3rC2TGv4OFKOqM/DvcOCZZXuwM=
 github.com/ipfs/go-ipld-format v0.6.4/go.mod h1:1WGiDa1Nv8dXNQBknGQYe+9OF8IoNrErvN76BYvlaIA=
-github.com/ipfs/go-ipld-git v0.1.2 h1:cC2LFJzYCOIrM+ocGB3izmmOU6cL3DlGh3kfqnr3jpI=
-github.com/ipfs/go-ipld-git v0.1.2/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
+github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938 h1:ot7/RMMlhZEcp2EHRSDWje3EYKfsWL8zSisyAbj/4uk=
+github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
 github.com/ipfs/go-ipld-legacy v0.3.0 h1:7XhFKkRyCvP5upOlQfKUFIqL3S5DEZnbUE4bQmQ/tNE=
 github.com/ipfs/go-ipld-legacy v0.3.0/go.mod h1:Ukef9ARQiX+RVetwH2XiReLgJvQDEXcUPszrZ1KRjKI=
 github.com/ipfs/go-libdht v0.5.0 h1:ZN+eCqwahZvUeT0e4DsIxRtm78Mc9UR5tmZUiMsrGjQ=
@@ -332,8 +332,8 @@ github.com/ipfs/go-peertaskqueue v0.8.3 h1:tBPpGJy+A92RqtRFq5amJn0Uuj8Pw8tXi0X3e
 github.com/ipfs/go-peertaskqueue v0.8.3/go.mod h1:OqVync4kPOcXEGdj/LKvox9DCB5mkSBeXsPczCxLtYA=
 github.com/ipfs/go-test v0.4.1 h1:n6uNSakIgpTQIRorqNg2O02aMIFDLQk2z4rBfrlD3Uw=
 github.com/ipfs/go-test v0.4.1/go.mod h1:QmvVBf9kClNtRuFow4DASq03eFvjKla4Fy/UAkeeLO8=
-github.com/ipfs/go-unixfsnode v1.10.5 h1:V34JV7fM90y+2ZUef7ToShjmwAZ8oo1yP7zrpWzC5L4=
-github.com/ipfs/go-unixfsnode v1.10.5/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
+github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e h1:iWMcCUmgAGezAYCq2U9dlfv3Zx0yjuTRzqnA5kC5qh0=
+github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
 github.com/ipld/go-car/v2 v2.17.0 h1:zgjSxf/lQNYcQPX08cvb5rSdEY8sv5OOnQIsZhZMPx4=
 github.com/ipld/go-car/v2 v2.17.0/go.mod h1:/4HY8tFZ1q42Mw54ILLPQfjkUqMJxFKqY1yMDKHlYko=
 github.com/ipld/go-codec-dagpb v1.7.0 h1:hpuvQjCSVSLnTnHXn+QAMR0mLmb1gA6wl10LExo2Ts0=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -268,8 +268,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c h1:V7Jr4IiGPj3P24r3pOTPndpKBdg+2QznrBAe+wbEtqI=
-github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c/go.mod h1:ZHZwi6WrrP4JEwf8N98oWMo+p2WHnZTWPdppmiPvALg=
+github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f h1:5muOzAC+BQlgs8IKTLZMZ/5vJMuWE+qrOUCrQSV0tQM=
+github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f/go.mod h1:i4Q5+g0hZYkn7AsXDfcfLDb25K7rhZ5xLD7h5qWuOMY=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -317,8 +317,8 @@ github.com/ipfs/go-ipld-cbor v0.3.0 h1:oYksX360/YPa+XfC7eciqDSLyLLrJ9MdiWiSFOE7N
 github.com/ipfs/go-ipld-cbor v0.3.0/go.mod h1:wQZ/Rz7ZsxboluciiI0i8OcVYEl8cawN3wmK5EQJPIA=
 github.com/ipfs/go-ipld-format v0.6.4 h1:NikmzItTDyQO0WkJI3rC2TGv4OFKOqM/DvcOCZZXuwM=
 github.com/ipfs/go-ipld-format v0.6.4/go.mod h1:1WGiDa1Nv8dXNQBknGQYe+9OF8IoNrErvN76BYvlaIA=
-github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938 h1:ot7/RMMlhZEcp2EHRSDWje3EYKfsWL8zSisyAbj/4uk=
-github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
+github.com/ipfs/go-ipld-git v0.1.3 h1:1o7nQ2a8NArfQU4h0ZYVSfhZy9cIFRfiDiwcoKM7ehI=
+github.com/ipfs/go-ipld-git v0.1.3/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
 github.com/ipfs/go-ipld-legacy v0.3.0 h1:7XhFKkRyCvP5upOlQfKUFIqL3S5DEZnbUE4bQmQ/tNE=
 github.com/ipfs/go-ipld-legacy v0.3.0/go.mod h1:Ukef9ARQiX+RVetwH2XiReLgJvQDEXcUPszrZ1KRjKI=
 github.com/ipfs/go-libdht v0.5.0 h1:ZN+eCqwahZvUeT0e4DsIxRtm78Mc9UR5tmZUiMsrGjQ=
@@ -332,8 +332,8 @@ github.com/ipfs/go-peertaskqueue v0.8.3 h1:tBPpGJy+A92RqtRFq5amJn0Uuj8Pw8tXi0X3e
 github.com/ipfs/go-peertaskqueue v0.8.3/go.mod h1:OqVync4kPOcXEGdj/LKvox9DCB5mkSBeXsPczCxLtYA=
 github.com/ipfs/go-test v0.4.1 h1:n6uNSakIgpTQIRorqNg2O02aMIFDLQk2z4rBfrlD3Uw=
 github.com/ipfs/go-test v0.4.1/go.mod h1:QmvVBf9kClNtRuFow4DASq03eFvjKla4Fy/UAkeeLO8=
-github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e h1:iWMcCUmgAGezAYCq2U9dlfv3Zx0yjuTRzqnA5kC5qh0=
-github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
+github.com/ipfs/go-unixfsnode v1.10.6 h1:0rnKD4azJad4cT8t6wITqNl9Q0GTjB+YRBfMQ39C7Sw=
+github.com/ipfs/go-unixfsnode v1.10.6/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
 github.com/ipld/go-car/v2 v2.17.0 h1:zgjSxf/lQNYcQPX08cvb5rSdEY8sv5OOnQIsZhZMPx4=
 github.com/ipld/go-car/v2 v2.17.0/go.mod h1:/4HY8tFZ1q42Mw54ILLPQfjkUqMJxFKqY1yMDKHlYko=
 github.com/ipld/go-codec-dagpb v1.7.0 h1:hpuvQjCSVSLnTnHXn+QAMR0mLmb1gA6wl10LExo2Ts0=

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.42.0
+	github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c
 	github.com/ipfs/go-block-format v0.2.4
 	github.com/ipfs/go-cid v0.6.2
 	github.com/ipfs/go-cidutil v0.1.2
@@ -37,13 +37,13 @@ require (
 	github.com/ipfs/go-ipfs-cmds v0.16.1
 	github.com/ipfs/go-ipld-cbor v0.3.0
 	github.com/ipfs/go-ipld-format v0.6.4
-	github.com/ipfs/go-ipld-git v0.1.2
+	github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938
 	github.com/ipfs/go-ipld-legacy v0.3.0
 	github.com/ipfs/go-log/v2 v2.9.2
 	github.com/ipfs/go-metrics-interface v0.3.0
 	github.com/ipfs/go-metrics-prometheus v0.1.0
 	github.com/ipfs/go-test v0.4.1
-	github.com/ipfs/go-unixfsnode v1.10.5
+	github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e
 	github.com/ipld/go-car/v2 v2.17.0
 	github.com/ipld/go-codec-dagpb v1.7.0
 	github.com/ipld/go-ipld-prime v0.24.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c
+	github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f
 	github.com/ipfs/go-block-format v0.2.4
 	github.com/ipfs/go-cid v0.6.2
 	github.com/ipfs/go-cidutil v0.1.2
@@ -37,13 +37,13 @@ require (
 	github.com/ipfs/go-ipfs-cmds v0.16.1
 	github.com/ipfs/go-ipld-cbor v0.3.0
 	github.com/ipfs/go-ipld-format v0.6.4
-	github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938
+	github.com/ipfs/go-ipld-git v0.1.3
 	github.com/ipfs/go-ipld-legacy v0.3.0
 	github.com/ipfs/go-log/v2 v2.9.2
 	github.com/ipfs/go-metrics-interface v0.3.0
 	github.com/ipfs/go-metrics-prometheus v0.1.0
 	github.com/ipfs/go-test v0.4.1
-	github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e
+	github.com/ipfs/go-unixfsnode v1.10.6
 	github.com/ipld/go-car/v2 v2.17.0
 	github.com/ipld/go-codec-dagpb v1.7.0
 	github.com/ipld/go-ipld-prime v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.0 h1:081LA7V9orgvGsCHMpxAjPz51JSDZtUaptZ9FwMcqP4=
-github.com/ipfs/boxo v0.42.0/go.mod h1:YoQNNShPIELwAGxmxemjZ/g7gqPUT8WDVO4ehPJU4Zg=
+github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c h1:V7Jr4IiGPj3P24r3pOTPndpKBdg+2QznrBAe+wbEtqI=
+github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c/go.mod h1:ZHZwi6WrrP4JEwf8N98oWMo+p2WHnZTWPdppmiPvALg=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -389,8 +389,8 @@ github.com/ipfs/go-ipld-cbor v0.3.0 h1:oYksX360/YPa+XfC7eciqDSLyLLrJ9MdiWiSFOE7N
 github.com/ipfs/go-ipld-cbor v0.3.0/go.mod h1:wQZ/Rz7ZsxboluciiI0i8OcVYEl8cawN3wmK5EQJPIA=
 github.com/ipfs/go-ipld-format v0.6.4 h1:NikmzItTDyQO0WkJI3rC2TGv4OFKOqM/DvcOCZZXuwM=
 github.com/ipfs/go-ipld-format v0.6.4/go.mod h1:1WGiDa1Nv8dXNQBknGQYe+9OF8IoNrErvN76BYvlaIA=
-github.com/ipfs/go-ipld-git v0.1.2 h1:cC2LFJzYCOIrM+ocGB3izmmOU6cL3DlGh3kfqnr3jpI=
-github.com/ipfs/go-ipld-git v0.1.2/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
+github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938 h1:ot7/RMMlhZEcp2EHRSDWje3EYKfsWL8zSisyAbj/4uk=
+github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
 github.com/ipfs/go-ipld-legacy v0.3.0 h1:7XhFKkRyCvP5upOlQfKUFIqL3S5DEZnbUE4bQmQ/tNE=
 github.com/ipfs/go-ipld-legacy v0.3.0/go.mod h1:Ukef9ARQiX+RVetwH2XiReLgJvQDEXcUPszrZ1KRjKI=
 github.com/ipfs/go-libdht v0.5.0 h1:ZN+eCqwahZvUeT0e4DsIxRtm78Mc9UR5tmZUiMsrGjQ=
@@ -406,8 +406,8 @@ github.com/ipfs/go-peertaskqueue v0.8.3 h1:tBPpGJy+A92RqtRFq5amJn0Uuj8Pw8tXi0X3e
 github.com/ipfs/go-peertaskqueue v0.8.3/go.mod h1:OqVync4kPOcXEGdj/LKvox9DCB5mkSBeXsPczCxLtYA=
 github.com/ipfs/go-test v0.4.1 h1:n6uNSakIgpTQIRorqNg2O02aMIFDLQk2z4rBfrlD3Uw=
 github.com/ipfs/go-test v0.4.1/go.mod h1:QmvVBf9kClNtRuFow4DASq03eFvjKla4Fy/UAkeeLO8=
-github.com/ipfs/go-unixfsnode v1.10.5 h1:V34JV7fM90y+2ZUef7ToShjmwAZ8oo1yP7zrpWzC5L4=
-github.com/ipfs/go-unixfsnode v1.10.5/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
+github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e h1:iWMcCUmgAGezAYCq2U9dlfv3Zx0yjuTRzqnA5kC5qh0=
+github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
 github.com/ipld/go-car/v2 v2.17.0 h1:zgjSxf/lQNYcQPX08cvb5rSdEY8sv5OOnQIsZhZMPx4=
 github.com/ipld/go-car/v2 v2.17.0/go.mod h1:/4HY8tFZ1q42Mw54ILLPQfjkUqMJxFKqY1yMDKHlYko=
 github.com/ipld/go-codec-dagpb v1.7.0 h1:hpuvQjCSVSLnTnHXn+QAMR0mLmb1gA6wl10LExo2Ts0=

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c h1:V7Jr4IiGPj3P24r3pOTPndpKBdg+2QznrBAe+wbEtqI=
-github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c/go.mod h1:ZHZwi6WrrP4JEwf8N98oWMo+p2WHnZTWPdppmiPvALg=
+github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f h1:5muOzAC+BQlgs8IKTLZMZ/5vJMuWE+qrOUCrQSV0tQM=
+github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f/go.mod h1:i4Q5+g0hZYkn7AsXDfcfLDb25K7rhZ5xLD7h5qWuOMY=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -389,8 +389,8 @@ github.com/ipfs/go-ipld-cbor v0.3.0 h1:oYksX360/YPa+XfC7eciqDSLyLLrJ9MdiWiSFOE7N
 github.com/ipfs/go-ipld-cbor v0.3.0/go.mod h1:wQZ/Rz7ZsxboluciiI0i8OcVYEl8cawN3wmK5EQJPIA=
 github.com/ipfs/go-ipld-format v0.6.4 h1:NikmzItTDyQO0WkJI3rC2TGv4OFKOqM/DvcOCZZXuwM=
 github.com/ipfs/go-ipld-format v0.6.4/go.mod h1:1WGiDa1Nv8dXNQBknGQYe+9OF8IoNrErvN76BYvlaIA=
-github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938 h1:ot7/RMMlhZEcp2EHRSDWje3EYKfsWL8zSisyAbj/4uk=
-github.com/ipfs/go-ipld-git v0.1.3-0.20260726225936-271fdd4b5938/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
+github.com/ipfs/go-ipld-git v0.1.3 h1:1o7nQ2a8NArfQU4h0ZYVSfhZy9cIFRfiDiwcoKM7ehI=
+github.com/ipfs/go-ipld-git v0.1.3/go.mod h1:oA2QnIjtrQ1scw0/I/mSMxxYXH5Uh5zzZHLBC8LHgUs=
 github.com/ipfs/go-ipld-legacy v0.3.0 h1:7XhFKkRyCvP5upOlQfKUFIqL3S5DEZnbUE4bQmQ/tNE=
 github.com/ipfs/go-ipld-legacy v0.3.0/go.mod h1:Ukef9ARQiX+RVetwH2XiReLgJvQDEXcUPszrZ1KRjKI=
 github.com/ipfs/go-libdht v0.5.0 h1:ZN+eCqwahZvUeT0e4DsIxRtm78Mc9UR5tmZUiMsrGjQ=
@@ -406,8 +406,8 @@ github.com/ipfs/go-peertaskqueue v0.8.3 h1:tBPpGJy+A92RqtRFq5amJn0Uuj8Pw8tXi0X3e
 github.com/ipfs/go-peertaskqueue v0.8.3/go.mod h1:OqVync4kPOcXEGdj/LKvox9DCB5mkSBeXsPczCxLtYA=
 github.com/ipfs/go-test v0.4.1 h1:n6uNSakIgpTQIRorqNg2O02aMIFDLQk2z4rBfrlD3Uw=
 github.com/ipfs/go-test v0.4.1/go.mod h1:QmvVBf9kClNtRuFow4DASq03eFvjKla4Fy/UAkeeLO8=
-github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e h1:iWMcCUmgAGezAYCq2U9dlfv3Zx0yjuTRzqnA5kC5qh0=
-github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
+github.com/ipfs/go-unixfsnode v1.10.6 h1:0rnKD4azJad4cT8t6wITqNl9Q0GTjB+YRBfMQ39C7Sw=
+github.com/ipfs/go-unixfsnode v1.10.6/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
 github.com/ipld/go-car/v2 v2.17.0 h1:zgjSxf/lQNYcQPX08cvb5rSdEY8sv5OOnQIsZhZMPx4=
 github.com/ipld/go-car/v2 v2.17.0/go.mod h1:/4HY8tFZ1q42Mw54ILLPQfjkUqMJxFKqY1yMDKHlYko=
 github.com/ipld/go-codec-dagpb v1.7.0 h1:hpuvQjCSVSLnTnHXn+QAMR0mLmb1gA6wl10LExo2Ts0=

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c // indirect
+	github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.4 // indirect
 	github.com/ipfs/go-cid v0.6.2 // indirect
@@ -148,7 +148,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.6.4 // indirect
 	github.com/ipfs/go-ipld-legacy v0.3.0 // indirect
 	github.com/ipfs/go-metrics-interface v0.3.0 // indirect
-	github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e // indirect
+	github.com/ipfs/go-unixfsnode v1.10.6 // indirect
 	github.com/ipfs/kubo v0.31.0 // indirect
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.42.0 // indirect
+	github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.4 // indirect
 	github.com/ipfs/go-cid v0.6.2 // indirect
@@ -148,7 +148,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.6.4 // indirect
 	github.com/ipfs/go-ipld-legacy v0.3.0 // indirect
 	github.com/ipfs/go-metrics-interface v0.3.0 // indirect
-	github.com/ipfs/go-unixfsnode v1.10.5 // indirect
+	github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e // indirect
 	github.com/ipfs/kubo v0.31.0 // indirect
 	github.com/ipld/go-car/v2 v2.17.0 // indirect
 	github.com/ipld/go-codec-dagpb v1.7.0 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -299,8 +299,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.0 h1:081LA7V9orgvGsCHMpxAjPz51JSDZtUaptZ9FwMcqP4=
-github.com/ipfs/boxo v0.42.0/go.mod h1:YoQNNShPIELwAGxmxemjZ/g7gqPUT8WDVO4ehPJU4Zg=
+github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c h1:V7Jr4IiGPj3P24r3pOTPndpKBdg+2QznrBAe+wbEtqI=
+github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c/go.mod h1:ZHZwi6WrrP4JEwf8N98oWMo+p2WHnZTWPdppmiPvALg=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -339,8 +339,8 @@ github.com/ipfs/go-peertaskqueue v0.8.3 h1:tBPpGJy+A92RqtRFq5amJn0Uuj8Pw8tXi0X3e
 github.com/ipfs/go-peertaskqueue v0.8.3/go.mod h1:OqVync4kPOcXEGdj/LKvox9DCB5mkSBeXsPczCxLtYA=
 github.com/ipfs/go-test v0.4.1 h1:n6uNSakIgpTQIRorqNg2O02aMIFDLQk2z4rBfrlD3Uw=
 github.com/ipfs/go-test v0.4.1/go.mod h1:QmvVBf9kClNtRuFow4DASq03eFvjKla4Fy/UAkeeLO8=
-github.com/ipfs/go-unixfsnode v1.10.5 h1:V34JV7fM90y+2ZUef7ToShjmwAZ8oo1yP7zrpWzC5L4=
-github.com/ipfs/go-unixfsnode v1.10.5/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
+github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e h1:iWMcCUmgAGezAYCq2U9dlfv3Zx0yjuTRzqnA5kC5qh0=
+github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
 github.com/ipfs/hang-fds v0.1.0 h1:deBiFlWHsVGzJ0ZMaqscEqRM1r2O1rFZ59UiQXb1Xko=
 github.com/ipfs/hang-fds v0.1.0/go.mod h1:29VLWOn3ftAgNNgXg/al7b11UzuQ+w7AwtCGcTaWkbM=
 github.com/ipfs/iptb v1.4.1 h1:faXd3TKGPswbHyZecqqg6UfbES7RDjTKQb+6VFPKDUo=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -299,8 +299,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c h1:V7Jr4IiGPj3P24r3pOTPndpKBdg+2QznrBAe+wbEtqI=
-github.com/ipfs/boxo v0.42.1-0.20260726234027-d1f52458f62c/go.mod h1:ZHZwi6WrrP4JEwf8N98oWMo+p2WHnZTWPdppmiPvALg=
+github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f h1:5muOzAC+BQlgs8IKTLZMZ/5vJMuWE+qrOUCrQSV0tQM=
+github.com/ipfs/boxo v0.42.1-0.20260727115347-1c8cf646367f/go.mod h1:i4Q5+g0hZYkn7AsXDfcfLDb25K7rhZ5xLD7h5qWuOMY=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -339,8 +339,8 @@ github.com/ipfs/go-peertaskqueue v0.8.3 h1:tBPpGJy+A92RqtRFq5amJn0Uuj8Pw8tXi0X3e
 github.com/ipfs/go-peertaskqueue v0.8.3/go.mod h1:OqVync4kPOcXEGdj/LKvox9DCB5mkSBeXsPczCxLtYA=
 github.com/ipfs/go-test v0.4.1 h1:n6uNSakIgpTQIRorqNg2O02aMIFDLQk2z4rBfrlD3Uw=
 github.com/ipfs/go-test v0.4.1/go.mod h1:QmvVBf9kClNtRuFow4DASq03eFvjKla4Fy/UAkeeLO8=
-github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e h1:iWMcCUmgAGezAYCq2U9dlfv3Zx0yjuTRzqnA5kC5qh0=
-github.com/ipfs/go-unixfsnode v1.10.6-0.20260726230606-70b7b4e8854e/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
+github.com/ipfs/go-unixfsnode v1.10.6 h1:0rnKD4azJad4cT8t6wITqNl9Q0GTjB+YRBfMQ39C7Sw=
+github.com/ipfs/go-unixfsnode v1.10.6/go.mod h1:u/9Ukl+XYpfKTMu+NXQqxbzAJVTwSCoyTYBGgE+JdSE=
 github.com/ipfs/hang-fds v0.1.0 h1:deBiFlWHsVGzJ0ZMaqscEqRM1r2O1rFZ59UiQXb1Xko=
 github.com/ipfs/hang-fds v0.1.0/go.mod h1:29VLWOn3ftAgNNgXg/al7b11UzuQ+w7AwtCGcTaWkbM=
 github.com/ipfs/iptb v1.4.1 h1:faXd3TKGPswbHyZecqqg6UfbES7RDjTKQb+6VFPKDUo=


### PR DESCRIPTION
## Problem

A CAR response that stopped partway through looked exactly like a complete one. By the time anything goes wrong the status line and headers are long gone, and `X-Stream-Error` is set once the body is already streaming, so it rarely reaches the client and never survives a reverse proxy or CDN. Debugging a short response meant guessing which hop dropped it. Nothing bounded how deep a CAR walk goes either, and `ls`, `dag get` and `dag export` each hand their work to a goroutine and read the result back over a channel, where a panic ends the daemon rather than the command.

## Fix

- A CAR that stops early now ends with a marker, so a reader errors instead of accepting a short DAG as complete.
- CAR traversal is bounded by depth, 1024 by default and configurable in boxo.
- The three commands recover on their own goroutines and report through the channel they already use.

Dependency updates carry the rest: ipfs/boxo#1197, ipfs/go-ipld-git#77 and ipfs/go-unixfsnode#100. All three are pinned to their branches, so this needs their tagged releases before it can merge.