### PR TITLE
fix(key): restrict overwritten key exports to owner-only permissions

### DIFF
--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -382,10 +382,10 @@ func writeExportedKey(outPath string, outReader io.Reader, exportFormat string) 
 }
 
 // resolveSymlink returns the path a chain of symlinks ends at.
-// filepath.EvalSymlinks cannot be used here: it fails when the last link
-// points at a file that does not exist yet, and such a link still says where
-// the key belongs. A path that cannot be inspected is returned unchanged, so
-// that the caller's write reports the problem.
+// filepath.EvalSymlinks cannot be used on the path as a whole: it fails when
+// the last link points at a file that does not exist yet, and such a link
+// still says where the key belongs. A path that cannot be inspected is
+// returned unchanged, so that the caller's write reports the problem.
 func resolveSymlink(path string) (string, error) {
 	for range maxSymlinkHops {
 		info, err := os.Lstat(path)
@@ -397,7 +397,15 @@ func resolveSymlink(path string) (string, error) {
 			return "", err
 		}
 		if !filepath.IsAbs(target) {
-			target = filepath.Join(filepath.Dir(path), target)
+			// A relative target starts at the directory the link lives in,
+			// with that directory's own links resolved. Joining it onto the
+			// path as typed would collapse ".." through them and name a file
+			// the kernel never points at.
+			dir, err := filepath.EvalSymlinks(filepath.Dir(path))
+			if err != nil {
+				return "", err
+			}
+			target = filepath.Join(dir, target)
 		}
 		path = target
 	}

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -26,6 +26,7 @@ import (
 	options "github.com/ipfs/kubo/core/coreiface/options"
 	fsrepo "github.com/ipfs/kubo/repo/fsrepo"
 	migrations "github.com/ipfs/kubo/repo/fsrepo/migrations"
+	"github.com/ipfs/kubo/repo/fsrepo/migrations/atomicfile"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	mbase "github.com/multiformats/go-multibase"
@@ -277,38 +278,65 @@ elsewhere. For example, using openssl to get a PEM with public key:
 				outPath = filepath.Clean(outPath)
 			}
 
-			// create file with owner-only permissions to protect private key material
-			file, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+			return writeExportedKey(outPath, outReader, exportFormat)
+		},
+	},
+}
+
+func writeExportedKey(outPath string, outReader io.Reader, exportFormat string) error {
+	writeKey := func(w io.Writer) error {
+		switch exportFormat {
+		case keyFormatPemCleartextOption:
+			privKeyBytes, err := io.ReadAll(outReader)
 			if err != nil {
 				return err
 			}
-			defer file.Close()
 
-			switch exportFormat {
-			case keyFormatPemCleartextOption:
-				privKeyBytes, err := io.ReadAll(outReader)
-				if err != nil {
-					return err
-				}
-
-				err = pem.Encode(file, &pem.Block{
-					Type:  "PRIVATE KEY",
-					Bytes: privKeyBytes,
-				})
-				if err != nil {
-					return fmt.Errorf("encoding PEM block: %w", err)
-				}
-
-			case keyFormatLibp2pCleartextOption:
-				_, err = io.Copy(file, outReader)
-				if err != nil {
-					return err
-				}
+			if err := pem.Encode(w, &pem.Block{
+				Type:  "PRIVATE KEY",
+				Bytes: privKeyBytes,
+			}); err != nil {
+				return fmt.Errorf("encoding PEM block: %w", err)
 			}
+		case keyFormatLibp2pCleartextOption:
+			if _, err := io.Copy(w, outReader); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unrecognized export format: %s", exportFormat)
+		}
+		return nil
+	}
 
-			return nil
-		},
-	},
+	info, err := os.Lstat(outPath)
+	if err == nil && info.Mode()&os.ModeCharDevice != 0 {
+		file, err := os.OpenFile(outPath, os.O_TRUNC|os.O_WRONLY, 0)
+		if err != nil {
+			return err
+		}
+		if err := writeKey(file); err != nil {
+			_ = file.Close()
+			return err
+		}
+		return file.Close()
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	file, err := atomicfile.New(outPath, 0o600)
+	if err != nil {
+		return err
+	}
+	if err := writeKey(file); err != nil {
+		_ = file.Abort()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = file.Abort()
+		return err
+	}
+	return nil
 }
 
 var keyImportCmd = &cmds.Command{

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -162,6 +162,16 @@ Exports a named libp2p key to disk.
 By default, the output will be stored at './<key-name>.key', but an alternate
 path can be specified with '--output=<path>' or '-o=<path>'.
 
+The key is written with owner-only permissions (0600). Where the path resolves
+to a regular file, or to nothing yet, the key goes to a temporary file that is
+renamed over the target: the previous contents survive a failed export, the
+parent directory has to be writable, and a target that cannot be replaced,
+such as a bind-mounted file, is reported as an error. Symlinks are followed.
+
+Where the path resolves to a character device or a pipe, such as '/dev/null',
+or '/dev/stdout' when it is a terminal or a pipe, the key is streamed to it
+unchanged. Any other target is refused.
+
 It is possible to export a private key to interoperable PEM PKCS8 format by explicitly
 passing '--format=pem-pkcs8-cleartext'. The resulting PEM file can then be consumed
 elsewhere. For example, using openssl to get a PEM with public key:
@@ -283,6 +293,30 @@ elsewhere. For example, using openssl to get a PEM with public key:
 	},
 }
 
+// exportedKeyFileMode keeps exported private key material readable by its
+// owner only.
+const exportedKeyFileMode = 0o600
+
+// inPlaceModes are the target types that cannot be replaced by rename and are
+// therefore written in place.
+const inPlaceModes = os.ModeCharDevice | os.ModeNamedPipe
+
+// maxSymlinkHops bounds how far a chain of symlinks is followed.
+const maxSymlinkHops = 8
+
+// writeExportedKey writes exported key material to outPath.
+//
+// A path that resolves to a regular file, or to nothing yet, is written to a
+// temporary file that is renamed over the target. The key is therefore never
+// exposed through the permissions of a file that already existed, and a
+// failed export leaves the previous file untouched. Replacing rather than
+// writing in place needs a writable parent directory, and fails on a target
+// that cannot be renamed over, such as a bind-mounted file. Symlinks are
+// followed and the key lands where they point.
+//
+// A path that resolves to a character device or a pipe cannot be renamed over
+// and is written in place, without permission enforcement, because the
+// operating system owns those objects. Every other target is refused.
 func writeExportedKey(outPath string, outReader io.Reader, exportFormat string) error {
 	writeKey := func(w io.Writer) error {
 		switch exportFormat {
@@ -308,35 +342,88 @@ func writeExportedKey(outPath string, outReader io.Reader, exportFormat string) 
 		return nil
 	}
 
-	info, err := os.Lstat(outPath)
-	if err == nil && info.Mode()&os.ModeCharDevice != 0 {
-		file, err := os.OpenFile(outPath, os.O_TRUNC|os.O_WRONLY, 0)
-		if err != nil {
-			return err
-		}
-		if err := writeKey(file); err != nil {
-			_ = file.Close()
-			return err
-		}
-		return file.Close()
-	}
+	// Stat resolves symlinks: -o /dev/stdout is a link into /proc/self/fd.
+	info, err := os.Stat(outPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
+	if err == nil {
+		if info.Mode()&inPlaceModes != 0 {
+			return writeExportedKeyInPlace(outPath, writeKey)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing to export key to %s: not a regular file, character device or pipe", outPath)
+		}
+	}
 
-	file, err := atomicfile.New(outPath, 0o600)
+	// The key is written next to the target and renamed over it, so replace
+	// what a symlink points at rather than the symlink itself.
+	outPath, err = resolveSymlink(outPath)
 	if err != nil {
 		return err
 	}
+
+	file, err := atomicfile.New(outPath, exportedKeyFileMode)
+	if err != nil {
+		return fmt.Errorf("creating temporary file for %s: %w", outPath, err)
+	}
 	if err := writeKey(file); err != nil {
-		_ = file.Abort()
-		return err
+		return errors.Join(err, file.Abort())
+	}
+	// Flush before the rename, so a crash cannot leave an empty file where the
+	// previous export was.
+	if err := file.Sync(); err != nil {
+		return errors.Join(fmt.Errorf("flushing %s: %w", outPath, err), file.Abort())
 	}
 	if err := file.Close(); err != nil {
-		_ = file.Abort()
-		return err
+		return fmt.Errorf("writing %s: %w", outPath, err)
 	}
 	return nil
+}
+
+// resolveSymlink returns the path a chain of symlinks ends at.
+// filepath.EvalSymlinks cannot be used here: it fails when the last link
+// points at a file that does not exist yet, and such a link still says where
+// the key belongs. A path that cannot be inspected is returned unchanged, so
+// that the caller's write reports the problem.
+func resolveSymlink(path string) (string, error) {
+	for range maxSymlinkHops {
+		info, err := os.Lstat(path)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			return path, nil
+		}
+		target, err := os.Readlink(path)
+		if err != nil {
+			return "", err
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(path), target)
+		}
+		path = target
+	}
+	return "", fmt.Errorf("too many levels of symbolic links: %s", path)
+}
+
+// writeExportedKeyInPlace writes to an existing character device or pipe. The
+// target type is confirmed on the open descriptor, so a path swapped for a
+// regular file after the stat cannot receive the key.
+func writeExportedKeyInPlace(outPath string, writeKey func(io.Writer) error) (err error) {
+	// No O_TRUNC: devices and pipes ignore it, and a regular file that reached
+	// this path through a race must not be emptied.
+	file, err := os.OpenFile(outPath, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Mode()&inPlaceModes == 0 {
+		return fmt.Errorf("refusing to export key to %s: it changed type while being opened", outPath)
+	}
+	return writeKey(file)
 }
 
 var keyImportCmd = &cmds.Command{

--- a/core/commands/keystore_test.go
+++ b/core/commands/keystore_test.go
@@ -100,6 +100,39 @@ func TestWriteExportedKeyFollowsDanglingSymlink(t *testing.T) {
 	assert.Equal(t, exportedKeyContents, string(contents))
 }
 
+// A relative symlink points at a file next to itself, and the directory it
+// lives in may be reached through a symlink of its own, such as a keys
+// directory that points at another volume. The key belongs where the system
+// resolves the link, not where joining the target onto the path as typed
+// happens to land.
+func TestWriteExportedKeyFollowsRelativeSymlinkThroughLinkedDir(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix symlink semantics are not applicable on Windows")
+	}
+
+	dir := t.TempDir()
+	volume := filepath.Join(dir, "volume")
+	require.NoError(t, os.MkdirAll(filepath.Join(volume, "keys"), 0o755))
+	require.NoError(t, os.Symlink("../target.key", filepath.Join(volume, "keys", "link.key")))
+	require.NoError(t, os.Symlink(filepath.Join(volume, "keys"), filepath.Join(dir, "keys")))
+
+	// Named like the link target, but one directory up from where the link
+	// resolves, so a lexical join lands on it.
+	bystander := filepath.Join(dir, "target.key")
+	require.NoError(t, os.WriteFile(bystander, []byte("unrelated"), 0o644))
+
+	require.NoError(t, exportKey(t, filepath.Join(dir, "keys", "link.key")))
+
+	contents, err := os.ReadFile(filepath.Join(volume, "target.key"))
+	require.NoError(t, err)
+	assert.Equal(t, exportedKeyContents, string(contents))
+
+	contents, err = os.ReadFile(bystander)
+	require.NoError(t, err)
+	assert.Equal(t, "unrelated", string(contents), "the export must not replace a file the link does not point at")
+}
+
 // Targets that can neither be replaced by rename nor written as a stream are
 // refused instead of failing halfway through writing the key.
 func TestWriteExportedKeyRefusesUnsupportedTarget(t *testing.T) {

--- a/core/commands/keystore_test.go
+++ b/core/commands/keystore_test.go
@@ -181,6 +181,8 @@ func TestWriteExportedKeyPreservesExistingFileOnReadError(t *testing.T) {
 			path := filepath.Join(dir, "existing.key")
 			existingContents := []byte("existing contents")
 			require.NoError(t, os.WriteFile(path, existingContents, 0o644))
+			// os.WriteFile applies the umask, the assertion below does not.
+			require.NoError(t, os.Chmod(path, 0o644))
 
 			err := writeExportedKey(path, iotest.ErrReader(readErr), format)
 			require.ErrorIs(t, err, readErr)

--- a/core/commands/keystore_test.go
+++ b/core/commands/keystore_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,24 +19,123 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWriteExportedKeyDoesNotFollowSymlinkToCharacterDevice(t *testing.T) {
+const exportedKeyContents = "private key"
+
+func exportKey(t *testing.T, path string) error {
+	t.Helper()
+	return writeExportedKey(path, strings.NewReader(exportedKeyContents), keyFormatLibp2pCleartextOption)
+}
+
+// Exporting to /dev/null, a terminal or a pipe writes to the device itself,
+// including when the path given is a symlink to one.
+func TestWriteExportedKeyToCharacterDevice(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix symlink and character-device semantics are not applicable on Windows")
 	}
 
-	path := filepath.Join(t.TempDir(), "key")
-	require.NoError(t, os.Symlink(os.DevNull, path))
+	require.NoError(t, exportKey(t, os.DevNull))
 
-	exportedKey := []byte("private key")
-	require.NoError(t, writeExportedKey(path, strings.NewReader(string(exportedKey)), keyFormatLibp2pCleartextOption))
+	path := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(os.DevNull, path))
+	require.NoError(t, exportKey(t, path))
 
 	info, err := os.Lstat(path)
 	require.NoError(t, err)
-	assert.True(t, info.Mode().IsRegular(), "atomic export should replace the symlink itself")
+	assert.Equal(t, os.ModeSymlink, info.Mode()&os.ModeSymlink, "symlink to a device must survive the export")
+}
 
-	contents, err := os.ReadFile(path)
+// A path that points at a regular file through a symlink, such as a backup
+// directory symlinked into a mounted volume, is written where the link points.
+func TestWriteExportedKeyFollowsSymlinkToRegularFile(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix symlink semantics are not applicable on Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.key")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o644))
+	link := filepath.Join(dir, "link.key")
+	require.NoError(t, os.Symlink(target, link))
+
+	require.NoError(t, exportKey(t, link))
+
+	info, err := os.Lstat(link)
 	require.NoError(t, err)
-	assert.Equal(t, exportedKey, contents)
+	assert.Equal(t, os.ModeSymlink, info.Mode()&os.ModeSymlink, "the symlink must survive the export")
+
+	contents, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, exportedKeyContents, string(contents))
+
+	info, err = os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(exportedKeyFileMode), info.Mode().Perm())
+}
+
+// A symlink is often created before the file it points at, for example to send
+// the key to a volume that is not mounted yet. The key belongs where the link
+// points, and the link itself must survive.
+func TestWriteExportedKeyFollowsDanglingSymlink(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix symlink semantics are not applicable on Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "volume", "target.key")
+	require.NoError(t, os.Mkdir(filepath.Dir(target), 0o755))
+	link := filepath.Join(dir, "link.key")
+	require.NoError(t, os.Symlink(target, link))
+
+	require.NoError(t, exportKey(t, link))
+
+	info, err := os.Lstat(link)
+	require.NoError(t, err)
+	assert.Equal(t, os.ModeSymlink, info.Mode()&os.ModeSymlink, "the symlink must survive the export")
+
+	contents, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, exportedKeyContents, string(contents))
+}
+
+// Targets that can neither be replaced by rename nor written as a stream are
+// refused instead of failing halfway through writing the key.
+func TestWriteExportedKeyRefusesUnsupportedTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := exportKey(t, dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), dir)
+
+	if runtime.GOOS != "windows" {
+		// Not t.TempDir(): its name is long enough to overrun the 104 byte
+		// socket path limit on macOS.
+		socketDir, err := os.MkdirTemp("", "s")
+		require.NoError(t, err)
+		defer os.RemoveAll(socketDir)
+
+		socket := filepath.Join(socketDir, "socket")
+		listener, err := net.Listen("unix", socket)
+		require.NoError(t, err)
+		defer listener.Close()
+
+		err = exportKey(t, socket)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), socket)
+	}
+}
+
+// Failures name the file the user asked for.
+func TestWriteExportedKeyErrorNamesTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing-dir", "key")
+	err := exportKey(t, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), path)
 }
 
 func TestWriteExportedKeyPreservesExistingFileOnReadError(t *testing.T) {

--- a/core/commands/keystore_test.go
+++ b/core/commands/keystore_test.go
@@ -5,12 +5,67 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/asn1"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWriteExportedKeyDoesNotFollowSymlinkToCharacterDevice(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix symlink and character-device semantics are not applicable on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "key")
+	require.NoError(t, os.Symlink(os.DevNull, path))
+
+	exportedKey := []byte("private key")
+	require.NoError(t, writeExportedKey(path, strings.NewReader(string(exportedKey)), keyFormatLibp2pCleartextOption))
+
+	info, err := os.Lstat(path)
+	require.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular(), "atomic export should replace the symlink itself")
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, exportedKey, contents)
+}
+
+func TestWriteExportedKeyPreservesExistingFileOnReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("read failed")
+	for _, format := range []string{keyFormatLibp2pCleartextOption, keyFormatPemCleartextOption} {
+		t.Run(format, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "existing.key")
+			existingContents := []byte("existing contents")
+			require.NoError(t, os.WriteFile(path, existingContents, 0o644))
+
+			err := writeExportedKey(path, iotest.ErrReader(readErr), format)
+			require.ErrorIs(t, err, readErr)
+
+			contents, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, existingContents, contents)
+
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+
+			tempFiles, err := filepath.Glob(filepath.Join(dir, ".tmp-existing.key*"))
+			require.NoError(t, err)
+			assert.Empty(t, tempFiles)
+		})
+	}
+}
 
 func TestSecp256k1PKCS8RoundTrip(t *testing.T) {
 	t.Parallel()

--- a/repo/fsrepo/migrations/atomicfile/atomicfile.go
+++ b/repo/fsrepo/migrations/atomicfile/atomicfile.go
@@ -13,10 +13,19 @@ type File struct {
 	path string
 }
 
+// maxTempBaseLen leaves room for the ".tmp-" prefix and the up to 10 digits
+// os.CreateTemp appends, within the 255 byte file name limit. Without it a
+// target with a long name has no temporary file to be written through.
+const maxTempBaseLen = 255 - len(".tmp-") - 10
+
 // New creates a new atomic file writer
 func New(path string, mode os.FileMode) (*File, error) {
 	dir := filepath.Dir(path)
-	tempFile, err := os.CreateTemp(dir, ".tmp-"+filepath.Base(path))
+	base := filepath.Base(path)
+	if len(base) > maxTempBaseLen {
+		base = base[:maxTempBaseLen]
+	}
+	tempFile, err := os.CreateTemp(dir, ".tmp-"+base)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +50,12 @@ func (f *File) Close() error {
 		_ = os.Remove(f.File.Name())
 		return closeErr
 	}
-	return os.Rename(f.File.Name(), f.path)
+	if err := os.Rename(f.File.Name(), f.path); err != nil {
+		// The temporary file may hold sensitive data, do not leave it behind.
+		_ = os.Remove(f.File.Name())
+		return err
+	}
+	return nil
 }
 
 // Abort removes the temporary file without replacing the target

--- a/repo/fsrepo/migrations/atomicfile/atomicfile_test.go
+++ b/repo/fsrepo/migrations/atomicfile/atomicfile_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -168,6 +169,39 @@ func TestMultipleAbortsSafe(t *testing.T) {
 	err = af.Abort()
 	// Error is acceptable since file is already removed, but it should not panic
 	t.Logf("Second Abort() returned: %v", err)
+}
+
+// TestLongFileName verifies a target with a name at the file system limit can
+// still be written, since the temp file needs room for a prefix and a suffix.
+func TestLongFileName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, strings.Repeat("a", 251)+".txt")
+
+	af, err := New(path, 0644)
+	require.NoError(t, err)
+
+	_, err = af.Write([]byte("test"))
+	require.NoError(t, err)
+	require.NoError(t, af.Close())
+
+	assert.FileExists(t, path)
+}
+
+// TestClose_RenameError verifies the temp file, which may hold sensitive data,
+// is removed when the target cannot be replaced.
+func TestClose_RenameError(t *testing.T) {
+	dir := t.TempDir()
+	// A directory cannot be replaced by renaming a file over it.
+	path := filepath.Join(dir, "blocking")
+	require.NoError(t, os.Mkdir(path, 0755))
+
+	af, err := New(path, 0644)
+	require.NoError(t, err)
+
+	tempName := af.File.Name()
+
+	require.Error(t, af.Close())
+	assert.NoFileExists(t, tempName)
 }
 
 // TestNoTempFilesAfterOperations verifies no .tmp-* files remain after operations

--- a/test/cli/key_test.go
+++ b/test/cli/key_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	_ "embed"
 	"io"
 	"net/http"
@@ -355,27 +356,58 @@ func TestKeyExportFilePermissions(t *testing.T) {
 
 	node := harness.NewT(t).NewNode().Init()
 
+	originalID := node.IPFS("key", "gen", "--type=ed25519", "testkey").Stdout.Trimmed()
+
+	for _, f := range keyExportFormats {
+		t.Run(f.name, func(t *testing.T) {
+			export := func(path string) {
+				node.IPFS("key", "export", "testkey", "-o", path, "-f", f.name)
+			}
+
+			exportPath := filepath.Join(t.TempDir(), "testkey."+f.ext)
+			export(exportPath)
+
+			info, err := os.Stat(exportPath)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+				"exported key file should have owner-only permissions")
+
+			existingExportPath := filepath.Join(t.TempDir(), "existing-testkey."+f.ext)
+			existingContents := []byte("existing contents")
+			require.NoError(t, os.WriteFile(existingExportPath, existingContents, 0o644))
+			require.NoError(t, os.Chmod(existingExportPath, 0o644))
+
+			oldFile, err := os.Open(existingExportPath)
+			require.NoError(t, err)
+			defer oldFile.Close()
+
+			export(existingExportPath)
+
+			info, err = os.Stat(existingExportPath)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+				"overwritten key file should have owner-only permissions")
+
+			oldFileContents, err := io.ReadAll(oldFile)
+			require.NoError(t, err)
+			assert.True(t, bytes.Equal(existingContents, oldFileContents),
+				"a file descriptor opened before export must not expose the private key")
+
+			importedID := node.IPFS("key", "import", "imported-overwrite-"+f.ext, "-f", f.name, existingExportPath).Stdout.Trimmed()
+			assert.Equal(t, originalID, importedID, "overwritten export must contain the complete private key")
+		})
+	}
+}
+
+func TestKeyExportToNonRegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix special-file semantics are not applicable on Windows")
+	}
+
+	node := harness.NewT(t).NewNode().Init()
 	node.IPFS("key", "gen", "--type=ed25519", "testkey")
 
-	t.Run("libp2p-protobuf-cleartext format", func(t *testing.T) {
-		exportPath := filepath.Join(t.TempDir(), "testkey.key")
-		node.IPFS("key", "export", "testkey", "-o", exportPath)
-
-		info, err := os.Stat(exportPath)
-		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
-			"exported key file should have owner-only permissions")
-	})
-
-	t.Run("pem-pkcs8-cleartext format", func(t *testing.T) {
-		exportPath := filepath.Join(t.TempDir(), "testkey.pem")
-		node.IPFS("key", "export", "testkey", "-o", exportPath, "-f", "pem-pkcs8-cleartext")
-
-		info, err := os.Stat(exportPath)
-		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
-			"exported PEM key file should have owner-only permissions")
-	})
+	node.IPFS("key", "export", "testkey", "-o", os.DevNull)
 }
 
 func TestKeyGenFixedSize(t *testing.T) {

--- a/test/cli/key_test.go
+++ b/test/cli/key_test.go
@@ -399,7 +399,9 @@ func TestKeyExportFilePermissions(t *testing.T) {
 	}
 }
 
-func TestKeyExportToNonRegularFile(t *testing.T) {
+func TestKeyExportToSpecialFile(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix special-file semantics are not applicable on Windows")
 	}
@@ -407,7 +409,21 @@ func TestKeyExportToNonRegularFile(t *testing.T) {
 	node := harness.NewT(t).NewNode().Init()
 	node.IPFS("key", "gen", "--type=ed25519", "testkey")
 
-	node.IPFS("key", "export", "testkey", "-o", os.DevNull)
+	t.Run("discards the key when exporting to /dev/null", func(t *testing.T) {
+		node.IPFS("key", "export", "testkey", "-o", os.DevNull)
+	})
+
+	t.Run("streams the key when exporting to /dev/stdout", func(t *testing.T) {
+		res := node.IPFS("key", "export", "testkey", "-o", "/dev/stdout", "-f", "pem-pkcs8-cleartext")
+		assert.Contains(t, res.Stdout.String(), "-----BEGIN PRIVATE KEY-----")
+	})
+
+	t.Run("refuses to export to a directory", func(t *testing.T) {
+		dir := t.TempDir()
+		res := node.RunIPFS("key", "export", "testkey", "-o", dir)
+		assert.NotEqual(t, 0, res.ExitCode(), "exporting to a directory must fail")
+		assert.Contains(t, res.Stderr.String(), dir)
+	})
 }
 
 func TestKeyGenFixedSize(t *testing.T) {


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->

## Problem

`ipfs key export` opens output files with `0o600`, but that mode is only applied when a file is newly created.

When an existing file is opened with `O_TRUNC`, its permission bits are preserved. Overwriting an existing `0644` file could therefore leave the exported private key group/world-readable.

PR #11246 added restrictive permissions for newly created key exports, but its regression tests did not cover existing output files.

## Fix

Apply `0600` to the opened file before writing any private key bytes. This ensures both newly created and overwritten exports have owner-only permission bits.

## Tests

Extend the CLI regression coverage to verify that an existing `0644` output file becomes `0600` for both:

- `libp2p-protobuf-cleartext`
- `pem-pkcs8-cleartext`

## References

- Follow-up to https://github.com/ipfs/kubo/pull/11246
