### PR TITLE
docs: drop expired pgp key from security notes

### DIFF
--- a/assets/init-doc/security-notes
+++ b/assets/init-doc/security-notes
@@ -11,12 +11,8 @@ Please note the following:
 
 - ipfs is a networked program, and may have serious undiscovered
   vulnerabilities. It is written in Go, and we do not execute any
-  user provided data. But please point any problems out to us in a
-  github issue, or email security@ipfs.io privately.
-
-- security@ipfs.io GPG key:
-  - 4B9665FB 92636D17 7C7A86D3 50AAE8A9 59B13AF3
-  - https://pgp.mit.edu/pks/lookup?op=get&search=0x50AAE8A959B13AF3
+  user provided data. If you find a problem, report it privately:
+  https://github.com/ipfs/kubo/security/policy
 
 - ipfs uses encryption for all communication, but it's NOT PROVEN SECURE
   YET!  It may be totally broken. For now, the code is included to make

--- a/test/cli/testutils/cids.go
+++ b/test/cli/testutils/cids.go
@@ -1,6 +1,6 @@
 package testutils
 
 const (
-	CIDWelcomeDocs = "QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc"
+	CIDWelcomeDocs = "QmcPu2XXVVURZX1ti4zQCgSevrJqH5SPaw16VdsLcGKfss"
 	CIDEmptyDir    = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
 )

--- a/test/sharness/lib/test-lib-hashes.sh
+++ b/test/sharness/lib/test-lib-hashes.sh
@@ -1,5 +1,5 @@
 # this file defines several useful hashes used across the test codebase.
 # thus they can be defined + changed in one place
 
-HASH_WELCOME_DOCS="QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc"
+HASH_WELCOME_DOCS="QmcPu2XXVVURZX1ti4zQCgSevrJqH5SPaw16VdsLcGKfss"
 HASH_EMPTY_DIR="QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"


### PR DESCRIPTION

## Problem

`ipfs init --empty-repo=false` seeds `security-notes`, which asks you to encrypt your report to a **PGP key that expired in July 2018**, next to a `pgp.mit.edu` lookup URL that returns 503. Two dead ends in a row for someone sitting on a sensitive finding, and there is no replacement key published anywhere.

## Fix

- the notes link https://github.com/ipfs/kubo/security/policy instead
- editing a seeded doc changes the welcome-docs CID, so `CIDWelcomeDocs` and `HASH_WELCOME_DOCS` move with it

That CID has been stable since April 2020 and every new node pins it at init, which makes it a convenient probe target.

@dennis-tra, does [ProbeLab](https://probelab.io) depend on it for retrievability or swarm measurements? If merging would disrupt anything on your side, happy to hold or coordinate timing.