### PR TITLE
chore(ci): remove self-hosted runners [skip changelog]

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   go-build:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       TEST_DOCKER: 0

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -17,7 +17,7 @@ jobs:
   # Unit tests with coverage collection (uploaded to Codecov)
   unit-tests:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       GOTRACEBACK: single  # reduce noise on test timeout panics
@@ -90,7 +90,7 @@ jobs:
   # (Go-based replacement for legacy test/sharness shell scripts)
   cli-tests:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       GOTRACEBACK: single  # reduce noise on test timeout panics
@@ -153,7 +153,7 @@ jobs:
   # Runs both FUSE unit tests (./fuse/...) and CLI integration tests (./test/cli/fuse/...)
   fuse-tests:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     concurrency:
       group: fuse-tests-${{ github.repository }}
       cancel-in-progress: false
@@ -184,8 +184,7 @@ jobs:
           fi
       - name: Clean up stale FUSE mounts
         run: |
-          # On shared self-hosted runners, leftover mounts from previous
-          # runs can exhaust the kernel FUSE mount limit (mount_max).
+          # Leftover mounts can exhaust the kernel FUSE mount limit (mount_max).
           # Unit tests mount with FsName "kubo-test"; CLI tests mount
           # under the harness temp dir (ipfs/ipns/mfs subdirectories).
           awk '$1 == "kubo-test" || $2 ~ /\/tmp\/.*\/(ipfs|ipns|mfs)$/ { print $2 }' /proc/mounts 2>/dev/null \
@@ -205,7 +204,7 @@ jobs:
   # Example tests (kubo-as-a-library)
   example-tests:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       GOTRACEBACK: single

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -57,7 +57,7 @@ jobs:
           path: cmd/ipfs/ipfs
   helia-interop:
     needs: [interop-prep]
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
       run:
@@ -155,7 +155,7 @@ jobs:
         working-directory: node_modules/@helia/interop
   ipfs-webui:
     needs: [interop-prep]
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "2xlarge"]' || '"ubuntu-latest"') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       NO_SANDBOX: true

--- a/.github/workflows/sharness.yml
+++ b/.github/workflows/sharness.yml
@@ -16,8 +16,8 @@ concurrency:
 jobs:
   sharness-test:
     if: github.repository == 'ipfs/kubo' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(github.repository == 'ipfs/kubo' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
-    timeout-minutes: ${{ github.repository == 'ipfs/kubo' && 15 || 60 }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash
@@ -52,8 +52,7 @@ jobs:
           TEST_EXPENSIVE: 1
           IPFS_CHECK_RCMGR_DEFAULTS: 1
           CONTINUE_ON_S_FAILURE: 1
-          # increasing parallelism beyond 10 doesn't speed up the tests much
-          PARALLEL: ${{ github.repository == 'ipfs/kubo' && 10 || 3 }}
+          PARALLEL: 3
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: failure() || success()
@@ -81,15 +80,8 @@ jobs:
           mode: no-frames
           input: kubo/test/sharness/test-results/sharness.xml
           output: kubo/test/sharness/test-results/sharness.html
-      - name: Upload one-page HTML report to S3
-        id: one-page
-        uses: ipdxco/custom-github-runners/.github/actions/upload-artifact@main
-        if: github.repository == 'ipfs/kubo' && (failure() || success())
-        with:
-          source: kubo/test/sharness/test-results/sharness.html
-          destination: sharness.html
       - name: Upload one-page HTML report
-        if: github.repository != 'ipfs/kubo' && (failure() || success())
+        if: failure() || success()
         uses: actions/upload-artifact@v7
         with:
           name: sharness.html
@@ -101,25 +93,9 @@ jobs:
           mode: frames
           input: kubo/test/sharness/test-results/sharness.xml
           output: kubo/test/sharness/test-results/sharness-html
-      - name: Upload full HTML report to S3
-        id: full
-        uses: ipdxco/custom-github-runners/.github/actions/upload-artifact@main
-        if: github.repository == 'ipfs/kubo' && (failure() || success())
-        with:
-          source: kubo/test/sharness/test-results/sharness-html
-          destination: sharness-html/
       - name: Upload full HTML report
-        if: github.repository != 'ipfs/kubo' && (failure() || success())
+        if: failure() || success()
         uses: actions/upload-artifact@v7
         with:
           name: sharness-html
           path: kubo/test/sharness/test-results/sharness-html
-      - name: Add S3 links to the summary
-        if: github.repository == 'ipfs/kubo' && (failure() || success())
-        run: echo "$MD" >> $GITHUB_STEP_SUMMARY
-        env:
-          MD: |
-            # HTML Reports
-
-            - View the [one page HTML report](${{ steps.one-page.outputs.url }})
-            - View the [full HTML report](${{ steps.full.outputs.url }}index.html)

--- a/test/cli/completion_test.go
+++ b/test/cli/completion_test.go
@@ -48,7 +48,11 @@ func TestZshCompletion(t *testing.T) {
 		completionFile := h.WriteToTemp(res.Stdout.String())
 		res = h.Runner.Run(harness.RunRequest{
 			Path: "zsh",
-			Args: []string{"-c", fmt.Sprintf("autoload -Uz compinit && compinit && source %s && echo -E $_comps[ipfs]", completionFile)},
+			// compinit -i skips insecure (group/other-writable) fpath dirs instead of
+			// prompting about them; the prompt aborts in non-interactive shells (no tty),
+			// e.g. on GitHub-hosted runners. This test validates kubo's generated
+			// completion script, not the host's fpath hygiene.
+			Args: []string{"-c", fmt.Sprintf("autoload -Uz compinit && compinit -i && source %s && echo -E $_comps[ipfs]", completionFile)},
 		})
 
 		assert.NoError(t, res.Err)


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

Switch CI jobs that used self-hosted runner labels to `ubuntu-latest`, matching their existing fallback.
Sharness now uses the hosted-runner timeout and parallelism values and uploads HTML reports with `actions/upload-artifact` instead of the runner-specific S3 helper.
Validated with `git diff --check`, a basic YAML parse, and a grep confirming no self-hosted or custom runner references remain.

## References
