### PR TITLE
docs: guide for running on low-memory devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Kubo runs on most Linux, macOS, and Windows systems. For optimal performance, we
 > [!CAUTION]
 > Systems with less than the recommended memory may experience instability, frequent OOM errors or restarts, and missing data announcement (reprovider window), which can make data fully or partially inaccessible to other peers. Running Kubo on underprovisioned hardware is at your own risk.
 
+For running Kubo on constrained hardware such as a Raspberry Pi, see [Kubo on low-memory devices](docs/production/low-memory.md).
+
 ### Official Prebuilt Binaries
 
 Download from https://dist.ipfs.tech#kubo or [GitHub Releases](https://github.com/ipfs/kubo/releases/latest).

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ If you're experiencing an issue with IPFS, please [file an issue](https://github
 
 - [Reverse proxy setup](production/reverse-proxy.md)
 - [Firewall setup (ufw)](production/firewall.md)
+- [Low-memory devices (Raspberry Pi and similar)](production/low-memory.md)
 
 ## Specifications
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -4565,7 +4565,7 @@ Reduces daemon overhead on the system by disabling optional swarm services.
 > [!NOTE]
 > This profile is provided for legacy reasons.
 > With modern Kubo setting the above should not be necessary.
-> For memory tuning on constrained hardware (systemd limits, `GOMEMLIMIT`), see [Kubo on low-memory devices](production/low-memory.md).
+> For running on constrained hardware, see [Kubo on low-memory devices](production/low-memory.md): it covers these settings individually, plus memory limits (systemd, `GOMEMLIMIT`) and DHT announcement sizing.
 
 ### `announce-off` profile
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -3603,6 +3603,10 @@ It is possible to inspect the runtime limits via `ipfs swarm resources --help`.
 > `Swarm.ResourceMgr.MaxMemory` is the memory limit for go-libp2p networking stack alone, and not for entire Kubo or Bitswap.
 >
 > To set memory limit for the entire Kubo process, use [`GOMEMLIMIT` environment variable](http://web.archive.org/web/20240222201412/https://kupczynski.info/posts/go-container-aware/) which all Go programs recognize, and then set `Swarm.ResourceMgr.MaxMemory` to less than your custom `GOMEMLIMIT`.
+> For a worked example on constrained hardware, see [Kubo on low-memory devices](production/low-memory.md).
+
+> [!CAUTION]
+> Leave this unset unless you know what you are doing. Setting it too low cripples connectivity: the daemon keeps running and looks online, but the resource manager refuses new connections ("Protected from exceeding resource limits" in logs, inspect with `ipfs swarm resources`). See [libp2p resource management](libp2p-resource-management.md).
 
 Default: `[TOTAL_SYSTEM_MEMORY]/2`
 Type: [`optionalBytes`](#optionalbytes)
@@ -4561,6 +4565,7 @@ Reduces daemon overhead on the system by disabling optional swarm services.
 > [!NOTE]
 > This profile is provided for legacy reasons.
 > With modern Kubo setting the above should not be necessary.
+> For memory tuning on constrained hardware (systemd limits, `GOMEMLIMIT`), see [Kubo on low-memory devices](production/low-memory.md).
 
 ### `announce-off` profile
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -23,6 +23,7 @@
   - [`HTTPS_PROXY`](#https_proxy)
   - [`HTTP_PROXY`](#http_proxy)
   - [`NO_PROXY`](#no_proxy)
+  - [`GOMEMLIMIT`](#gomemlimit)
   - [`LIBP2P_TCP_REUSEPORT`](#libp2p_tcp_reuseport)
   - [`LIBP2P_TCP_MUX`](#libp2p_tcp_mux)
   - [`LIBP2P_MUX_PREFS`](#libp2p_mux_prefs)
@@ -276,6 +277,14 @@ Example:
 ```console
 NO_PROXY="localhost,127.0.0.1,.internal" HTTPS_PROXY=http://proxy.local:8080 ipfs daemon
 ```
+
+## `GOMEMLIMIT`
+
+Soft memory limit for the Go runtime, recognized by every Go program. As the Kubo daemon's memory use approaches this value, the garbage collector runs more often and returns free memory to the OS sooner. The limit is soft: memory that is still in use cannot be freed, so the process can exceed it under load.
+
+On devices with limited RAM, set it to about half of total memory and pair it with OS-level limits; see [Kubo on low-memory devices](production/low-memory.md) for a worked setup and the [Go garbage collector guide](https://go.dev/doc/gc-guide) for the mechanics.
+
+Default: not set (no limit)
 
 ## `LIBP2P_TCP_REUSEPORT`
 

--- a/docs/production/low-memory.md
+++ b/docs/production/low-memory.md
@@ -1,0 +1,97 @@
+# Kubo on low-memory devices
+
+This guide is for running the Kubo daemon on devices with limited RAM, such as a Raspberry Pi or Orange Pi with 8 GiB, managed by systemd. It covers three layers that work together: the Go runtime, the systemd unit, and Kubo configuration. Set all three. Each layer catches what the previous one cannot. The same principles apply to other orchestration: for example, in Docker set `GOMEMLIMIT` via `--env` and replace the systemd limits with `--memory` and `--memory-reservation`.
+
+## Quick start (8 GiB device)
+
+Add memory limits to the service:
+
+```console
+$ sudo systemctl edit ipfs
+```
+
+```ini
+[Service]
+Environment=GOMEMLIMIT=4GiB
+MemoryHigh=6G
+MemoryMax=7G
+Restart=on-failure
+```
+
+Cap concurrent DHT announcement work:
+
+```console
+$ ipfs config --json Provide.DHT.MaxWorkers 4
+```
+
+Then reload and restart:
+
+```console
+$ sudo systemctl daemon-reload
+$ sudo systemctl restart ipfs
+```
+
+If the node provides millions of CIDs, also read [Announcements on a large pinset](#announcements-on-a-large-pinset) below.
+
+## How the layers fit together
+
+Keep the values in this order, with room between each pair:
+
+```
+GOMEMLIMIT  <  MemoryHigh  <  MemoryMax  <  total RAM
+```
+
+### Go runtime: `GOMEMLIMIT`
+
+`GOMEMLIMIT` is a soft ceiling for the memory managed by the Go runtime. As usage approaches the limit, the garbage collector runs more often and returns free memory to the OS sooner. Set it to about half of total RAM.
+
+The limit is soft: memory that is still in use cannot be freed, so the process can exceed `GOMEMLIMIT` under load. That is why the systemd limits below are still needed. See the [Go garbage collector guide](https://go.dev/doc/gc-guide) for how the limit works.
+
+For a systemd service, set it with `Environment=GOMEMLIMIT=4GiB` in the unit (or a `systemctl edit` drop-in, as in the quick start). For manual runs, export it in the shell before starting the daemon.
+
+### systemd: `MemoryHigh`, `MemoryMax`, swap
+
+`MemoryHigh` is the throttling threshold: above it, the kernel slows the service down and reclaims memory from it. `MemoryMax` is the hard limit: above it, the kernel kills the service.
+
+Two rules for picking the values:
+
+- Leave a gap between `GOMEMLIMIT` and `MemoryHigh`. The service uses memory the Go runtime does not manage: thread stacks, and the OS page cache for repo files, which the kernel accounts to the service. If `MemoryHigh` sits at or below `GOMEMLIMIT`, the kernel throttles the daemon during normal operation.
+- On a device without swap, keep `MemoryMax` close above `MemoryHigh`. Without swap the kernel cannot reclaim the daemon's working memory, so a process stuck above `MemoryHigh` is throttled to a crawl and can stay there indefinitely: it drops peers and stops responding, but never recovers. Crossing `MemoryMax` instead gets a clean kill, and `Restart=on-failure` brings the daemon back within seconds. A fast restart beats a slow zombie.
+
+If the device has swap, add `MemorySwapMax=0` to keep the daemon from pushing the rest of the system into swap.
+
+### Kubo configuration
+
+On a node that announces a lot of content, the DHT announcement subsystem is the main memory consumer that Kubo configuration controls. [`Provide.DHT.MaxWorkers`](../config.md#providedhtmaxworkers) caps its concurrency; the next section explains why this matters on low-memory devices.
+
+Leave [`Swarm.ResourceMgr.MaxMemory`](../config.md#swarmresourcemgrmaxmemory) unset unless you know what you are doing. It does not limit the Kubo process; it scales the [libp2p resource manager](../libp2p-resource-management.md) limits, including how many inbound connections the node accepts. Setting it too low cripples connectivity: the daemon keeps running and looks online, but the resource manager refuses new connections with `cannot reserve inbound connection: resource limit exceeded` errors, logged as "Protected from exceeding resource limits". Inspect current usage against the limits with `ipfs swarm resources`.
+
+## Announcements on a large pinset
+
+Keep [`Provide.DHT.SweepEnabled`](../config.md#providedhtsweepenabled) at its default `true` on low-power devices. Sweep mode spreads announcement work smoothly across the reprovide cycle instead of completing it in bursts, which avoids the resource spikes of the legacy provider.
+
+With sweep mode, the daemon announces content region by region across the DHT keyspace, and each active worker holds one region's keys in memory while it works. After downtime, many regions are due at once and the daemon puts every worker to work, so peak memory scales with [`Provide.DHT.MaxWorkers`](../config.md#providedhtmaxworkers) times the region size. On a node providing millions of CIDs, a high worker count can consume several GiB during this catch-up phase. `4` workers keep the peak small and still reprovide millions of CIDs within the daily cycle.
+
+The number of announced CIDs itself is the biggest lever. [`Provide.Strategy`](../config.md#providestrategy) selects what gets announced: `pinned+mfs+entities` announces file and directory roots instead of every block, which typically shrinks the workload by orders of magnitude. Read the trade-offs in the strategy documentation before changing it.
+
+## Verify
+
+Check where the service sits relative to its limits:
+
+```console
+$ systemctl status ipfs | grep Memory
+```
+
+Check memory pressure. The `avg10` values show the percentage of time the service was stalled waiting for memory over the last 10 seconds. Near-zero is healthy; sustained values above a few percent mean the limits are too tight or the workload is too big:
+
+```console
+$ cat /sys/fs/cgroup/system.slice/ipfs.service/memory.pressure
+```
+
+Check that announcements keep up with the reprovide cycle:
+
+```console
+$ ipfs stats provide
+```
+
+See [provide-stats.md](../provide-stats.md) for reading this output, and [libp2p resource management](../libp2p-resource-management.md) for the resource manager's own limits.

--- a/docs/production/low-memory.md
+++ b/docs/production/low-memory.md
@@ -18,10 +18,13 @@ MemoryMax=7G
 Restart=on-failure
 ```
 
-Cap concurrent DHT announcement work:
+Cap concurrent DHT announcement work, and turn off the services that spend resources on other peers:
 
 ```console
 $ ipfs config --json Provide.DHT.MaxWorkers 4
+$ ipfs config Routing.Type autoclient
+$ ipfs config AutoNAT.ServiceMode disabled
+$ ipfs config --json Swarm.RelayService.Enabled false
 ```
 
 Then reload and restart:
@@ -62,6 +65,10 @@ If the device has swap, add `MemorySwapMax=0` to keep the daemon from pushing th
 
 ### Kubo configuration
 
+Run the node as a DHT client. With the default [`Routing.Type`](../config.md#routingtype) of `auto`, a publicly reachable node becomes a DHT server: it stores other peers' provider records in its datastore and answers their lookups, which adds network, CPU, and storage load unrelated to your own content. Setting `Routing.Type` to `autoclient` (or `dhtclient`) removes that duty; the node still announces its own content and retrieves normally.
+
+Two more services exist to help other peers and can go on constrained hardware: [`AutoNAT.ServiceMode`](../config.md#autonatservicemode) set to `disabled` stops answering other peers' reachability dial-back requests, and [`Swarm.RelayService.Enabled`](../config.md#swarmrelayserviceenabled) set to `false` stops relaying traffic between third parties. Neither affects this node's own connectivity: it still uses AutoNAT as a client and public relays when it needs them.
+
 On a node that announces a lot of content, the DHT announcement subsystem is the main memory consumer that Kubo configuration controls. [`Provide.DHT.MaxWorkers`](../config.md#providedhtmaxworkers) caps its concurrency; the next section explains why this matters on low-memory devices.
 
 Leave [`Swarm.ResourceMgr.MaxMemory`](../config.md#swarmresourcemgrmaxmemory) unset unless you know what you are doing. It does not limit the Kubo process; it scales the [libp2p resource manager](../libp2p-resource-management.md) limits, including how many inbound connections the node accepts. Setting it too low cripples connectivity: the daemon keeps running and looks online, but the resource manager refuses new connections with `cannot reserve inbound connection: resource limit exceeded` errors, logged as "Protected from exceeding resource limits". Inspect current usage against the limits with `ipfs swarm resources`.
@@ -70,7 +77,13 @@ Leave [`Swarm.ResourceMgr.MaxMemory`](../config.md#swarmresourcemgrmaxmemory) un
 
 Keep [`Provide.DHT.SweepEnabled`](../config.md#providedhtsweepenabled) at its default `true` on low-power devices. Sweep mode spreads announcement work smoothly across the reprovide cycle instead of completing it in bursts, which avoids the resource spikes of the legacy provider.
 
-With sweep mode, the daemon announces content region by region across the DHT keyspace, and each active worker holds one region's keys in memory while it works. After downtime, many regions are due at once and the daemon puts every worker to work, so peak memory scales with [`Provide.DHT.MaxWorkers`](../config.md#providedhtmaxworkers) times the region size. On a node providing millions of CIDs, a high worker count can consume several GiB during this catch-up phase. `4` workers keep the peak small and still reprovide millions of CIDs within the daily cycle.
+With sweep mode, the daemon announces content region by region across the DHT keyspace, and each active worker holds one region's keys in memory while it works. After downtime, many regions are due at once and the daemon puts every worker to work, so peak memory scales with [`Provide.DHT.MaxWorkers`](../config.md#providedhtmaxworkers) times the region size. On a node providing millions of CIDs, a high worker count can consume several GiB during this catch-up phase; `4` workers keep the peak small on an 8 GiB device.
+
+Size the workload with two rates. The sustained rate is what your node actually announces: read `Total CIDs provided` from `ipfs stats provide` twice, 24 hours apart. As a reference, an 8 GiB board with NVMe storage and 4 workers sustains roughly 300k records per hour. The required rate is your CID count divided by [`Provide.DHT.Interval`](../config.md#providedhtinterval) (default 22h). Keep the required rate below the sustained rate, with margin. The hard floor is record expiry: provider records on the Amino DHT expire after 48 hours ([`amino.DefaultProvideValidity`](https://github.com/libp2p/go-libp2p-kad-dht/blob/v0.34.0/amino/defaults.go#L40-L43)), so a full pass over the pinset must always complete faster than that, or some content periodically becomes undiscoverable.
+
+Worked example, 10 million CIDs on an 8 GiB device: the default 22h interval requires ~455k records per hour, above the reference rate, so the cycle slips. Raising `Provide.DHT.MaxWorkers` to `6` and `Provide.DHT.Interval` to `32h` lowers the requirement to ~313k per hour, within reach of the sustained rate, and a full pass stays well inside the 48h expiry (the floor for 10M CIDs is ~208k per hour). After a change, let a full cycle finish and use the [Verify](#verify) checks to confirm the reprovide queue is not growing.
+
+Do not enable [`Routing.AcceleratedDHTClient`](../config.md#routingaccelerateddhtclient) to speed announcements up on a low-memory device. It crawls the entire DHT on an hourly schedule, and those crawls cause the memory and traffic spikes this guide exists to prevent. Adjust workers and interval as above instead.
 
 The number of announced CIDs itself is the biggest lever. [`Provide.Strategy`](../config.md#providestrategy) selects what gets announced: `pinned+mfs+entities` announces file and directory roots instead of every block, which typically shrinks the workload by orders of magnitude. Read the trade-offs in the strategy documentation before changing it.
 

--- a/misc/systemd/ipfs-hardened.service
+++ b/misc/systemd/ipfs-hardened.service
@@ -55,6 +55,12 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 # enable to specify a higher limit for open files/connections
 #LimitNOFILE=1000000
 
+# enable memory limits on low-memory devices (example values for 8 GiB of RAM)
+# see https://github.com/ipfs/kubo/blob/master/docs/production/low-memory.md
+#Environment=GOMEMLIMIT=4GiB
+#MemoryHigh=6G
+#MemoryMax=7G
+
 #don't use swap
 MemorySwapMax=0
 

--- a/misc/systemd/ipfs.service
+++ b/misc/systemd/ipfs.service
@@ -26,6 +26,12 @@ After=network.target
 # enable to specify a higher limit for open files/connections
 #LimitNOFILE=1000000
 
+# enable memory limits on low-memory devices (example values for 8 GiB of RAM)
+# see https://github.com/ipfs/kubo/blob/master/docs/production/low-memory.md
+#Environment=GOMEMLIMIT=4GiB
+#MemoryHigh=6G
+#MemoryMax=7G
+
 #don't use swap
 MemorySwapMax=0
 


### PR DESCRIPTION
## Problem

Kubo on an 8 GiB single-board computer can livelock instead of failing cleanly: memory grows past the cgroup throttle threshold, the kernel stalls the daemon, and it drops all peers while still looking online. The docs had no place explaining how `GOMEMLIMIT`, systemd memory limits, and Kubo config fit together on constrained hardware, or how to tell whether a pinset fits the reprovide cycle.

## Fix

- add `docs/production/low-memory.md`: worked 8 GiB setup (`GOMEMLIMIT`, `MemoryHigh`/`MemoryMax`, `Provide.DHT.MaxWorkers`, client-only routing, AutoNAT and relay services off), plus announcement sizing against the 48h record expiry with a worked 10M-CID example, and a warning against `Routing.AcceleratedDHTClient`
- document `GOMEMLIMIT` in `docs/environment-variables.md`
- link the guide from README system requirements, the docs index, `config.md`, and commented examples in `misc/systemd/*.service`

These are my notes from running Kubo 0.43 on an Orange Pi RV2 (RISC-V, 8 GiB RAM) providing 16.2M CIDs: stable at ~6.6 GiB with no OOM kills, sustaining ~7M provider records per day (~300k/hour), which is the reference rate behind the guide's estimates.