### PR TITLE
fix(fuse): give mounts stable inode numbers

### DIFF
--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -7,6 +7,8 @@
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
   - [📁 `ipfs ls` can print readable sizes and sort by size](#-ipfs-ls-can-print-readable-sizes-and-sort-by-size)
+  - [📌 Files on FUSE mounts keep their inode number](#-files-on-fuse-mounts-keep-their-inode-number)
+  - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
@@ -17,6 +19,14 @@
 #### 📁 `ipfs ls` can print readable sizes and sort by size
 
 Two new flags on `ipfs ls`, both off by default. `--human` (`-H`) prints sizes in SI units such as `3.0 kB` and `2.0 MB`, matching `ipfs repo stat -H`. `--sort-size` (`-S`) lists the biggest entries first, so you can find what fills a directory without piping through `sort`. Run `ipfs ls --help` for how they combine with `--stream`, `--size`, and the JSON response.
+
+#### 📌 Files on FUSE mounts keep their inode number
+
+A file on a mount made by `ipfs mount` used to get a new inode number roughly every second, whenever the kernel dropped and re-read its directory entry. Programs that check whether a file is still the same file read that as the file being replaced under them. Saving a file on `/mfs` with vim could fail with `E949: File changed while writing`, and `pwd`, `find` and backup tools could misbehave for the same reason.
+
+All three mounts now hand out stable numbers. On `/ipfs` the number comes from the CID, so the same content is the same object whichever path reaches it. On `/ipns` and `/mfs` an entry keeps its number for as long as it exists, and a name that is deleted and created again is numbered afresh. Numbers are assigned per mount and are not preserved across a remount.
+
+Smaller fixes come with it: mount points report an inode number instead of `0`, `ls -i` agrees with `stat`, the link count is `1` rather than the `0` POSIX gives to a deleted file, and `/ipns/<key>` directories show their real permissions instead of `d---------`.
 
 #### 📦️ Dependency updates
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -24,7 +24,7 @@ Two new flags on `ipfs ls`, both off by default. `--human` (`-H`) prints sizes i
 
 A file on a mount made by `ipfs mount` used to get a new inode number roughly every second, whenever the kernel dropped and re-read its directory entry. Programs that check whether a file is still the same file read that as the file being replaced under them. Saving a file on `/mfs` with vim could fail with `E949: File changed while writing`, and `pwd`, `find` and backup tools could misbehave for the same reason.
 
-All three mounts now hand out stable numbers. On `/ipfs` the number comes from the CID, so the same content is the same object whichever path reaches it. On `/ipns` and `/mfs` an entry keeps its number for as long as it exists, and a name that is deleted and created again is numbered afresh. Numbers are assigned per mount and are not preserved across a remount.
+All three mounts now hand out stable numbers. On `/ipfs` the number comes from the CID, so the same content is the same object whichever path reaches it, and the same number comes back after a remount. On `/ipns` and `/mfs` an entry keeps its number for as long as it exists, including across a rename, while a name that is deleted and created again is numbered afresh; those numbers are assigned per mount and start over on the next one. Deleting through `ipfs files` rather than through the mount is the exception: the mount does not see it, so the name keeps its old number if it comes back.
 
 Smaller fixes come with it: mount points report an inode number instead of `0`, `ls -i` agrees with `stat`, the link count is `1` rather than the `0` POSIX gives to a deleted file, and `/ipns/<key>` directories show their real permissions instead of `d---------`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -2069,6 +2069,9 @@ Default: `"cache"`
 
 FUSE mount point configuration options.
 
+> [!WARNING]
+> While `/ipns` or `/mfs` is mounted, change what they hold through the mounted filesystem only. Writing to the same MFS tree with `ipfs files` commands at the same time is not supported: each side keeps its own view of the tree, so a write made on one side can be lost when the other writes back, and a file deleted and created again with `ipfs files` still looks like the same file to programs watching it on the mount. Unmount before using `ipfs files` on a mounted tree.
+
 All mounts expose the `ipfs.cid` extended attribute on files and directories, returning the CID of the underlying DAG node:
 
 ```console

--- a/fuse/fusetest/dirents_linux.go
+++ b/fuse/fusetest/dirents_linux.go
@@ -1,0 +1,51 @@
+//go:build !nofuse
+
+package fusetest
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// assertDirEntryInos checks that the inode number a directory listing reports
+// for each entry (d_ino from getdents) is the one stat reports for it. A mount
+// fills the two in from separate code paths, and tools take the listing's
+// number as authoritative because it costs them no extra syscall.
+func assertDirEntryInos(t *testing.T, dir string) {
+	t.Helper()
+
+	fd, err := unix.Open(dir, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	require.NoError(t, err)
+	defer unix.Close(fd)
+
+	buf := make([]byte, 8192)
+	seen := 0
+	for {
+		n, err := unix.Getdents(fd, buf)
+		require.NoError(t, err)
+		if n == 0 {
+			break
+		}
+		for b := buf[:n]; len(b) > 0; {
+			ent := (*unix.Dirent)(unsafe.Pointer(&b[0]))
+			b = b[ent.Reclen:]
+
+			name := string(bytes.SplitN(unsafe.Slice((*byte)(unsafe.Pointer(&ent.Name[0])), len(ent.Name)), []byte{0}, 2)[0])
+			if name == "." || name == ".." {
+				continue
+			}
+
+			var st unix.Stat_t
+			require.NoError(t, unix.Lstat(filepath.Join(dir, name), &st))
+			require.Equal(t, st.Ino, ent.Ino,
+				"inode number for %q differs between the directory listing and stat", name)
+			seen++
+		}
+	}
+	require.NotZero(t, seen, "expected the listing to report at least one entry")
+}

--- a/fuse/fusetest/dirents_other.go
+++ b/fuse/fusetest/dirents_other.go
@@ -1,0 +1,10 @@
+//go:build (darwin || freebsd) && !nofuse
+
+package fusetest
+
+import "testing"
+
+// assertDirEntryInos compares getdents inode numbers with stat, which the
+// linux build does. The syscall differs on every other platform and the FUSE
+// suite runs on Linux, so there is nothing to check here.
+func assertDirEntryInos(_ *testing.T, _ string) {}

--- a/fuse/fusetest/fusetest.go
+++ b/fuse/fusetest/fusetest.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/stretchr/testify/require"
+
+	fusemnt "github.com/ipfs/kubo/fuse/mount"
 )
 
 // SkipUnlessFUSE skips the test when FUSE is not available.
@@ -48,6 +50,11 @@ func TestMount(t *testing.T, root fs.InodeEmbedder, opts *fs.Options) string {
 	opts.GID = uint32(os.Getgid())
 	if opts.MountOptions.FsName == "" {
 		opts.MountOptions.FsName = "kubo-test"
+	}
+	// Match what mount.NewMount gives the real mounts, so tests see the
+	// inode numbers users see.
+	if opts.RootStableAttr == nil {
+		opts.RootStableAttr = &fs.StableAttr{Ino: fusemnt.RootIno}
 	}
 	server, err := fs.Mount(mntDir, root, opts)
 	MountError(t, err)

--- a/fuse/fusetest/fusetest.go
+++ b/fuse/fusetest/fusetest.go
@@ -56,6 +56,9 @@ func TestMount(t *testing.T, root fs.InodeEmbedder, opts *fs.Options) string {
 	if opts.RootStableAttr == nil {
 		opts.RootStableAttr = &fs.StableAttr{Ino: fusemnt.RootIno}
 	}
+	if opts.FirstAutomaticIno == 0 {
+		opts.FirstAutomaticIno = fusemnt.AutomaticIno
+	}
 	server, err := fs.Mount(mntDir, root, opts)
 	MountError(t, err)
 	t.Cleanup(func() { _ = server.Unmount() })

--- a/fuse/fusetest/writablesuite.go
+++ b/fuse/fusetest/writablesuite.go
@@ -484,6 +484,11 @@ func RunWritableSuite(t *testing.T, mount MountFunc) {
 		require.NotEqual(t, first.Ino, recreated.Ino,
 			"a name that was removed and created again should get a new inode number")
 		VerifyFile(t, path, []byte("second"))
+
+		// A directory listing reports an inode number per entry of its own,
+		// and tools that read it (ls -i, find) never learn of the one stat
+		// would give them. The two have to agree.
+		assertDirEntryInos(t, dir)
 	})
 
 	// Renaming moves a file, it does not replace it, so the inode number goes

--- a/fuse/fusetest/writablesuite.go
+++ b/fuse/fusetest/writablesuite.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	racedet "github.com/ipfs/go-detect-race"
+	fusemnt "github.com/ipfs/kubo/fuse/mount"
 	"github.com/ipfs/kubo/fuse/writable"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -456,10 +457,11 @@ func RunWritableSuite(t *testing.T, mount MountFunc) {
 		var first unix.Stat_t
 		require.NoError(t, unix.Stat(path, &first))
 		require.NotZero(t, first.Ino, "file should report an inode number")
-		// go-fuse numbers whatever the filesystem leaves to it from 1<<63 up,
-		// handing out a new number for every node it builds. A number in that
-		// range means the mount is not numbering its own entries.
-		require.Less(t, first.Ino, uint64(1<<63),
+		// go-fuse numbers whatever the filesystem leaves to it from
+		// AutomaticIno up, handing out a new number for every node it builds.
+		// A number in that range means the mount is not numbering its own
+		// entries.
+		require.Less(t, first.Ino, uint64(fusemnt.AutomaticIno),
 			"inode number should come from the mount, not go-fuse's automatic range")
 
 		// Outlast the entry timeout of the writable mounts (one second) so
@@ -482,6 +484,56 @@ func RunWritableSuite(t *testing.T, mount MountFunc) {
 		require.NotEqual(t, first.Ino, recreated.Ino,
 			"a name that was removed and created again should get a new inode number")
 		VerifyFile(t, path, []byte("second"))
+	})
+
+	// Renaming moves a file, it does not replace it, so the inode number goes
+	// with it. Backup tools that track files by identity (tar
+	// --listed-incremental, file watchers) re-copy a file whose number
+	// changed, and a directory rename must not renumber what is inside it.
+	t.Run("InodeNumbersAcrossRename", func(t *testing.T) {
+		dir := mount(t, writable.Config{})
+
+		src := filepath.Join(dir, "before")
+		require.NoError(t, os.WriteFile(src, []byte("payload"), 0o644))
+
+		subdir := filepath.Join(dir, "olddir")
+		require.NoError(t, os.Mkdir(subdir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(subdir, "child"), []byte("payload"), 0o644))
+
+		ino := func(path string) uint64 {
+			t.Helper()
+			var st unix.Stat_t
+			require.NoError(t, unix.Stat(path, &st))
+			return st.Ino
+		}
+
+		fileBefore := ino(src)
+		dirBefore := ino(subdir)
+		childBefore := ino(filepath.Join(subdir, "child"))
+
+		dst := filepath.Join(dir, "after")
+		moved := filepath.Join(dir, "newdir")
+		require.NoError(t, os.Rename(src, dst))
+		require.NoError(t, os.Rename(subdir, moved))
+
+		require.Equal(t, fileBefore, ino(dst), "a renamed file keeps its inode number")
+		require.Equal(t, dirBefore, ino(moved), "a renamed directory keeps its inode number")
+
+		// The kernel answered those from the directory entries it moved
+		// itself. Outlasting the entry timeout makes it ask the mount, which
+		// is where a renamed entry used to come back as a different file.
+		time.Sleep(1500 * time.Millisecond)
+
+		require.Equal(t, fileBefore, ino(dst), "and keeps it once the kernel asks again")
+		require.Equal(t, dirBefore, ino(moved), "and so does the directory")
+		require.Equal(t, childBefore, ino(filepath.Join(moved, "child")),
+			"an entry inside a renamed directory keeps its inode number")
+
+		// The renamed directory is a live MFS handle, not the one that was
+		// unlinked: writes through it have to reach the tree.
+		child := filepath.Join(moved, "child")
+		require.NoError(t, os.WriteFile(child, []byte("rewritten"), 0o644))
+		VerifyFile(t, child, []byte("rewritten"))
 	})
 
 	// rsync default save: create temp file, write, rename over target.

--- a/fuse/fusetest/writablesuite.go
+++ b/fuse/fusetest/writablesuite.go
@@ -438,6 +438,52 @@ func RunWritableSuite(t *testing.T, mount MountFunc) {
 		VerifyFile(t, path, newData)
 	})
 
+	// A file's inode number has to outlive the kernel dropping its directory
+	// entry and looking it up again, which happens once EntryTimeout passes.
+	// When it does not, a program that compares a file's identity over time
+	// concludes the file was swapped underneath it: vim abandons a save with
+	// "E949: File changed while writing".
+	t.Run("InodeNumbers", func(t *testing.T) {
+		dir := mount(t, writable.Config{})
+
+		var mnt unix.Stat_t
+		require.NoError(t, unix.Stat(dir, &mnt))
+		require.NotZero(t, mnt.Ino, "mount point should report an inode number")
+
+		path := filepath.Join(dir, "stable")
+		require.NoError(t, os.WriteFile(path, []byte("first"), 0o644))
+
+		var first unix.Stat_t
+		require.NoError(t, unix.Stat(path, &first))
+		require.NotZero(t, first.Ino, "file should report an inode number")
+		// go-fuse numbers whatever the filesystem leaves to it from 1<<63 up,
+		// handing out a new number for every node it builds. A number in that
+		// range means the mount is not numbering its own entries.
+		require.Less(t, first.Ino, uint64(1<<63),
+			"inode number should come from the mount, not go-fuse's automatic range")
+
+		// Outlast the entry timeout of the writable mounts (one second) so
+		// the kernel has to ask for the entry again.
+		time.Sleep(1500 * time.Millisecond)
+
+		var again unix.Stat_t
+		require.NoError(t, unix.Stat(path, &again))
+		require.Equal(t, first.Ino, again.Ino, "inode number should survive a re-lookup")
+
+		// A name that is removed and created again names a different file, so
+		// it must not inherit the old number. go-fuse matches nodes by inode
+		// number, and would hand back the removed entry's node; MFS has that
+		// one marked as unlinked and drops writes made through it.
+		require.NoError(t, os.Remove(path))
+		require.NoError(t, os.WriteFile(path, []byte("second"), 0o644))
+
+		var recreated unix.Stat_t
+		require.NoError(t, unix.Stat(path, &recreated))
+		require.NotEqual(t, first.Ino, recreated.Ino,
+			"a name that was removed and created again should get a new inode number")
+		VerifyFile(t, path, []byte("second"))
+	})
+
 	// rsync default save: create temp file, write, rename over target.
 	t.Run("RsyncPattern", func(t *testing.T) {
 		dir := mount(t, writable.Config{})

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -11,7 +11,9 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
@@ -140,6 +142,40 @@ func TestNamespaceRootMode(t *testing.T) {
 	info, err := os.Stat(mnt.Dir)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o111), info.Mode().Perm())
+}
+
+// TestKeyDirAttrs verifies that a key directory served by the /ipns root
+// reports the same attributes as any other directory on a writable mount: a
+// stable inode number of its own, a link count, and real permissions. The
+// root answers these lookups itself rather than through writable.Dir, so the
+// reply used to carry nothing but zeroes.
+func TestKeyDirAttrs(t *testing.T) {
+	nd, mnt := setupIpnsTest(t, nil)
+	keyDir := mnt.Dir + "/" + nd.Identity.String()
+
+	stat := func() (uint64, os.FileInfo) {
+		t.Helper()
+		info, err := os.Stat(keyDir)
+		require.NoError(t, err)
+		st, ok := info.Sys().(*syscall.Stat_t)
+		require.True(t, ok)
+		return st.Ino, info
+	}
+
+	ino, info := stat()
+	require.NotZero(t, ino, "key directory should report an inode number")
+	require.Less(t, ino, uint64(fusemnt.AutomaticIno),
+		"inode number should come from the mount, not go-fuse's automatic range")
+	require.True(t, info.IsDir())
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	require.EqualValues(t, fusemnt.Nlink, info.Sys().(*syscall.Stat_t).Nlink)
+
+	// Outlast the mount's one second entry timeout so the kernel has to look
+	// the entry up again.
+	time.Sleep(1500 * time.Millisecond)
+
+	again, _ := stat()
+	require.Equal(t, ino, again, "inode number should survive a re-lookup")
 }
 
 // TestFilePersistence verifies that file data survives unmount and remount.

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -134,6 +134,25 @@ func TestIpnsLocalLink(t *testing.T) {
 	require.Equal(t, nd.Identity.String(), target)
 }
 
+// TestRenameOntoNamespaceRoot moves a file from a key directory onto the
+// /ipns root, which holds no files and cannot take it. The move has to fail
+// with the file still where it was: the mount used to unlink the source
+// before finding out it had nowhere to put it, and the file was gone.
+func TestRenameOntoNamespaceRoot(t *testing.T) {
+	nd, mnt := setupIpnsTest(t, nil)
+	keyDir := mnt.Dir + "/" + nd.Identity.String()
+
+	src := keyDir + "/keepme"
+	content := []byte("still here")
+	require.NoError(t, os.WriteFile(src, content, 0o644))
+
+	require.Error(t, os.Rename(src, mnt.Dir+"/keepme"))
+
+	got, err := os.ReadFile(src)
+	require.NoError(t, err, "the file must survive a rename that could not be carried out")
+	require.Equal(t, content, got)
+}
+
 // TestNamespaceRootMode verifies that the /ipns root has execute-only
 // mode (not listable, only traversable).
 func TestNamespaceRootMode(t *testing.T) {

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -124,6 +124,7 @@ func CreateRoot(ctx context.Context, ipfs iface.CoreAPI, gcLocker bstore.GCLocke
 // Getattr returns the root directory attributes.
 func (r *Root) Getattr(_ context.Context, _ fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	out.Attr.Mode = uint32(fusemnt.NamespaceRootMode.Perm())
+	out.Attr.Nlink = fusemnt.Nlink
 	return 0
 }
 

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -45,6 +45,11 @@ type Root struct {
 
 	LocalLinks map[string]*Link
 	RepoPath   string
+
+	// Cfg is the writable mounts' shared config. The root uses its inode
+	// table so the entries it serves itself are numbered from the same
+	// sequence as the files under the key directories.
+	Cfg *writable.Config
 }
 
 func ipnsPubFunc(ipfs iface.CoreAPI, key iface.Key) mfs.PubFunc {
@@ -93,6 +98,9 @@ func CreateRoot(ctx context.Context, ipfs iface.CoreAPI, gcLocker bstore.GCLocke
 		GCLocker:   gcLocker,
 		MountCtx:   ctx,
 	}
+	// The root serves the key directories and alias symlinks itself, so it
+	// needs the table even when there are no keys to build a Dir from.
+	cfg.InitInodes()
 
 	ldirs := make(map[string]*writable.Dir)
 	roots := make(map[string]*mfs.Root)
@@ -110,6 +118,7 @@ func CreateRoot(ctx context.Context, ipfs iface.CoreAPI, gcLocker bstore.GCLocke
 	}
 
 	return &Root{
+		Cfg:        cfg,
 		Ipfs:       ipfs,
 		IpfsRoot:   ipfspath,
 		IpnsRoot:   ipnspath,
@@ -156,6 +165,14 @@ func fillEntryAttr(ctx context.Context, node fs.NodeGetattrer, out *fuse.EntryOu
 	out.Attr = attr.Attr
 }
 
+// entryAttr numbers an entry the root serves itself: a key directory, an
+// alias symlink, or a symlink to a name resolved through IPNS. The number
+// follows the name rather than what the name currently resolves to, so that
+// a republished record does not renumber the entry.
+func (r *Root) entryAttr(name string, mode uint32) fs.StableAttr {
+	return r.Cfg.EntryAttr(fusemnt.RootIno, name, mode)
+}
+
 func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	switch name {
 	case "mach_kernel", ".hidden", "._.":
@@ -164,12 +181,12 @@ func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 
 	if lnk, ok := r.LocalLinks[name]; ok {
 		fillEntryAttr(ctx, lnk, out)
-		return r.NewInode(ctx, lnk, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+		return r.NewInode(ctx, lnk, r.entryAttr(name, syscall.S_IFLNK)), 0
 	}
 
 	if dir, ok := r.LocalDirs[name]; ok {
 		fillEntryAttr(ctx, dir, out)
-		return r.NewInode(ctx, dir, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		return r.NewInode(ctx, dir, r.entryAttr(name, syscall.S_IFDIR)), 0
 	}
 
 	// Other links go through IPNS resolution and are symlinked into the /ipfs mount.
@@ -185,15 +202,16 @@ func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 
 	lnk := &Link{Target: r.IpfsRoot + "/" + strings.TrimPrefix(resolved.String(), "/ipfs/")}
 	fillEntryAttr(ctx, lnk, out)
-	return r.NewInode(ctx, lnk, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+	return r.NewInode(ctx, lnk, r.entryAttr(name, syscall.S_IFLNK)), 0
 }
 
 func (r *Root) Readdir(_ context.Context) (fs.DirStream, syscall.Errno) {
 	entries := make([]fuse.DirEntry, 0, len(r.Keys)*2)
 	for alias, k := range r.Keys {
+		keyName := k.ID().String()
 		entries = append(entries,
-			fuse.DirEntry{Name: k.ID().String(), Mode: syscall.S_IFDIR},
-			fuse.DirEntry{Name: alias, Mode: syscall.S_IFLNK},
+			fuse.DirEntry{Name: keyName, Mode: syscall.S_IFDIR, Ino: r.Cfg.EntryIno(fusemnt.RootIno, keyName)},
+			fuse.DirEntry{Name: alias, Mode: syscall.S_IFLNK, Ino: r.Cfg.EntryIno(fusemnt.RootIno, alias)},
 		)
 	}
 	return fs.NewListDirStream(entries), 0

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -143,6 +143,19 @@ func (r *Root) Statfs(_ context.Context, out *fuse.StatfsOut) syscall.Errno {
 	return 0
 }
 
+// fillEntryAttr copies a node's attributes into the lookup reply. Without it
+// the reply carries zeroes, and since every later lookup refreshes the
+// kernel's cache with the same zeroes, a key directory keeps showing up with
+// no permissions and no link count.
+func fillEntryAttr(ctx context.Context, node fs.NodeGetattrer, out *fuse.EntryOut) {
+	var attr fuse.AttrOut
+	if errno := node.Getattr(ctx, nil, &attr); errno != 0 {
+		log.Warnf("ipns: attributes for lookup reply: %s", errno)
+		return
+	}
+	out.Attr = attr.Attr
+}
+
 func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	switch name {
 	case "mach_kernel", ".hidden", "._.":
@@ -150,10 +163,12 @@ func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 	}
 
 	if lnk, ok := r.LocalLinks[name]; ok {
+		fillEntryAttr(ctx, lnk, out)
 		return r.NewInode(ctx, lnk, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
 	}
 
 	if dir, ok := r.LocalDirs[name]; ok {
+		fillEntryAttr(ctx, dir, out)
 		return r.NewInode(ctx, dir, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
 	}
 
@@ -169,6 +184,7 @@ func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 	}
 
 	lnk := &Link{Target: r.IpfsRoot + "/" + strings.TrimPrefix(resolved.String(), "/ipfs/")}
+	fillEntryAttr(ctx, lnk, out)
 	return r.NewInode(ctx, lnk, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
 }
 

--- a/fuse/ipns/link_unix.go
+++ b/fuse/ipns/link_unix.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
+
+	fusemnt "github.com/ipfs/kubo/fuse/mount"
 )
 
 type Link struct {
@@ -19,6 +21,7 @@ type Link struct {
 func (l *Link) Getattr(_ context.Context, _ fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	log.Debug("Link attr.")
 	out.Attr.Mode = 0o555
+	out.Attr.Nlink = fusemnt.Nlink
 	return 0
 }
 

--- a/fuse/mount/fuse.go
+++ b/fuse/mount/fuse.go
@@ -31,6 +31,9 @@ func NewMount(root fs.InodeEmbedder, mountpoint string, opts *fs.Options) (Mount
 	if opts.RootStableAttr == nil {
 		opts.RootStableAttr = &fs.StableAttr{Ino: RootIno}
 	}
+	if opts.FirstAutomaticIno == 0 {
+		opts.FirstAutomaticIno = AutomaticIno
+	}
 	server, err := fs.Mount(mountpoint, root, opts)
 	if err != nil {
 		return nil, fmt.Errorf("mounting %s: %w", mountpoint, err)

--- a/fuse/mount/fuse.go
+++ b/fuse/mount/fuse.go
@@ -28,6 +28,9 @@ type mount struct {
 // NewMount mounts a FUSE filesystem at a given location, and returns a Mount instance.
 func NewMount(root fs.InodeEmbedder, mountpoint string, opts *fs.Options) (Mount, error) {
 	PlatformMountOpts(&opts.MountOptions)
+	if opts.RootStableAttr == nil {
+		opts.RootStableAttr = &fs.StableAttr{Ino: RootIno}
+	}
 	server, err := fs.Mount(mountpoint, root, opts)
 	if err != nil {
 		return nil, fmt.Errorf("mounting %s: %w", mountpoint, err)

--- a/fuse/mount/inode.go
+++ b/fuse/mount/inode.go
@@ -5,11 +5,10 @@
 package mount
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
-	"hash/fnv"
 
 	"github.com/ipfs/go-cid"
-	mh "github.com/multiformats/go-multihash"
 )
 
 // RootIno is the inode number reported for a mount point. go-fuse leaves the
@@ -24,31 +23,51 @@ const RootIno = 1
 const FirstIno = 2
 
 // AutomaticIno is where go-fuse starts numbering nodes a filesystem did not
-// number itself (fs.Options.FirstAutomaticIno). Mounts keep their own numbers
-// below it, so a node that slips through unnumbered can never be mistaken for
-// one that was numbered. Staying in the lower half also keeps the numbers
-// readable by 32-bit callers of stat and getdents for any realistic tree.
+// number itself. Mounts keep their own numbers below it, so a node that slips
+// through unnumbered can never be mistaken for one that was numbered.
+// NewMount pins fs.Options.FirstAutomaticIno to it rather than relying on
+// go-fuse's default, which is the same value but free to change.
 const AutomaticIno = 1 << 63
 
 // InoFromCid derives an inode number for a node on an immutable mount, where
 // the CID is the identity of the content and nothing else has to be tracked.
-//
-// The first eight bytes of the multihash digest are already uniformly
-// distributed, so they are taken as they are. Two paths that resolve to the
-// same CID get the same number on purpose: on a content-addressed tree they
-// are the same object, and go-fuse then serves both from one node, which
-// keeps a single page cache for the content behind both names.
+// Two paths that resolve to the same CID get the same number on purpose: on a
+// content-addressed tree they are the same object, and go-fuse then serves
+// both from one node, which keeps a single page cache for the content behind
+// both names.
 func InoFromCid(c cid.Cid) uint64 {
-	if dec, err := mh.Decode(c.Hash()); err == nil && dec.Code != mh.IDENTITY && len(dec.Digest) >= 8 {
-		return boundIno(binary.BigEndian.Uint64(dec.Digest[:8]))
-	}
-	// An identity multihash carries the content itself rather than a digest
-	// of it, so its leading bytes would give one number to every file that
-	// starts alike. Digests shorter than eight bytes have too little to take.
-	// Both cases fall back to hashing the whole CID.
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(c.KeyString()))
-	return boundIno(h.Sum64())
+	ino, _ := InoGenFromCid(c)
+	return ino
+}
+
+// InoGenFromCid derives both halves of a node's identity on an immutable
+// mount: the inode number reported to userspace, and the generation that goes
+// with it in fs.StableAttr.
+//
+// go-fuse matches a lookup against the nodes it already holds by the whole of
+// StableAttr, so two CIDs that agree on all of it are served as one object,
+// and whichever was looked up first answers for both. The inode number alone
+// cannot carry that identity: it is 63 bits, which two of the files a busy
+// mount serves are liable to share, and a mount serves whatever content it is
+// asked for, including content chosen to collide. The generation adds another
+// 64 bits, out of reach of both.
+//
+// Both numbers come from a hash of the codec together with the multihash. The
+// codec has to be in there because the same block reached as raw and as
+// dag-pb is decoded differently and is not the same file; the CID version is
+// left out because a CIDv0 and a CIDv1 dag-pb of the same content are.
+func InoGenFromCid(c cid.Cid) (ino, gen uint64) {
+	var codec [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(codec[:], c.Type())
+
+	h := sha256.New()
+	_, _ = h.Write(codec[:n])
+	_, _ = h.Write(c.Hash())
+
+	var sum [sha256.Size]byte
+	h.Sum(sum[:0])
+
+	return boundIno(binary.BigEndian.Uint64(sum[:8])), binary.BigEndian.Uint64(sum[8:16])
 }
 
 // boundIno moves a derived number into the range a mount may report,

--- a/fuse/mount/inode.go
+++ b/fuse/mount/inode.go
@@ -1,0 +1,62 @@
+// Inode numbering rules shared by the FUSE mounts.
+//
+//go:build (linux || darwin || freebsd) && !nofuse
+
+package mount
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// RootIno is the inode number reported for a mount point. go-fuse leaves the
+// root's inode number at 0 unless it is told otherwise, and 0 is not a valid
+// inode number: tools that check it read the mount point as a file that is
+// not there. 1 is the conventional root number and is already the FUSE node
+// ID the kernel uses for the root.
+const RootIno = 1
+
+// FirstIno is the lowest number a mount hands out to an entry, leaving 0
+// (not a valid inode number) and 1 (the mount point) alone.
+const FirstIno = 2
+
+// AutomaticIno is where go-fuse starts numbering nodes a filesystem did not
+// number itself (fs.Options.FirstAutomaticIno). Mounts keep their own numbers
+// below it, so a node that slips through unnumbered can never be mistaken for
+// one that was numbered. Staying in the lower half also keeps the numbers
+// readable by 32-bit callers of stat and getdents for any realistic tree.
+const AutomaticIno = 1 << 63
+
+// InoFromCid derives an inode number for a node on an immutable mount, where
+// the CID is the identity of the content and nothing else has to be tracked.
+//
+// The first eight bytes of the multihash digest are already uniformly
+// distributed, so they are taken as they are. Two paths that resolve to the
+// same CID get the same number on purpose: on a content-addressed tree they
+// are the same object, and go-fuse then serves both from one node, which
+// keeps a single page cache for the content behind both names.
+func InoFromCid(c cid.Cid) uint64 {
+	if dec, err := mh.Decode(c.Hash()); err == nil && dec.Code != mh.IDENTITY && len(dec.Digest) >= 8 {
+		return boundIno(binary.BigEndian.Uint64(dec.Digest[:8]))
+	}
+	// An identity multihash carries the content itself rather than a digest
+	// of it, so its leading bytes would give one number to every file that
+	// starts alike. Digests shorter than eight bytes have too little to take.
+	// Both cases fall back to hashing the whole CID.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(c.KeyString()))
+	return boundIno(h.Sum64())
+}
+
+// boundIno moves a derived number into the range a mount may report,
+// [FirstIno, AutomaticIno).
+func boundIno(ino uint64) uint64 {
+	ino &^= AutomaticIno
+	if ino < FirstIno {
+		ino += FirstIno
+	}
+	return ino
+}

--- a/fuse/mount/stat.go
+++ b/fuse/mount/stat.go
@@ -26,6 +26,18 @@ const StatBlockSize = 512
 // contract stays stable across Kubo and boxo upgrades.
 const DefaultBlksize = 1024 * 1024
 
+// Nlink is the link count (stat.st_nlink) reported for every entry on a
+// FUSE mount. Left unset it is 0, which POSIX gives to an inode with no
+// remaining names, so tools read a live file as one that is on its way out.
+//
+// 1 is right for files and symlinks: neither IPFS nor MFS has hard links.
+// Directories conventionally count their own entry, their parent's, and one
+// per subdirectory, but reporting 1 for them as well is deliberate. GNU find
+// skips the stat of a directory's children once it has seen st_nlink-2 of
+// them, and would miss entries if the count were a guess; a count below 2
+// tells it to walk the directory properly instead.
+const Nlink = 1
+
 // SizeToStatBlocks converts a byte size to the number of 512-byte blocks
 // reported by POSIX stat(2) in the st_blocks field, rounded up so a
 // non-empty file reports at least one block.

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -36,6 +36,7 @@ import (
 	importer "github.com/ipfs/boxo/ipld/unixfs/importer"
 	uio "github.com/ipfs/boxo/ipld/unixfs/io"
 	"github.com/ipfs/boxo/path"
+	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-test/random"
 	options "github.com/ipfs/kubo/core/coreiface/options"
@@ -201,6 +202,48 @@ func TestInodeNumbersFromCID(t *testing.T) {
 		"repeated lookups of one path should agree")
 	require.Equal(t, direct, ino(gopath.Join(mntDir, dir.RootCid().String(), "child")),
 		"the same content reached through another path is the same object")
+}
+
+// TestSameBlockUnderTwoCodecs reads one block through both a dag-pb and a raw
+// CID. They name different files, since the raw CID is the block itself and
+// the dag-pb CID is the UnixFS file inside it, so they have to be numbered
+// apart: go-fuse serves two entries that agree on their whole identity from
+// one node, and the first one read would then answer for both.
+func TestSameBlockUnderTwoCodecs(t *testing.T) {
+	nd, mntDir := setupIpfsTest(t, nil)
+
+	api, err := coreapi.NewCoreAPI(nd)
+	require.NoError(t, err)
+
+	content := []byte("one block, two codecs")
+	added, err := api.Unixfs().Add(t.Context(), files.NewBytesFile(content),
+		options.Unixfs.CidVersion(1), options.Unixfs.RawLeaves(false))
+	require.NoError(t, err)
+
+	pbCid := added.RootCid()
+	rawCid := cid.NewCidV1(cid.Raw, pbCid.Hash())
+
+	block, err := nd.Blockstore.Get(t.Context(), pbCid)
+	require.NoError(t, err)
+
+	stat := func(c cid.Cid) (uint64, []byte) {
+		t.Helper()
+		p := gopath.Join(mntDir, c.String())
+		info, err := os.Stat(p)
+		require.NoError(t, err)
+		st, ok := info.Sys().(*syscall.Stat_t)
+		require.True(t, ok)
+		data, err := os.ReadFile(p)
+		require.NoError(t, err)
+		return st.Ino, data
+	}
+
+	pbIno, pbData := stat(pbCid)
+	rawIno, rawData := stat(rawCid)
+
+	require.NotEqual(t, pbIno, rawIno, "two CIDs for one block should be numbered apart")
+	require.Equal(t, content, pbData, "the dag-pb CID should read as the UnixFS file")
+	require.Equal(t, block.RawData(), rawData, "the raw CID should read as the block itself")
 }
 
 // Test reading a directory that contains both dag-pb and raw-leaf children.

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -163,6 +163,46 @@ func TestBareFileCID(t *testing.T) {
 	})
 }
 
+// TestInodeNumbersFromCID verifies that /ipfs entries are numbered from the
+// CID they resolve to, so a file keeps one inode number no matter which path
+// reaches it or how often the kernel looks it up.
+func TestInodeNumbersFromCID(t *testing.T) {
+	nd, mntDir := setupIpfsTest(t, nil)
+
+	api, err := coreapi.NewCoreAPI(nd)
+	require.NoError(t, err)
+
+	content := []byte("inode numbering test content")
+	file, err := api.Unixfs().Add(t.Context(), files.NewBytesFile(content))
+	require.NoError(t, err)
+
+	dir, err := api.Unixfs().Add(t.Context(), files.NewMapDirectory(map[string]files.Node{
+		"child": files.NewBytesFile(content),
+	}))
+	require.NoError(t, err)
+
+	ino := func(path string) uint64 {
+		t.Helper()
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		st, ok := info.Sys().(*syscall.Stat_t)
+		require.True(t, ok)
+		return st.Ino
+	}
+
+	direct := ino(gopath.Join(mntDir, file.RootCid().String()))
+	require.NotZero(t, direct, "file should report an inode number")
+	// Numbers at or above this point are the ones go-fuse hands out when a
+	// filesystem does not number a node itself.
+	require.Less(t, direct, uint64(fusemnt.AutomaticIno),
+		"inode number should be derived from the CID, not left to go-fuse")
+
+	require.Equal(t, direct, ino(gopath.Join(mntDir, file.RootCid().String())),
+		"repeated lookups of one path should agree")
+	require.Equal(t, direct, ino(gopath.Join(mntDir, dir.RootCid().String(), "child")),
+		"the same content reached through another path is the same object")
+}
+
 // Test reading a directory that contains both dag-pb and raw-leaf children.
 // This is the typical layout produced by `ipfs add --raw-leaves`: the
 // directory node is dag-pb, while file leaves are raw blocks.

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -37,11 +37,13 @@ import (
 	uio "github.com/ipfs/boxo/ipld/unixfs/io"
 	"github.com/ipfs/boxo/path"
 	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-test/random"
 	options "github.com/ipfs/kubo/core/coreiface/options"
 	"github.com/ipfs/kubo/fuse/fusetest"
 	fusemnt "github.com/ipfs/kubo/fuse/mount"
+	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 )
 
@@ -244,6 +246,55 @@ func TestSameBlockUnderTwoCodecs(t *testing.T) {
 	require.NotEqual(t, pbIno, rawIno, "two CIDs for one block should be numbered apart")
 	require.Equal(t, content, pbData, "the dag-pb CID should read as the UnixFS file")
 	require.Equal(t, block.RawData(), rawData, "the raw CID should read as the block itself")
+}
+
+// TestLookupOfUnreadableChild covers the two children a UnixFS directory can
+// hold that this mount cannot read as a UnixFS file: one in a codec it does
+// not decode, and one whose block is not in the blockstore. A stat of either
+// used to dereference the UnixFS metadata it never got and take the whole
+// daemon down with it.
+func TestLookupOfUnreadableChild(t *testing.T) {
+	dirWithChild := func(t *testing.T, nd *core.IpfsNode, name string, child ipld.Node) string {
+		t.Helper()
+		db, err := uio.NewDirectory(nd.DAG)
+		require.NoError(t, err)
+		require.NoError(t, db.AddChild(t.Context(), name, child))
+		dir, err := db.GetNode()
+		require.NoError(t, err)
+		require.NoError(t, nd.DAG.Add(t.Context(), dir))
+		return dir.Cid().String()
+	}
+
+	t.Run("dag-cbor child", func(t *testing.T) {
+		nd, mntDir := setupIpfsTest(t, nil)
+
+		child, err := cbor.WrapObject(map[string]string{"hello": "world"}, mh.SHA2_256, -1)
+		require.NoError(t, err)
+		require.NoError(t, nd.DAG.Add(t.Context(), child))
+
+		dir := dirWithChild(t, nd, "obj", child)
+		info, err := os.Stat(gopath.Join(mntDir, dir, "obj"))
+		require.NoError(t, err)
+		require.False(t, info.IsDir())
+		require.EqualValues(t, len(child.RawData()), info.Size(),
+			"a block this mount cannot decode should report its own size")
+	})
+
+	t.Run("missing block", func(t *testing.T) {
+		// An offline node, so that a block nobody has is reported missing
+		// rather than waited for.
+		offline, err := core.NewNode(t.Context(), &core.BuildCfg{})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = offline.Close() })
+		_, mntDir := setupIpfsTest(t, offline)
+
+		child := dag.NodeWithData(ft.FilePBData([]byte("gone"), 4))
+		dir := dirWithChild(t, offline, "gone", child)
+		require.NoError(t, offline.DAG.Remove(t.Context(), child.Cid()))
+
+		_, err = os.Stat(gopath.Join(mntDir, dir, "gone"))
+		require.Error(t, err, "a child whose block is missing should not resolve")
+	})
 }
 
 // Test reading a directory that contains both dag-pb and raw-leaf children.

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -376,16 +376,19 @@ func (fh *roFileHandle) Release(_ context.Context) syscall.Errno {
 	return fs.ToErrno(fh.r.Close())
 }
 
-// stableAttrFor describes a node to go-fuse: which object it is (Ino,
-// derived from c, the CID the entry resolved to) and what kind of object.
+// stableAttrFor describes a node to go-fuse: which object it is (Ino and Gen,
+// both derived from c, the CID the entry resolved to) and what kind of object.
 //
-// No generation is set, unlike the writable mounts: /ipfs content never
-// changes under a CID, so a node go-fuse already holds for that CID is
-// still accurate and is reused rather than rebuilt.
+// Ino and Gen together are the identity go-fuse matches a lookup against, so
+// both are needed to tell two CIDs apart; see fusemnt.InoGenFromCid. They are
+// derived rather than counted because /ipfs content never changes under a CID:
+// a node go-fuse already holds for that CID is still accurate and is reused
+// rather than rebuilt.
 func stableAttrFor(n *Node, c cid.Cid) fs.StableAttr {
-	ino := fusemnt.InoFromCid(c)
+	ino, gen := fusemnt.InoGenFromCid(c)
+	attr := fs.StableAttr{Ino: ino, Gen: gen} // Mode 0 is S_IFREG
 	if _, ok := n.nd.(*mdag.RawNode); ok {
-		return fs.StableAttr{Ino: ino} // S_IFREG
+		return attr
 	}
 	if n.cached == nil {
 		_ = n.loadData()
@@ -393,12 +396,12 @@ func stableAttrFor(n *Node, c cid.Cid) fs.StableAttr {
 	if n.cached != nil {
 		switch n.cached.Type() {
 		case ft.TDirectory, ft.THAMTShard:
-			return fs.StableAttr{Mode: syscall.S_IFDIR, Ino: ino}
+			attr.Mode = syscall.S_IFDIR
 		case ft.TSymlink:
-			return fs.StableAttr{Mode: syscall.S_IFLNK, Ino: ino}
+			attr.Mode = syscall.S_IFLNK
 		}
 	}
-	return fs.StableAttr{Ino: ino} // S_IFREG
+	return attr
 }
 
 // Interface checks.

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -119,7 +119,7 @@ func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 	}
 
 	child := &Node{ipfs: r.ipfs, nd: fnd}
-	stable := stableAttrFor(child)
+	stable := stableAttrFor(child, cidLnk.Cid)
 
 	// Fill attrs in the lookup response so the kernel doesn't cache zeros.
 	child.fillAttr(&out.Attr)
@@ -255,7 +255,7 @@ func (n *Node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 	}
 
 	child := &Node{ipfs: n.ipfs, nd: nd}
-	stable := stableAttrFor(child)
+	stable := stableAttrFor(child, link.Cid)
 
 	child.fillAttr(&out.Attr)
 	out.SetEntryTimeout(immutableAttrCacheTime)
@@ -304,7 +304,9 @@ func (n *Node) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 				}
 			}
 		}
-		entries = append(entries, fuse.DirEntry{Name: name, Mode: mode})
+		// Ino has to match what Lookup reports for the same name, or d_ino
+		// from getdents disagrees with st_ino from stat.
+		entries = append(entries, fuse.DirEntry{Name: name, Mode: mode, Ino: fusemnt.InoFromCid(lnk.Cid)})
 		return nil
 	})
 	if err != nil {
@@ -374,10 +376,16 @@ func (fh *roFileHandle) Release(_ context.Context) syscall.Errno {
 	return fs.ToErrno(fh.r.Close())
 }
 
-// stableAttrFor returns the StableAttr (file type bits) for a Node.
-func stableAttrFor(n *Node) fs.StableAttr {
+// stableAttrFor describes a node to go-fuse: which object it is (Ino,
+// derived from c, the CID the entry resolved to) and what kind of object.
+//
+// No generation is set, unlike the writable mounts: /ipfs content never
+// changes under a CID, so a node go-fuse already holds for that CID is
+// still accurate and is reused rather than rebuilt.
+func stableAttrFor(n *Node, c cid.Cid) fs.StableAttr {
+	ino := fusemnt.InoFromCid(c)
 	if _, ok := n.nd.(*mdag.RawNode); ok {
-		return fs.StableAttr{} // S_IFREG
+		return fs.StableAttr{Ino: ino} // S_IFREG
 	}
 	if n.cached == nil {
 		_ = n.loadData()
@@ -385,12 +393,12 @@ func stableAttrFor(n *Node) fs.StableAttr {
 	if n.cached != nil {
 		switch n.cached.Type() {
 		case ft.TDirectory, ft.THAMTShard:
-			return fs.StableAttr{Mode: syscall.S_IFDIR}
+			return fs.StableAttr{Mode: syscall.S_IFDIR, Ino: ino}
 		case ft.TSymlink:
-			return fs.StableAttr{Mode: syscall.S_IFLNK}
+			return fs.StableAttr{Mode: syscall.S_IFLNK, Ino: ino}
 		}
 	}
-	return fs.StableAttr{} // S_IFREG
+	return fs.StableAttr{Ino: ino} // S_IFREG
 }
 
 // Interface checks.

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -62,6 +62,7 @@ func (r *Root) Statfs(_ context.Context, out *fuse.StatfsOut) syscall.Errno {
 
 func (*Root) Getattr(_ context.Context, _ fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	out.Attr.Mode = uint32(fusemnt.NamespaceRootMode.Perm())
+	out.Attr.Nlink = fusemnt.Nlink
 	out.SetTimeout(immutableAttrCacheTime)
 	return 0
 }
@@ -186,6 +187,7 @@ type roFileHandle struct {
 // which clobbers the UnixFS-derived values set below.
 func (n *Node) fillAttr(a *fuse.Attr) {
 	a.Blksize = fusemnt.DefaultBlksize
+	a.Nlink = fusemnt.Nlink
 
 	if rawnd, ok := n.nd.(*mdag.RawNode); ok {
 		a.Mode = uint32(fusemnt.DefaultFileModeRO.Perm())

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -203,6 +203,16 @@ func (n *Node) fillAttr(a *fuse.Attr) {
 		}
 	}
 
+	// A UnixFS directory can link to a block of any codec, and loadData only
+	// reads UnixFS metadata out of dag-pb. Report anything else as a file of
+	// the block's own size, which is what reads of it return.
+	if n.cached == nil {
+		a.Mode = uint32(fusemnt.DefaultFileModeRO.Perm())
+		a.Size = uint64(len(n.nd.RawData()))
+		a.Blocks = fusemnt.SizeToStatBlocks(a.Size)
+		return
+	}
+
 	switch n.cached.Type() {
 	case ft.TDirectory, ft.THAMTShard:
 		a.Mode = uint32(fusemnt.DefaultDirModeRO.Perm())
@@ -248,8 +258,13 @@ func (n *Node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 		return nil, syscall.EIO
 	}
 
+	// A block we cannot read is not an entry we can serve: every attribute
+	// of it, down to its type, comes from the block itself.
 	nd, err := n.ipfs.DAG.Get(ctx, link.Cid)
-	if err != nil && !ipld.IsNotFound(err) {
+	if err != nil {
+		if ipld.IsNotFound(err) {
+			return nil, syscall.ENOENT
+		}
 		log.Errorf("fuse lookup %q: %s", name, err)
 		return nil, syscall.EIO
 	}

--- a/fuse/writable/inodes.go
+++ b/fuse/writable/inodes.go
@@ -1,0 +1,127 @@
+// Inode numbering for writable mounts.
+//
+//go:build (linux || darwin || freebsd) && !nofuse
+
+package writable
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+)
+
+// firstInode is the first number handed out to a directory entry. 0 is not
+// a valid inode number and 1 is the mount root, so entries start above both.
+const firstInode = 2
+
+// entryKey identifies a directory entry by its parent's inode number and its
+// name. MFS offers nothing better to key on: a file's CID changes on every
+// write, and boxo hands out a fresh *mfs.File for an unchanged file whenever
+// a directory flush clears its child cache.
+type entryKey struct {
+	parent uint64
+	name   string
+}
+
+// inodeTable hands out inode numbers for the entries of one mount.
+//
+// go-fuse picks an automatic inode number for every Inode built with a zero
+// StableAttr.Ino, and a different one each time. The kernel drops a mount's
+// dentries once EntryTimeout expires, so under automatic numbering a file
+// nobody touched comes back from the next lookup with a different st_ino.
+// Programs that compare a file's identity over time then conclude the file
+// was swapped underneath them: vim gives up on a save with "E949: File
+// changed while writing".
+//
+// A number is allocated the first time an entry is looked up and survives
+// the kernel forgetting the entry and looking it up again. Numbers are never
+// reused. Removing or renaming an entry drops its number for good, so a name
+// that is created again gets a new one. That is what keeps go-fuse from
+// matching the new entry to the removed entry's Inode, which still holds a
+// handle on the object that went away.
+//
+// The table only grows while a mount is up, by one entry per name looked up
+// and not since removed, and it starts empty on every mount. Inode numbers
+// therefore mean nothing outside the mount that issued them.
+type inodeTable struct {
+	mu      sync.Mutex
+	next    uint64
+	entries map[entryKey]uint64
+
+	gen atomic.Uint64
+}
+
+func newInodeTable() *inodeTable {
+	return &inodeTable{next: firstInode, entries: make(map[entryKey]uint64)}
+}
+
+// stable describes a node to go-fuse: which file it is (Ino), what kind of
+// file (Mode), and which incarnation of it (Gen).
+//
+// Every node gets a generation of its own, which stops go-fuse from matching
+// a lookup against a node it already holds for the same entry. Matching would
+// be tempting, since the inode numbers now say the two are the same file, but
+// the node go-fuse kept has a *mfs.File or *mfs.Directory captured when it was
+// built, and boxo replaces those whenever a directory flush clears its child
+// cache. Reusing the node would mean operating on a handle MFS has moved on
+// from: `rm -r` unlinks entries that stay in the tree, and writes go nowhere.
+// A fresh node per lookup re-reads the handle, which is what the mount did
+// before it numbered its own inodes, and all that changes is the number.
+func (t *inodeTable) stable(parent uint64, name string, mode uint32) fs.StableAttr {
+	return fs.StableAttr{
+		Ino:  t.get(parent, name),
+		Mode: mode,
+		Gen:  t.gen.Add(1),
+	}
+}
+
+// get returns the inode number for an entry, allocating one on first use.
+func (t *inodeTable) get(parent uint64, name string) uint64 {
+	key := entryKey{parent: parent, name: name}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if ino, ok := t.entries[key]; ok {
+		return ino
+	}
+	ino := t.next
+	t.next++
+	t.entries[key] = ino
+	return ino
+}
+
+// InitInodes prepares the mount's inode table, once per Config. NewDir calls
+// it, and so must any mount that serves entries of its own above the writable
+// directories, before it answers a lookup. Call it while the mount is being
+// built, not from a FUSE handler.
+func (c *Config) InitInodes() {
+	if c.inodes == nil {
+		c.inodes = newInodeTable()
+	}
+}
+
+// EntryAttr describes an entry of this mount to go-fuse: which entry it is
+// (Ino) and what kind (Mode, file type bits only), plus a generation of its
+// own. It is exported for the /ipns root, which serves the key directories
+// and alias symlinks itself but has to number them from the same table as the
+// files underneath them, or the two could hand out one number twice.
+func (c *Config) EntryAttr(parent uint64, name string, mode uint32) fs.StableAttr {
+	return c.inodes.stable(parent, name, mode)
+}
+
+// EntryIno returns an entry's inode number on its own, for filling
+// fuse.DirEntry in a Readdir. See EntryAttr.
+func (c *Config) EntryIno(parent uint64, name string) uint64 {
+	return c.inodes.get(parent, name)
+}
+
+// drop forgets an entry's inode number. Call it once the entry is gone from
+// MFS so that whatever takes the name next is numbered separately.
+func (t *inodeTable) drop(parent uint64, name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	delete(t.entries, entryKey{parent: parent, name: name})
+}

--- a/fuse/writable/inodes.go
+++ b/fuse/writable/inodes.go
@@ -35,15 +35,27 @@ type entryKey struct {
 // changed while writing".
 //
 // A number is allocated the first time an entry is looked up and survives
-// the kernel forgetting the entry and looking it up again. Numbers are never
-// reused. Removing or renaming an entry drops its number for good, so a name
-// that is created again gets a new one. That is what keeps go-fuse from
-// matching the new entry to the removed entry's Inode, which still holds a
-// handle on the object that went away.
+// the kernel forgetting the entry and looking it up again. A rename carries
+// the number over to the new name. Numbers are never reused: removing an
+// entry retires its number, so a name that is created again is a new file
+// with a new number, which is what a program watching the name expects.
 //
-// The table only grows while a mount is up, by one entry per name looked up
-// and not since removed, and it starts empty on every mount. Inode numbers
-// therefore mean nothing outside the mount that issued them.
+// Only mutations that arrive through the mount retire a number. `ipfs files
+// rm` on a mounted MFS goes straight to the same tree, so a name removed that
+// way and created again keeps the number the deleted file had. Nothing is
+// served wrong (each lookup still reads the live entry), but an observer
+// watching st_ino alone does not see the replacement.
+//
+// The table only grows while a mount is up and starts empty on every mount,
+// so inode numbers mean nothing outside the mount that issued them. It holds
+// one entry per name looked up and not since removed through the mount, which
+// includes every name a directory listing walks past, and on /ipns every
+// external name that resolves.
+//
+// A lookup that is in flight while the name it is resolving is removed can
+// leave its entry behind, since the allocation is not serialized against the
+// removal. The entry is then either inherited by the next file of that name
+// or held until unmount.
 type inodeTable struct {
 	mu      sync.Mutex
 	next    uint64
@@ -59,15 +71,16 @@ func newInodeTable() *inodeTable {
 // stable describes a node to go-fuse: which file it is (Ino), what kind of
 // file (Mode), and which incarnation of it (Gen).
 //
-// Every node gets a generation of its own, which stops go-fuse from matching
-// a lookup against a node it already holds for the same entry. Matching would
-// be tempting, since the inode numbers now say the two are the same file, but
-// the node go-fuse kept has a *mfs.File or *mfs.Directory captured when it was
-// built, and boxo replaces those whenever a directory flush clears its child
-// cache. Reusing the node would mean operating on a handle MFS has moved on
-// from: `rm -r` unlinks entries that stay in the tree, and writes go nowhere.
-// A fresh node per lookup re-reads the handle, which is what the mount did
-// before it numbered its own inodes, and all that changes is the number.
+// Every node gets a generation of its own. go-fuse matches a lookup against
+// the nodes it holds by all three fields together, so a fresh generation is
+// what makes it build a new node rather than hand back one it already has for
+// this entry. It has to: the node it kept has a *mfs.File or *mfs.Directory
+// captured when it was built, and boxo replaces those whenever a directory
+// flush clears its child cache. Reusing the node would mean operating on a
+// handle MFS has moved on from, where `rm -r` unlinks entries that stay in
+// the tree and writes go nowhere. A fresh node per lookup re-reads the
+// handle, which is what the mount did before it numbered its own inodes, and
+// all that changes is the number.
 func (t *inodeTable) stable(parent uint64, name string, mode uint32) fs.StableAttr {
 	return fs.StableAttr{
 		Ino:  t.get(parent, name),
@@ -124,4 +137,33 @@ func (t *inodeTable) drop(parent uint64, name string) {
 	defer t.mu.Unlock()
 
 	delete(t.entries, entryKey{parent: parent, name: name})
+}
+
+// move carries an entry's inode number over to the name it was renamed to and
+// retires the number the destination held. Call it while both names are gone
+// from MFS, between unlinking them and adding the entry back under the new
+// name.
+//
+// The source keeps its number rather than being renumbered: two live entries
+// can never share one, because numbers are only ever handed out fresh, and
+// keeping it is what lets a program tell that the file it was watching moved
+// instead of being replaced. A directory keeps its number for the same
+// reason, and because its children are keyed by it: renumbering the directory
+// would renumber everything under it and strand the old keys.
+func (t *inodeTable) move(oldParent uint64, oldName string, newParent uint64, newName string) {
+	oldKey := entryKey{parent: oldParent, name: oldName}
+	newKey := entryKey{parent: newParent, name: newName}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	ino, ok := t.entries[oldKey]
+	delete(t.entries, oldKey)
+	if !ok {
+		// The source was never looked up, so it has no number to carry over
+		// and the destination must not keep the one it had.
+		delete(t.entries, newKey)
+		return
+	}
+	t.entries[newKey] = ino
 }

--- a/fuse/writable/writable.go
+++ b/fuse/writable/writable.go
@@ -116,6 +116,7 @@ type Dir struct {
 // (dedup scanners, file managers) treat as "unsupported".
 func (d *Dir) fillAttr(a *fuse.Attr) {
 	a.Mode = uint32(fusemnt.DefaultDirModeRW.Perm())
+	a.Nlink = fusemnt.Nlink
 	a.Blocks = 1
 	a.Blksize = d.Cfg.Blksize
 	if m, err := d.MFSDir.Mode(); err == nil && m != 0 {
@@ -440,6 +441,7 @@ type FileInode struct {
 
 func (fi *FileInode) fillAttr(a *fuse.Attr) {
 	size, _ := fi.MFSFile.Size()
+	a.Nlink = fusemnt.Nlink
 	a.Size = uint64(size)
 	a.Blocks = fusemnt.SizeToStatBlocks(a.Size)
 	a.Blksize = fi.Cfg.Blksize
@@ -746,6 +748,7 @@ func (s *Symlink) Readlink(_ context.Context) ([]byte, syscall.Errno) {
 
 func (s *Symlink) fillAttr(a *fuse.Attr) {
 	a.Mode = uint32(fusemnt.SymlinkMode.Perm())
+	a.Nlink = fusemnt.Nlink
 	a.Size = uint64(len(s.Target))
 	a.Blocks = fusemnt.SizeToStatBlocks(a.Size)
 	a.Blksize = s.Cfg.Blksize

--- a/fuse/writable/writable.go
+++ b/fuse/writable/writable.go
@@ -136,6 +136,13 @@ func (d *Dir) dropChildIno(name string) {
 	d.Cfg.inodes.drop(d.StableAttr().Ino, name)
 }
 
+// moveChildIno carries the inode number of this directory's entry over to the
+// name it is being renamed to, and retires the number of whatever that name
+// held before.
+func (d *Dir) moveChildIno(oldName string, target *Dir, newName string) {
+	d.Cfg.inodes.move(d.StableAttr().Ino, oldName, target.StableAttr().Ino, newName)
+}
+
 // fillAttr fills stat attributes for a directory. Blocks and Blksize
 // are set explicitly because go-fuse's setBlocks otherwise auto-fills
 // them from Size with a 4 KiB page-based fallback. For directories
@@ -347,6 +354,14 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 	if err := targetDir.MFSDir.Unlink(newName); err != nil && err != os.ErrNotExist {
 		return fs.ToErrno(err)
 	}
+
+	// The entry keeps its inode number: a rename moves a file, it does not
+	// replace it, and programs that track a file by identity have to see the
+	// same one afterwards. Whatever the new name held before is gone and
+	// gives its number up. Both names are absent from MFS at this point, so
+	// a lookup racing with the rename gets ENOENT rather than either number.
+	d.moveChildIno(oldName, targetDir, newName)
+
 	if err := targetDir.MFSDir.AddChild(newName, nd); err != nil {
 		return fs.ToErrno(err)
 	}
@@ -361,15 +376,6 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 			return fs.ToErrno(err)
 		}
 	}
-
-	// Both names change identity here, so both give up their inode numbers.
-	// POSIX would keep the source's number on the destination, but the entry
-	// that lands there is a new *mfs.File: MFS marks the unlinked one as
-	// gone and silently drops writes made through it. Renumbering makes the
-	// next lookup build a node on the live entry instead of reusing the dead
-	// one, at the cost of st_ino changing across a rename.
-	d.dropChildIno(oldName)
-	targetDir.dropChildIno(newName)
 
 	return fs.ToErrno(d.MFSDir.Flush())
 }

--- a/fuse/writable/writable.go
+++ b/fuse/writable/writable.go
@@ -351,6 +351,17 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 		return fs.ToErrno(err)
 	}
 
+	// Flush the destination before the source. AddChild only updates the
+	// target directory in memory, so without this the new link is lost if the
+	// daemon stops before something else flushes it; flushing it first means
+	// an interrupted rename leaves the entry under both names rather than
+	// under neither.
+	if targetDir.MFSDir != d.MFSDir {
+		if err := targetDir.MFSDir.Flush(); err != nil {
+			return fs.ToErrno(err)
+		}
+	}
+
 	// Both names change identity here, so both give up their inode numbers.
 	// POSIX would keep the source's number on the destination, but the entry
 	// that lands there is a new *mfs.File: MFS marks the unlinked one as

--- a/fuse/writable/writable.go
+++ b/fuse/writable/writable.go
@@ -62,6 +62,12 @@ type Config struct {
 	// instead of the per-operation context, which the kernel cancels once the
 	// operation returns. nil falls back to context.Background (e.g. tests).
 	MountCtx context.Context
+
+	// inodes numbers the entries of the mount this Config belongs to. One
+	// table serves every directory of a mount, including the several roots
+	// the /ipns mount creates, so that two entries never share a number.
+	// NewDir fills it in. See inodeTable.
+	inodes *inodeTable
 }
 
 // openContext returns the context to bind a long-lived file descriptor's
@@ -99,6 +105,9 @@ func NewDir(d *mfs.Directory, cfg *Config) *Dir {
 	if cfg.Blksize == 0 {
 		cfg.Blksize = fusemnt.DefaultBlksize
 	}
+	// The /ipns mount calls NewDir once per key, all sharing one Config, so
+	// the table has to be created once and then left alone.
+	cfg.InitInodes()
 	return &Dir{MFSDir: d, Cfg: cfg}
 }
 
@@ -107,6 +116,24 @@ type Dir struct {
 	fs.Inode
 	MFSDir *mfs.Directory
 	Cfg    *Config
+}
+
+// childIno returns the inode number to report for the named entry of this
+// directory. See inodeTable for why the numbers cannot be left to go-fuse.
+func (d *Dir) childIno(name string) uint64 {
+	return d.Cfg.inodes.get(d.StableAttr().Ino, name)
+}
+
+// childAttr describes the named entry of this directory to go-fuse. mode
+// carries the file type bits only (0 means a regular file).
+func (d *Dir) childAttr(name string, mode uint32) fs.StableAttr {
+	return d.Cfg.inodes.stable(d.StableAttr().Ino, name, mode)
+}
+
+// dropChildIno retires the inode number of an entry that is no longer in this
+// directory, so that a later entry of the same name is numbered separately.
+func (d *Dir) dropChildIno(name string) {
+	d.Cfg.inodes.drop(d.StableAttr().Ino, name)
 }
 
 // fillAttr fills stat attributes for a directory. Blocks and Blksize
@@ -182,17 +209,17 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 	case mfs.TDir:
 		child := &Dir{MFSDir: mfsNode.(*mfs.Directory), Cfg: d.Cfg}
 		child.fillAttr(&out.Attr)
-		return d.NewInode(ctx, child, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+		return d.NewInode(ctx, child, d.childAttr(name, syscall.S_IFDIR)), 0
 	case mfs.TFile:
 		mfsFile := mfsNode.(*mfs.File)
 		if target := SymlinkTarget(mfsFile); target != "" {
 			child := &Symlink{Target: target, MFSFile: mfsFile, Cfg: d.Cfg}
 			child.fillAttr(&out.Attr)
-			return d.NewInode(ctx, child, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+			return d.NewInode(ctx, child, d.childAttr(name, syscall.S_IFLNK)), 0
 		}
 		child := &FileInode{MFSFile: mfsFile, Cfg: d.Cfg}
 		child.fillAttr(&out.Attr)
-		return d.NewInode(ctx, child, fs.StableAttr{}), 0
+		return d.NewInode(ctx, child, d.childAttr(name, 0)), 0
 	default:
 		log.Errorf("unexpected MFS node type %d under directory", mfsNode.Type())
 		return nil, syscall.EIO
@@ -219,7 +246,11 @@ func (d *Dir) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 				}
 			}
 		}
-		entries[i] = fuse.DirEntry{Name: node.Name, Mode: mode}
+		// Ino must match what Lookup reports for the same name, or d_ino
+		// from getdents disagrees with st_ino from stat and tools that
+		// trust the cheaper of the two (ls -i, find) see two identities
+		// for one file.
+		entries[i] = fuse.DirEntry{Name: node.Name, Mode: mode, Ino: d.childIno(node.Name)}
 	}
 	return fs.NewListDirStream(entries), 0
 }
@@ -241,7 +272,7 @@ func (d *Dir) Mkdir(ctx context.Context, name string, _ uint32, out *fuse.EntryO
 	// Fill the response attrs so the kernel doesn't cache zero values
 	// until AttrTimeout expires. Matches Dir.Create and FileInode.Setattr.
 	child.fillAttr(&out.Attr)
-	return d.NewInode(ctx, child, fs.StableAttr{Mode: syscall.S_IFDIR}), 0
+	return d.NewInode(ctx, child, d.childAttr(name, syscall.S_IFDIR)), 0
 }
 
 func (d *Dir) Unlink(ctx context.Context, name string) syscall.Errno {
@@ -249,6 +280,7 @@ func (d *Dir) Unlink(ctx context.Context, name string) syscall.Errno {
 	if err := d.MFSDir.Unlink(name); err != nil {
 		return fs.ToErrno(err)
 	}
+	d.dropChildIno(name)
 	return fs.ToErrno(d.MFSDir.Flush())
 }
 
@@ -274,6 +306,7 @@ func (d *Dir) Rmdir(ctx context.Context, name string) syscall.Errno {
 	if err := d.MFSDir.Unlink(name); err != nil {
 		return fs.ToErrno(err)
 	}
+	d.dropChildIno(name)
 	return fs.ToErrno(d.MFSDir.Flush())
 }
 
@@ -313,6 +346,15 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 	if err := targetDir.MFSDir.AddChild(newName, nd); err != nil {
 		return fs.ToErrno(err)
 	}
+
+	// Both names change identity here, so both give up their inode numbers.
+	// POSIX would keep the source's number on the destination, but the entry
+	// that lands there is a new *mfs.File: MFS marks the unlinked one as
+	// gone and silently drops writes made through it. Renumbering makes the
+	// next lookup build a node on the live entry instead of reusing the dead
+	// one, at the cost of st_ino changing across a rename.
+	d.dropChildIno(oldName)
+	targetDir.dropChildIno(newName)
 
 	return fs.ToErrno(d.MFSDir.Flush())
 }
@@ -365,7 +407,7 @@ func (d *Dir) Create(ctx context.Context, name string, flags uint32, _ uint32, o
 	// after open. Matches FileInode.Setattr and Dir.Mkdir.
 	fileInode.fillAttr(&out.Attr)
 
-	inode := d.NewInode(ctx, fileInode, fs.StableAttr{})
+	inode := d.NewInode(ctx, fileInode, d.childAttr(name, 0))
 	return inode, &FileHandle{inode: inode, fd: fd, cfg: d.Cfg}, 0, 0
 }
 
@@ -429,7 +471,7 @@ func (d *Dir) Symlink(ctx context.Context, target, name string, out *fuse.EntryO
 
 	sym := &Symlink{Target: target, MFSFile: mfsFile, Cfg: d.Cfg}
 	sym.fillAttr(&out.Attr)
-	return d.NewInode(ctx, sym, fs.StableAttr{Mode: syscall.S_IFLNK}), 0
+	return d.NewInode(ctx, sym, d.childAttr(name, syscall.S_IFLNK)), 0
 }
 
 // FileInode is the FUSE adapter for MFS file inodes.

--- a/fuse/writable/writable.go
+++ b/fuse/writable/writable.go
@@ -328,6 +328,14 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 		return fs.ToErrno(err)
 	}
 
+	// Refuse a destination we cannot write to before touching MFS. The /ipns
+	// root is not a Dir, so `mv /ipns/<key>/f /ipns/f` lands here, and
+	// unlinking the source first would delete it with nowhere to put it.
+	targetDir, ok := newParent.EmbeddedInode().Operations().(*Dir)
+	if !ok {
+		return syscall.EINVAL
+	}
+
 	// Unlink the source first. For same-directory renames, this clears
 	// the old name from the directory's entry cache before AddChild
 	// repopulates it with the new name. Without this ordering, Flush
@@ -336,10 +344,6 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 		return fs.ToErrno(err)
 	}
 
-	targetDir, ok := newParent.EmbeddedInode().Operations().(*Dir)
-	if !ok {
-		return syscall.EINVAL
-	}
 	if err := targetDir.MFSDir.Unlink(newName); err != nil && err != os.ErrNotExist {
 		return fs.ToErrno(err)
 	}


### PR DESCRIPTION


## Problem

A file on a mount from `ipfs mount` got a new inode number about once a second, as soon as the kernel re-read its directory entry. Anything tracking whether a file is still the same file reads that as a replacement: vim gives up on a save over `/mfs` with `E949: File changed while writing`, and `find` and backup tools misread the mount the same way. It is also why `fuse-tests` began failing about half the time on hosted CI runners introduced in #11426 

## Fix

- `/ipfs` numbers entries from the CID, so one piece of content is one object whichever path reaches it
- `/ipns` and `/mfs` number entries per mount, and an entry keeps its number for as long as it exists, rename included
- mount points report a number instead of `0`, `ls -i` agrees with `stat`, and the link count is `1`, not `0`

Three more fixes fell out of the same work: a `stat` of an `/ipfs` entry whose block is missing took the daemon down, `mv /ipns/<key>/f /ipns/f` deleted the file, and a cross-directory rename could be lost on shutdown.

Out of scope: using `ipfs files` on a tree while it is mounted, which `docs/config.md` now warns against. Why the numbers behave the way they do is in `fuse/writable/inodes.go`.