### PR TITLE
fix(fuse): keep what you write after a rename

### DIFF
--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -8,6 +8,7 @@
 - [🔦 Highlights](#-highlights)
   - [📁 `ipfs ls` can print readable sizes and sort by size](#-ipfs-ls-can-print-readable-sizes-and-sort-by-size)
   - [📌 Files on FUSE mounts keep their inode number](#-files-on-fuse-mounts-keep-their-inode-number)
+  - [🧹 FUSE mounts keep what you write after a rename](#-fuse-mounts-keep-what-you-write-after-a-rename)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
@@ -27,6 +28,10 @@ A file on a mount made by `ipfs mount` used to get a new inode number roughly ev
 All three mounts now hand out stable numbers. On `/ipfs` the number comes from the CID, so the same content is the same object whichever path reaches it, and the same number comes back after a remount. On `/ipns` and `/mfs` an entry keeps its number for as long as it exists, including across a rename, while a name that is deleted and created again is numbered afresh; those numbers are assigned per mount and start over on the next one. Deleting through `ipfs files` rather than through the mount is the exception: the mount does not see it, so the name keeps its old number if it comes back.
 
 Smaller fixes come with it: mount points report an inode number instead of `0`, `ls -i` agrees with `stat`, the link count is `1` rather than the `0` POSIX gives to a deleted file, and `/ipns/<key>` directories show their real permissions instead of `d---------`.
+
+#### 🧹 FUSE mounts keep what you write after a rename
+
+Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry the rename had just taken away. `mv a b` followed by a write to `b` reported success and then quietly went back to the old contents a second later. A file created in a directory that had just been renamed vanished the same way, and the directory reappeared under the name it had been moved away from.
 
 #### 📦️ Dependency updates
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -31,7 +31,9 @@ Smaller fixes come with it: mount points report an inode number instead of `0`, 
 
 #### 🧹 FUSE mounts keep what you write after a rename
 
-Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry the rename had just taken away. `mv a b` followed by a write to `b` reported success and then quietly went back to the old contents a second later. A file created in a directory that had just been renamed vanished the same way, and the directory reappeared under the name it had been moved away from.
+Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry the rename had just taken away. `mv a b` followed by a write to `b` reported success and then quietly went back to the old contents a second later. A file created in a directory that had just been renamed vanished the same way, and the directory reappeared under the name it had been moved away from. Renaming over a directory that was not empty deleted everything in it, where POSIX asks for `ENOTEMPTY`.
+
+On `/ipfs`, a listing no longer fails in its entirety when one child's block is missing, an entry in a codec the mount cannot decode reads back the block rather than refusing, and the `ipfs.cid` xattr answers with the CID from the path instead of a re-encoded form of it.
 
 #### 📦️ Dependency updates
 

--- a/fuse/fusetest/dirents_linux.go
+++ b/fuse/fusetest/dirents_linux.go
@@ -33,6 +33,7 @@ func assertDirEntryInos(t *testing.T, dir string) {
 		}
 		for b := buf[:n]; len(b) > 0; {
 			ent := (*unix.Dirent)(unsafe.Pointer(&b[0]))
+			require.NotZero(t, ent.Reclen, "a dirent of no length would never end the loop")
 			b = b[ent.Reclen:]
 
 			name := string(bytes.SplitN(unsafe.Slice((*byte)(unsafe.Pointer(&ent.Name[0])), len(ent.Name)), []byte{0}, 2)[0])

--- a/fuse/fusetest/writablesuite.go
+++ b/fuse/fusetest/writablesuite.go
@@ -541,6 +541,56 @@ func RunWritableSuite(t *testing.T, mount MountFunc) {
 		VerifyFile(t, child, []byte("rewritten"))
 	})
 
+	// A rename leaves the kernel holding the entry it moved, and that entry
+	// carries the MFS handle the rename unlinked. Writing through the new
+	// name straight away has to reach the tree; it used to be accepted and
+	// then dropped, and the file read back with its old contents once the
+	// entry cache expired.
+	t.Run("WriteAfterRename", func(t *testing.T) {
+		dir := mount(t, writable.Config{})
+
+		src := filepath.Join(dir, "before")
+		dst := filepath.Join(dir, "after")
+		require.NoError(t, os.WriteFile(src, []byte("one"), 0o644))
+		require.NoError(t, os.Rename(src, dst))
+		require.NoError(t, os.WriteFile(dst, []byte("two"), 0o644))
+
+		// Outlast the entry timeout so the kernel asks the mount again
+		// instead of answering from the node it moved.
+		time.Sleep(1500 * time.Millisecond)
+		VerifyFile(t, dst, []byte("two"))
+
+		// Same for a directory: an entry created under the new name has to
+		// land there, and the old name must not come back.
+		oldDir := filepath.Join(dir, "olddir2")
+		newDir := filepath.Join(dir, "newdir2")
+		require.NoError(t, os.Mkdir(oldDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(oldDir, "kept"), []byte("kept"), 0o644))
+		require.NoError(t, os.Rename(oldDir, newDir))
+		require.NoError(t, os.WriteFile(filepath.Join(newDir, "fresh"), []byte("fresh"), 0o644))
+
+		time.Sleep(1500 * time.Millisecond)
+		VerifyFile(t, filepath.Join(newDir, "fresh"), []byte("fresh"))
+		VerifyFile(t, filepath.Join(newDir, "kept"), []byte("kept"))
+		_, err := os.Stat(oldDir)
+		require.True(t, os.IsNotExist(err), "the name a rename moved away from must stay gone")
+
+		// And an entry the kernel had already looked up before the rename.
+		// Its handle hangs off the directory the rename replaced, a level
+		// below the entry that moved.
+		oldParent := filepath.Join(dir, "oldparent")
+		newParent := filepath.Join(dir, "newparent")
+		require.NoError(t, os.Mkdir(oldParent, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(oldParent, "child"), []byte("one"), 0o644))
+		VerifyFile(t, filepath.Join(oldParent, "child"), []byte("one")) // make the kernel hold it
+
+		require.NoError(t, os.Rename(oldParent, newParent))
+		require.NoError(t, os.WriteFile(filepath.Join(newParent, "child"), []byte("two"), 0o644))
+
+		time.Sleep(1500 * time.Millisecond)
+		VerifyFile(t, filepath.Join(newParent, "child"), []byte("two"))
+	})
+
 	// rsync default save: create temp file, write, rename over target.
 	t.Run("RsyncPattern", func(t *testing.T) {
 		dir := mount(t, writable.Config{})

--- a/fuse/fusetest/writablesuite.go
+++ b/fuse/fusetest/writablesuite.go
@@ -218,6 +218,25 @@ func RunWritableSuite(t *testing.T, mount MountFunc) {
 		require.True(t, os.IsNotExist(err))
 	})
 
+	// A rename may only replace a directory when that directory is empty.
+	// MFS removes a directory and everything under it without complaint, so
+	// the mount has to check: `mv -T src dst` used to take dst's contents
+	// with it. mv(1) does its own checking, so drive rename(2) directly.
+	t.Run("RenameOntoNonEmptyDirectory", func(t *testing.T) {
+		dir := mount(t, writable.Config{})
+		src := filepath.Join(dir, "rename_src")
+		dst := filepath.Join(dir, "rename_dst")
+		require.NoError(t, os.Mkdir(src, 0o755))
+		require.NoError(t, os.Mkdir(dst, 0o755))
+		moved := WriteFileOrFail(t, 50, filepath.Join(src, "moved"))
+		keep := WriteFileOrFail(t, 50, filepath.Join(dst, "keep"))
+
+		require.ErrorIs(t, syscall.Rename(src, dst), syscall.ENOTEMPTY)
+
+		VerifyFile(t, filepath.Join(dst, "keep"), keep)
+		VerifyFile(t, filepath.Join(src, "moved"), moved)
+	})
+
 	t.Run("RemoveNonEmptyDirectory", func(t *testing.T) {
 		dir := mount(t, writable.Config{})
 		sub := filepath.Join(dir, "nonempty")

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ipfs/boxo/mfs"
+
 	"github.com/ipfs/kubo/config"
 	"github.com/ipfs/kubo/core"
 	coreapi "github.com/ipfs/kubo/core/coreapi"
@@ -148,8 +150,15 @@ func TestRenameOntoNamespaceRoot(t *testing.T) {
 
 	require.Error(t, os.Rename(src, mnt.Dir+"/keepme"))
 
-	got, err := os.ReadFile(src)
+	// Ask MFS, not the mount. The kernel still has the entry cached, so a
+	// read through the mount answers from the handle it already holds and
+	// succeeds for a second either way, whether or not the file is still
+	// in the tree.
+	_, err := mfs.Lookup(mnt.Root.Roots[nd.Identity.String()], "/keepme")
 	require.NoError(t, err, "the file must survive a rename that could not be carried out")
+
+	got, err := os.ReadFile(src)
+	require.NoError(t, err)
 	require.Equal(t, content, got)
 }
 

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -82,7 +82,16 @@ func setupIpnsTest(t *testing.T, nd *core.IpfsNode, cfgs ...config.Mounts) (*cor
 	key, err := coreAPI.Key().Self(nd.Context())
 	require.NoError(t, err)
 
-	root, err := CreateRoot(nd.Context(), coreAPI, nd.Blockstore, map[string]iface.Key{"local": key}, "", "", nd.Repo.Path(), cfg, config.Import{})
+	// Settle the repo path before the mount starts serving. Statfs reads it
+	// from a FUSE handler goroutine, so a test that assigns it afterwards
+	// races the server. The in-memory test repo reports no path, and Statfs
+	// needs a real directory to stat.
+	repoPath := nd.Repo.Path()
+	if repoPath == "" {
+		repoPath = t.TempDir()
+	}
+
+	root, err := CreateRoot(nd.Context(), coreAPI, nd.Blockstore, map[string]iface.Key{"local": key}, "", "", repoPath, cfg, config.Import{})
 	require.NoError(t, err)
 
 	mntDir := t.TempDir()
@@ -242,11 +251,6 @@ func TestMultipleDirs(t *testing.T) {
 // files onto a volume that reports zero free space.
 func TestStatfs(t *testing.T) {
 	_, mnt := setupIpnsTest(t, nil)
-
-	// The in-memory test repo returns "" for Path(), so point RepoPath
-	// at a real directory to exercise the syscall path.
-	repoDir := t.TempDir()
-	mnt.Root.RepoPath = repoDir
 
 	fusetest.AssertStatfsNonZero(t, mnt.Dir)
 }

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -278,6 +278,10 @@ func TestLookupOfUnreadableChild(t *testing.T) {
 		require.False(t, info.IsDir())
 		require.EqualValues(t, len(child.RawData()), info.Size(),
 			"a block this mount cannot decode should report its own size")
+
+		got, err := os.ReadFile(gopath.Join(mntDir, dir, "obj"))
+		require.NoError(t, err, "a size stat reports has to be a size reads can deliver")
+		require.Equal(t, child.RawData(), got)
 	})
 
 	t.Run("missing block", func(t *testing.T) {

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -301,6 +301,44 @@ func TestLookupOfUnreadableChild(t *testing.T) {
 	})
 }
 
+// A listing has to survive one child whose block is missing. The other
+// entries are still worth having, and the caller finds out what is wrong with
+// the bad one by stat'ing it.
+func TestReaddirWithUnreadableChild(t *testing.T) {
+	offline, err := core.NewNode(t.Context(), &core.BuildCfg{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = offline.Close() })
+	_, mntDir := setupIpfsTest(t, offline)
+
+	good := dag.NodeWithData(ft.FilePBData([]byte("here"), 4))
+	gone := dag.NodeWithData(ft.FilePBData([]byte("gone"), 4))
+	// AddChild only links a node, it does not store it, and an entry whose
+	// block was never stored is missing in the same way as one that was.
+	require.NoError(t, offline.DAG.Add(t.Context(), good))
+	require.NoError(t, offline.DAG.Add(t.Context(), gone))
+
+	db, err := uio.NewDirectory(offline.DAG)
+	require.NoError(t, err)
+	require.NoError(t, db.AddChild(t.Context(), "good", good))
+	require.NoError(t, db.AddChild(t.Context(), "gone", gone))
+	dirNode, err := db.GetNode()
+	require.NoError(t, err)
+	require.NoError(t, offline.DAG.Add(t.Context(), dirNode))
+	require.NoError(t, offline.DAG.Remove(t.Context(), gone.Cid()))
+
+	entries, err := os.ReadDir(gopath.Join(mntDir, dirNode.Cid().String()))
+	require.NoError(t, err, "one missing block should not fail the whole listing")
+
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	// The unreadable name is reported with no type and no inode number, which
+	// readdirplus and Go's dirent parsing then drop; what matters is that the
+	// readable half of the directory is still there.
+	require.Contains(t, names, "good")
+}
+
 // Test reading a directory that contains both dag-pb and raw-leaf children.
 // This is the typical layout produced by `ipfs add --raw-leaves`: the
 // directory node is dag-pb, while file leaves are raw blocks.

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -45,6 +45,7 @@ import (
 	fusemnt "github.com/ipfs/kubo/fuse/mount"
 	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func testMount(t *testing.T, root fs.InodeEmbedder) string {
@@ -337,6 +338,28 @@ func TestReaddirWithUnreadableChild(t *testing.T) {
 	// readdirplus and Go's dirent parsing then drop; what matters is that the
 	// readable half of the directory is still there.
 	require.Contains(t, names, "good")
+}
+
+// The ipfs.cid xattr has to answer with the CID the caller used to get here.
+// The mount rebuilds the node by decoding the block, which loses the version
+// and codec of the path it came from.
+func TestXattrCIDMatchesPath(t *testing.T) {
+	nd, mntDir := setupIpfsTest(t, nil)
+
+	api, err := coreapi.NewCoreAPI(nd)
+	require.NoError(t, err)
+
+	added, err := api.Unixfs().Add(t.Context(),
+		files.NewBytesFile([]byte("xattr cid version")),
+		options.Unixfs.CidVersion(1),
+		options.Unixfs.RawLeaves(false))
+	require.NoError(t, err)
+	want := added.RootCid().String()
+
+	dest := make([]byte, 256)
+	sz, err := unix.Getxattr(gopath.Join(mntDir, want), fusemnt.XattrCID, dest)
+	require.NoError(t, err)
+	require.Equal(t, want, string(dest[:sz]))
 }
 
 // Test reading a directory that contains both dag-pb and raw-leaf children.
@@ -666,7 +689,7 @@ func TestXattrCID(t *testing.T) {
 
 	t.Run("file", func(t *testing.T) {
 		obj, _ := randObj(t, nd, 100)
-		node := &Node{ipfs: nd, nd: obj}
+		node := &Node{ipfs: nd, nd: obj, cid: obj.Cid()}
 
 		dest := make([]byte, 256)
 		sz, errno := node.Listxattr(t.Context(), dest)
@@ -698,7 +721,7 @@ func TestXattrCID(t *testing.T) {
 		if err := nd.DAG.Add(nd.Context(), dirNode); err != nil {
 			t.Fatal(err)
 		}
-		node := &Node{ipfs: nd, nd: dirNode}
+		node := &Node{ipfs: nd, nd: dirNode, cid: dirNode.Cid()}
 
 		dest := make([]byte, 256)
 		sz, errno := node.Listxattr(t.Context(), dest)
@@ -1028,7 +1051,7 @@ func TestUnknownXattr(t *testing.T) {
 	nd, _ := setupIpfsTest(t, nil)
 
 	obj, _ := randObj(t, nd, 100)
-	node := &Node{ipfs: nd, nd: obj}
+	node := &Node{ipfs: nd, nd: obj, cid: obj.Cid()}
 
 	dest := make([]byte, 256)
 	_, errno := node.Getxattr(t.Context(), "user.bogus", dest)

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -118,7 +118,7 @@ func (r *Root) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 		return nil, syscall.ENOENT
 	}
 
-	child := &Node{ipfs: r.ipfs, nd: fnd}
+	child := &Node{ipfs: r.ipfs, nd: fnd, cid: cidLnk.Cid}
 	stable := stableAttrFor(child, cidLnk.Cid)
 
 	// Fill attrs in the lookup response so the kernel doesn't cache zeros.
@@ -136,8 +136,13 @@ func (*Root) Readdir(_ context.Context) (fs.DirStream, syscall.Errno) {
 // Node is the core object representing a filesystem tree node.
 type Node struct {
 	fs.Inode
-	ipfs   *core.IpfsNode
-	nd     ipld.Node
+	ipfs *core.IpfsNode
+	nd   ipld.Node
+	// cid is the CID this entry resolved to. It is kept separately because
+	// nd is rebuilt by decoding the block, which loses the CID version and
+	// codec the caller asked for: a v1 dag-pb path would otherwise report
+	// its v0 form through the ipfs.cid xattr.
+	cid    cid.Cid
 	cached *ft.FSNode
 }
 
@@ -293,7 +298,7 @@ func (n *Node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs
 		return nil, syscall.EIO
 	}
 
-	child := &Node{ipfs: n.ipfs, nd: nd}
+	child := &Node{ipfs: n.ipfs, nd: nd, cid: link.Cid}
 	stable := stableAttrFor(child, link.Cid)
 
 	child.fillAttr(&out.Attr)
@@ -379,7 +384,7 @@ func (n *Node) Getxattr(_ context.Context, attr string, dest []byte) (uint32, sy
 	if attr != fusemnt.XattrCID {
 		return 0, fs.ENOATTR
 	}
-	data := []byte(n.nd.Cid().String())
+	data := []byte(n.cid.String())
 	if len(dest) == 0 {
 		return uint32(len(data)), 0
 	}

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -162,11 +162,35 @@ func (n *Node) Getattr(_ context.Context, _ fs.FileHandle, out *fuse.AttrOut) sy
 // Open creates a DagReader that is reused across sequential Read
 // calls, avoiding re-traversal of the DAG from the root on each read.
 func (n *Node) Open(ctx context.Context, _ uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	// A UnixFS directory can link to a block of any codec, and there is no
+	// DAG to walk in one that is not dag-pb. fillAttr reports those as a file
+	// the size of the block, so hand back exactly those bytes; otherwise stat
+	// promises content that every read refuses to deliver.
+	switch n.nd.(type) {
+	case *mdag.ProtoNode, *mdag.RawNode:
+	default:
+		return &rawFileHandle{data: n.nd.RawData()}, fuse.FOPEN_KEEP_CACHE, 0
+	}
+
 	r, err := uio.NewDagReader(ctx, n.nd, n.ipfs.DAG)
 	if err != nil {
 		return nil, 0, fusemnt.ReadErrno(err)
 	}
 	return &roFileHandle{r: r}, fuse.FOPEN_KEEP_CACHE, 0
+}
+
+// rawFileHandle serves a block's own bytes. Used for entries whose codec
+// carries no UnixFS metadata, where the block is all there is to read.
+type rawFileHandle struct {
+	data []byte
+}
+
+func (fh *rawFileHandle) Read(_ context.Context, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	if off < 0 || off >= int64(len(fh.data)) {
+		return fuse.ReadResultData(nil), 0
+	}
+	end := min(off+int64(len(dest)), int64(len(fh.data)))
+	return fuse.ReadResultData(fh.data[off:end]), 0
 }
 
 // roFileHandle holds a DagReader for the lifetime of an open file.

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -317,8 +317,12 @@ func (n *Node) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 		}
 		nd, err := n.ipfs.DAG.Get(ctx, lnk.Cid)
 		if err != nil {
-			log.Warn("error fetching directory child node: ", err)
-			return err
+			// Listing the rest of the directory is more use than failing all
+			// of it because one block is missing. Reporting no type leaves
+			// the entry as DT_UNKNOWN, which tells the caller to stat it.
+			log.Warnf("fuse readdir: child %q: %s", name, err)
+			entries = append(entries, fuse.DirEntry{Name: name, Ino: fusemnt.InoFromCid(lnk.Cid)})
+			return nil
 		}
 
 		var mode uint32

--- a/fuse/writable/writable.go
+++ b/fuse/writable/writable.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -108,15 +109,33 @@ func NewDir(d *mfs.Directory, cfg *Config) *Dir {
 	// The /ipns mount calls NewDir once per key, all sharing one Config, so
 	// the table has to be created once and then left alone.
 	cfg.InitInodes()
-	return &Dir{MFSDir: d, Cfg: cfg}
+	return newDir(d, cfg)
 }
 
 // Dir is the FUSE adapter for MFS directories.
+//
+// The MFS handle is held in an atomic because a rename replaces it: see
+// rebind. Reads of it are serialized by nothing else, and the FUSE server
+// dispatches every request in its own goroutine.
 type Dir struct {
 	fs.Inode
-	MFSDir *mfs.Directory
+	mfsDir atomic.Pointer[mfs.Directory]
 	Cfg    *Config
 }
+
+func newDir(md *mfs.Directory, cfg *Config) *Dir {
+	d := &Dir{Cfg: cfg}
+	d.mfsDir.Store(md)
+	return d
+}
+
+// MFSDir returns the MFS directory this node currently stands for.
+func (d *Dir) MFSDir() *mfs.Directory { return d.mfsDir.Load() }
+
+// rebind points this node at another MFS directory. A rename gives the entry
+// a new *mfs.Directory, and the node the kernel keeps has to follow it; see
+// Dir.Rename.
+func (d *Dir) rebind(md *mfs.Directory) { d.mfsDir.Store(md) }
 
 // childIno returns the inode number to report for the named entry of this
 // directory. See inodeTable for why the numbers cannot be left to go-fuse.
@@ -153,10 +172,10 @@ func (d *Dir) fillAttr(a *fuse.Attr) {
 	a.Nlink = fusemnt.Nlink
 	a.Blocks = 1
 	a.Blksize = d.Cfg.Blksize
-	if m, err := d.MFSDir.Mode(); err == nil && m != 0 {
+	if m, err := d.MFSDir().Mode(); err == nil && m != 0 {
 		a.Mode = files.ModePermsToUnixPerms(m)
 	}
-	if t, err := d.MFSDir.ModTime(); err == nil && !t.IsZero() {
+	if t, err := d.MFSDir().ModTime(); err == nil && !t.IsZero() {
 		a.SetTimes(nil, &t, nil)
 	}
 }
@@ -193,12 +212,12 @@ func (d *Dir) Statfs(_ context.Context, out *fuse.StatfsOut) syscall.Errno {
 func (d *Dir) Setattr(ctx context.Context, _ fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
 	defer d.Cfg.pinLock(ctx)()
 	if mode, ok := in.GetMode(); ok && d.Cfg.StoreMode {
-		if err := d.MFSDir.SetMode(files.UnixPermsToModePerms(mode)); err != nil {
+		if err := d.MFSDir().SetMode(files.UnixPermsToModePerms(mode)); err != nil {
 			return fs.ToErrno(err)
 		}
 	}
 	if mtime, ok := in.GetMTime(); ok && d.Cfg.StoreMtime {
-		if err := d.MFSDir.SetModTime(mtime); err != nil {
+		if err := d.MFSDir().SetModTime(mtime); err != nil {
 			return fs.ToErrno(err)
 		}
 	}
@@ -207,24 +226,24 @@ func (d *Dir) Setattr(ctx context.Context, _ fs.FileHandle, in *fuse.SetAttrIn, 
 }
 
 func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
-	mfsNode, err := d.MFSDir.Child(name)
+	mfsNode, err := d.MFSDir().Child(name)
 	if err != nil {
 		return nil, syscall.ENOENT
 	}
 
 	switch mfsNode.Type() {
 	case mfs.TDir:
-		child := &Dir{MFSDir: mfsNode.(*mfs.Directory), Cfg: d.Cfg}
+		child := newDir(mfsNode.(*mfs.Directory), d.Cfg)
 		child.fillAttr(&out.Attr)
 		return d.NewInode(ctx, child, d.childAttr(name, syscall.S_IFDIR)), 0
 	case mfs.TFile:
 		mfsFile := mfsNode.(*mfs.File)
 		if target := SymlinkTarget(mfsFile); target != "" {
-			child := &Symlink{Target: target, MFSFile: mfsFile, Cfg: d.Cfg}
+			child := newSymlink(target, mfsFile, d.Cfg)
 			child.fillAttr(&out.Attr)
 			return d.NewInode(ctx, child, d.childAttr(name, syscall.S_IFLNK)), 0
 		}
-		child := &FileInode{MFSFile: mfsFile, Cfg: d.Cfg}
+		child := newFileInode(mfsFile, d.Cfg)
 		child.fillAttr(&out.Attr)
 		return d.NewInode(ctx, child, d.childAttr(name, 0)), 0
 	default:
@@ -234,7 +253,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 }
 
 func (d *Dir) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	nodes, err := d.MFSDir.List(ctx)
+	nodes, err := d.MFSDir().List(ctx)
 	if err != nil {
 		return nil, fs.ToErrno(err)
 	}
@@ -247,7 +266,7 @@ func (d *Dir) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 			mode = syscall.S_IFDIR
 		case node.Type == int(mfs.TFile):
 			// MFS represents symlinks as TFile; check the DAG node.
-			if child, err := d.MFSDir.Child(node.Name); err == nil {
+			if child, err := d.MFSDir().Child(node.Name); err == nil {
 				if f, ok := child.(*mfs.File); ok && SymlinkTarget(f) != "" {
 					mode = syscall.S_IFLNK
 				}
@@ -271,11 +290,11 @@ func (d *Dir) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
 // Fixing this requires a boxo MFS API change.
 func (d *Dir) Mkdir(ctx context.Context, name string, _ uint32, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	defer d.Cfg.pinLock(ctx)()
-	mfsDir, err := d.MFSDir.Mkdir(name)
+	mfsDir, err := d.MFSDir().Mkdir(name)
 	if err != nil {
 		return nil, fs.ToErrno(err)
 	}
-	child := &Dir{MFSDir: mfsDir, Cfg: d.Cfg}
+	child := newDir(mfsDir, d.Cfg)
 	// Fill the response attrs so the kernel doesn't cache zero values
 	// until AttrTimeout expires. Matches Dir.Create and FileInode.Setattr.
 	child.fillAttr(&out.Attr)
@@ -284,16 +303,16 @@ func (d *Dir) Mkdir(ctx context.Context, name string, _ uint32, out *fuse.EntryO
 
 func (d *Dir) Unlink(ctx context.Context, name string) syscall.Errno {
 	defer d.Cfg.pinLock(ctx)()
-	if err := d.MFSDir.Unlink(name); err != nil {
+	if err := d.MFSDir().Unlink(name); err != nil {
 		return fs.ToErrno(err)
 	}
 	d.dropChildIno(name)
-	return fs.ToErrno(d.MFSDir.Flush())
+	return fs.ToErrno(d.MFSDir().Flush())
 }
 
 func (d *Dir) Rmdir(ctx context.Context, name string) syscall.Errno {
 	defer d.Cfg.pinLock(ctx)()
-	child, err := d.MFSDir.Child(name)
+	child, err := d.MFSDir().Child(name)
 	if err != nil {
 		return fs.ToErrno(err)
 	}
@@ -310,11 +329,11 @@ func (d *Dir) Rmdir(ctx context.Context, name string) syscall.Errno {
 		return syscall.ENOTEMPTY
 	}
 
-	if err := d.MFSDir.Unlink(name); err != nil {
+	if err := d.MFSDir().Unlink(name); err != nil {
 		return fs.ToErrno(err)
 	}
 	d.dropChildIno(name)
-	return fs.ToErrno(d.MFSDir.Flush())
+	return fs.ToErrno(d.MFSDir().Flush())
 }
 
 // Rename moves an entry across MFS directories.
@@ -325,7 +344,7 @@ func (d *Dir) Rmdir(ctx context.Context, name string) syscall.Errno {
 // semantics (boxo/mfs does not currently expose an atomic rename).
 func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbedder, newName string, _ uint32) syscall.Errno {
 	defer d.Cfg.pinLock(ctx)()
-	child, err := d.MFSDir.Child(oldName)
+	child, err := d.MFSDir().Child(oldName)
 	if err != nil {
 		return fs.ToErrno(err)
 	}
@@ -347,11 +366,11 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 	// the old name from the directory's entry cache before AddChild
 	// repopulates it with the new name. Without this ordering, Flush
 	// would sync the stale cache entry back into the DAG.
-	if err := d.MFSDir.Unlink(oldName); err != nil {
+	if err := d.MFSDir().Unlink(oldName); err != nil {
 		return fs.ToErrno(err)
 	}
 
-	if err := targetDir.MFSDir.Unlink(newName); err != nil && err != os.ErrNotExist {
+	if err := targetDir.MFSDir().Unlink(newName); err != nil && err != os.ErrNotExist {
 		return fs.ToErrno(err)
 	}
 
@@ -362,7 +381,7 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 	// a lookup racing with the rename gets ENOENT rather than either number.
 	d.moveChildIno(oldName, targetDir, newName)
 
-	if err := targetDir.MFSDir.AddChild(newName, nd); err != nil {
+	if err := targetDir.MFSDir().AddChild(newName, nd); err != nil {
 		return fs.ToErrno(err)
 	}
 
@@ -371,31 +390,81 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 	// daemon stops before something else flushes it; flushing it first means
 	// an interrupted rename leaves the entry under both names rather than
 	// under neither.
-	if targetDir.MFSDir != d.MFSDir {
-		if err := targetDir.MFSDir.Flush(); err != nil {
+	if targetDir.MFSDir() != d.MFSDir() {
+		if err := targetDir.MFSDir().Flush(); err != nil {
 			return fs.ToErrno(err)
 		}
 	}
 
-	return fs.ToErrno(d.MFSDir.Flush())
+	if err := d.MFSDir().Flush(); err != nil {
+		return fs.ToErrno(err)
+	}
+
+	// go-fuse moves the node the kernel already has to the new name once we
+	// return (rawBridge.Rename calls MvChild), and that node still holds the
+	// MFS handle unlinked above. MFS marks such a handle gone: a write
+	// through it is accepted and then dropped, and a directory flush through
+	// it re-adds the name the rename moved away from. Point the node at the
+	// entry that exists now, for as long as the kernel keeps using it.
+	rebindMovedChild(d.GetChild(oldName), targetDir, newName)
+	return 0
+}
+
+// rebindMovedChild points a renamed node at the MFS entry now living under
+// its new name. moved is the node the kernel is about to carry over, or nil
+// when it never looked the old name up and so has nothing to carry.
+func rebindMovedChild(moved *fs.Inode, targetDir *Dir, newName string) {
+	if moved == nil {
+		return
+	}
+	fresh, err := targetDir.MFSDir().Child(newName)
+	if err != nil {
+		log.Errorf("rename: reading back %q: %s", newName, err)
+		return
+	}
+	switch ops := moved.Operations().(type) {
+	case *Dir:
+		md, ok := fresh.(*mfs.Directory)
+		if !ok {
+			return
+		}
+		ops.rebind(md)
+		// Whatever the kernel looked up underneath this directory holds a
+		// handle that hangs off the one it was reached through, so a write
+		// to a file already opened under the old name would bubble up into
+		// the directory that is gone. Follow them down; the kernel only
+		// keeps what it has been asked for, so this walks a live subtree,
+		// not the whole tree.
+		for name, child := range moved.Children() {
+			rebindMovedChild(child, ops, name)
+		}
+	case *FileInode:
+		if mf, ok := fresh.(*mfs.File); ok {
+			ops.rebind(mf)
+		}
+	case *Symlink:
+		if mf, ok := fresh.(*mfs.File); ok {
+			ops.rebind(mf)
+		}
+	}
 }
 
 func (d *Dir) Create(ctx context.Context, name string, flags uint32, _ uint32, out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
 	defer d.Cfg.pinLock(ctx)()
 	node := dag.NodeWithData(ft.FilePBData(nil, 0))
-	if err := node.SetCidBuilder(d.MFSDir.GetCidBuilder()); err != nil {
+	if err := node.SetCidBuilder(d.MFSDir().GetCidBuilder()); err != nil {
 		return nil, nil, 0, fs.ToErrno(err)
 	}
 
-	if err := d.MFSDir.AddChild(name, node); err != nil {
+	if err := d.MFSDir().AddChild(name, node); err != nil {
 		return nil, nil, 0, fs.ToErrno(err)
 	}
 
-	if err := d.MFSDir.Flush(); err != nil {
+	if err := d.MFSDir().Flush(); err != nil {
 		return nil, nil, 0, fs.ToErrno(err)
 	}
 
-	mfsNode, err := d.MFSDir.Child(name)
+	mfsNode, err := d.MFSDir().Child(name)
 	if err != nil {
 		return nil, nil, 0, fs.ToErrno(err)
 	}
@@ -409,7 +478,7 @@ func (d *Dir) Create(ctx context.Context, name string, flags uint32, _ uint32, o
 	if !ok {
 		return nil, nil, 0, syscall.EIO
 	}
-	fileInode := &FileInode{MFSFile: mfsFile, Cfg: d.Cfg}
+	fileInode := newFileInode(mfsFile, d.Cfg)
 
 	accessMode := flags & syscall.O_ACCMODE
 	fd, err := mfsFile.Open(d.Cfg.openContext(), mfs.Flags{
@@ -451,7 +520,7 @@ func (d *Dir) Getxattr(_ context.Context, attr string, dest []byte) (uint32, sys
 	if attr != fusemnt.XattrCID {
 		return 0, fs.ENOATTR
 	}
-	nd, err := d.MFSDir.GetNode()
+	nd, err := d.MFSDir().GetNode()
 	if err != nil {
 		return 0, fs.ToErrno(err)
 	}
@@ -473,24 +542,24 @@ func (d *Dir) Symlink(ctx context.Context, target, name string, out *fuse.EntryO
 		return nil, fs.ToErrno(err)
 	}
 	nd := dag.NodeWithData(data)
-	if err := nd.SetCidBuilder(d.MFSDir.GetCidBuilder()); err != nil {
+	if err := nd.SetCidBuilder(d.MFSDir().GetCidBuilder()); err != nil {
 		return nil, fs.ToErrno(err)
 	}
-	if err := d.MFSDir.AddChild(name, nd); err != nil {
+	if err := d.MFSDir().AddChild(name, nd); err != nil {
 		return nil, fs.ToErrno(err)
 	}
-	if err := d.MFSDir.Flush(); err != nil {
+	if err := d.MFSDir().Flush(); err != nil {
 		return nil, fs.ToErrno(err)
 	}
 
 	// Retrieve the mfs.File so Setattr can persist mtime.
-	mfsNode, err := d.MFSDir.Child(name)
+	mfsNode, err := d.MFSDir().Child(name)
 	if err != nil {
 		return nil, fs.ToErrno(err)
 	}
 	mfsFile, _ := mfsNode.(*mfs.File)
 
-	sym := &Symlink{Target: target, MFSFile: mfsFile, Cfg: d.Cfg}
+	sym := newSymlink(target, mfsFile, d.Cfg)
 	sym.fillAttr(&out.Attr)
 	return d.NewInode(ctx, sym, d.childAttr(name, syscall.S_IFLNK)), 0
 }
@@ -498,21 +567,33 @@ func (d *Dir) Symlink(ctx context.Context, target, name string, out *fuse.EntryO
 // FileInode is the FUSE adapter for MFS file inodes.
 type FileInode struct {
 	fs.Inode
-	MFSFile *mfs.File
+	mfsFile atomic.Pointer[mfs.File]
 	Cfg     *Config
 }
 
+func newFileInode(mf *mfs.File, cfg *Config) *FileInode {
+	fi := &FileInode{Cfg: cfg}
+	fi.mfsFile.Store(mf)
+	return fi
+}
+
+// MFSFile returns the MFS file this node currently stands for.
+func (fi *FileInode) MFSFile() *mfs.File { return fi.mfsFile.Load() }
+
+// rebind points this node at another MFS file. See Dir.Rename.
+func (fi *FileInode) rebind(mf *mfs.File) { fi.mfsFile.Store(mf) }
+
 func (fi *FileInode) fillAttr(a *fuse.Attr) {
-	size, _ := fi.MFSFile.Size()
+	size, _ := fi.MFSFile().Size()
 	a.Nlink = fusemnt.Nlink
 	a.Size = uint64(size)
 	a.Blocks = fusemnt.SizeToStatBlocks(a.Size)
 	a.Blksize = fi.Cfg.Blksize
 	a.Mode = uint32(fusemnt.DefaultFileModeRW.Perm())
-	if m, err := fi.MFSFile.Mode(); err == nil && m != 0 {
+	if m, err := fi.MFSFile().Mode(); err == nil && m != 0 {
 		a.Mode = files.ModePermsToUnixPerms(m)
 	}
-	if t, _ := fi.MFSFile.ModTime(); !t.IsZero() {
+	if t, _ := fi.MFSFile().ModTime(); !t.IsZero() {
 		a.SetTimes(nil, &t, nil)
 	}
 }
@@ -535,7 +616,7 @@ func (fi *FileInode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uin
 	// snapshot of the file at open time, and writers proceed through
 	// MFS independently. Cfg.DAG is required by NewDir.
 	if accessMode == syscall.O_RDONLY {
-		nd, err := fi.MFSFile.GetNode()
+		nd, err := fi.MFSFile().GetNode()
 		if err != nil {
 			return nil, 0, fs.ToErrno(err)
 		}
@@ -551,7 +632,7 @@ func (fi *FileInode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uin
 		Write: accessMode == syscall.O_WRONLY || accessMode == syscall.O_RDWR,
 		Sync:  true,
 	}
-	fd, err := fi.MFSFile.Open(fi.Cfg.openContext(), mfsFlags)
+	fd, err := fi.MFSFile().Open(fi.Cfg.openContext(), mfsFlags)
 	if err != nil {
 		return nil, 0, fs.ToErrno(err)
 	}
@@ -570,7 +651,7 @@ func (fi *FileInode) Open(ctx context.Context, flags uint32) (fs.FileHandle, uin
 	// O_APPEND is handled in FileHandle.Write by seeking to end.
 
 	if mfsFlags.Write && fi.Cfg.StoreMtime {
-		if err := fi.MFSFile.SetModTime(time.Now()); err != nil {
+		if err := fi.MFSFile().SetModTime(time.Now()); err != nil {
 			fd.Close()
 			return nil, 0, fs.ToErrno(err)
 		}
@@ -611,7 +692,7 @@ func (fi *FileInode) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.Set
 			// desclock; the FUSE kernel timeout (30s) bounds the wait.
 			// This descriptor is transient (truncate, flush, close below),
 			// so the per-operation context bounds it.
-			fd, err := fi.MFSFile.Open(ctx, mfs.Flags{Write: true, Sync: true})
+			fd, err := fi.MFSFile().Open(ctx, mfs.Flags{Write: true, Sync: true})
 			if err != nil {
 				return fs.ToErrno(err)
 			}
@@ -629,12 +710,12 @@ func (fi *FileInode) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.Set
 		}
 	}
 	if mode, ok := in.GetMode(); ok && fi.Cfg.StoreMode {
-		if err := fi.MFSFile.SetMode(files.UnixPermsToModePerms(mode)); err != nil {
+		if err := fi.MFSFile().SetMode(files.UnixPermsToModePerms(mode)); err != nil {
 			return fs.ToErrno(err)
 		}
 	}
 	if mtime, ok := in.GetMTime(); ok && fi.Cfg.StoreMtime {
-		if err := fi.MFSFile.SetModTime(mtime); err != nil {
+		if err := fi.MFSFile().SetModTime(mtime); err != nil {
 			return fs.ToErrno(err)
 		}
 	}
@@ -663,7 +744,7 @@ func (fi *FileInode) Getxattr(_ context.Context, attr string, dest []byte) (uint
 	if attr != fusemnt.XattrCID {
 		return 0, fs.ENOATTR
 	}
-	nd, err := fi.MFSFile.GetNode()
+	nd, err := fi.MFSFile().GetNode()
 	if err != nil {
 		return 0, fs.ToErrno(err)
 	}
@@ -801,9 +882,22 @@ func (fh *FileHandle) Fsync(ctx context.Context, _ uint32) syscall.Errno {
 type Symlink struct {
 	fs.Inode
 	Target  string
-	MFSFile *mfs.File // backing MFS node for mtime persistence
+	mfsFile atomic.Pointer[mfs.File] // backing MFS node for mtime persistence
 	Cfg     *Config
 }
+
+func newSymlink(target string, mf *mfs.File, cfg *Config) *Symlink {
+	s := &Symlink{Target: target, Cfg: cfg}
+	s.mfsFile.Store(mf)
+	return s
+}
+
+// MFSFile returns the MFS file this symlink currently stands for. It is nil
+// when the entry was created without one.
+func (s *Symlink) MFSFile() *mfs.File { return s.mfsFile.Load() }
+
+// rebind points this symlink at another MFS file. See Dir.Rename.
+func (s *Symlink) rebind(mf *mfs.File) { s.mfsFile.Store(mf) }
 
 func (s *Symlink) Readlink(_ context.Context) ([]byte, syscall.Errno) {
 	return []byte(s.Target), 0
@@ -815,8 +909,8 @@ func (s *Symlink) fillAttr(a *fuse.Attr) {
 	a.Size = uint64(len(s.Target))
 	a.Blocks = fusemnt.SizeToStatBlocks(a.Size)
 	a.Blksize = s.Cfg.Blksize
-	if s.MFSFile != nil {
-		if t, err := s.MFSFile.ModTime(); err == nil && !t.IsZero() {
+	if s.MFSFile() != nil {
+		if t, err := s.MFSFile().ModTime(); err == nil && !t.IsZero() {
 			a.SetTimes(nil, &t, nil)
 		}
 	}
@@ -835,9 +929,9 @@ func (s *Symlink) Getattr(_ context.Context, _ fs.FileHandle, out *fuse.AttrOut)
 // Mode is always 0777 per POSIX convention (access control uses the
 // target's mode), so chmod requests are silently accepted but not stored.
 func (s *Symlink) Setattr(_ context.Context, _ fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
-	if s.MFSFile != nil {
+	if s.MFSFile() != nil {
 		if mtime, ok := in.GetMTime(); ok && s.Cfg.StoreMtime {
-			if err := s.MFSFile.SetModTime(mtime); err != nil {
+			if err := s.MFSFile().SetModTime(mtime); err != nil {
 				return fs.ToErrno(err)
 			}
 		}

--- a/fuse/writable/writable.go
+++ b/fuse/writable/writable.go
@@ -9,6 +9,7 @@ package writable
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -362,6 +363,24 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 		return syscall.EINVAL
 	}
 
+	// A rename may only replace a directory when that directory is empty.
+	// MFS removes a directory and everything under it without complaint, so
+	// without this `mv -T src dst` would take the whole of dst with it. The
+	// kernel refuses the mismatched pairs (a directory onto a file, a file
+	// onto a directory) before the request reaches us; it cannot know whether
+	// the destination is empty, because only MFS can answer that.
+	if dst, err := targetDir.MFSDir().Child(newName); err == nil {
+		if dstDir, ok := dst.(*mfs.Directory); ok {
+			names, err := dstDir.ListNames(ctx)
+			if err != nil {
+				return fs.ToErrno(err)
+			}
+			if len(names) > 0 {
+				return syscall.ENOTEMPTY
+			}
+		}
+	}
+
 	// Unlink the source first. For same-directory renames, this clears
 	// the old name from the directory's entry cache before AddChild
 	// repopulates it with the new name. Without this ordering, Flush
@@ -370,7 +389,7 @@ func (d *Dir) Rename(ctx context.Context, oldName string, newParent fs.InodeEmbe
 		return fs.ToErrno(err)
 	}
 
-	if err := targetDir.MFSDir().Unlink(newName); err != nil && err != os.ErrNotExist {
+	if err := targetDir.MFSDir().Unlink(newName); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fs.ToErrno(err)
 	}
 


### PR DESCRIPTION


## Problem

Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry the rename had just taken away. `mv a b` then a write to `b` returned success and went back to the old contents a second later. A file created in a directory that had just been renamed vanished the same way, and the old directory name came back for good. Renaming over a directory that was not empty deleted everything in it.

## Fix

- a rename points the node the kernel keeps at the entry that exists afterwards, and follows what was already looked up underneath it
- renaming onto a directory that is not empty returns `ENOTEMPTY`
- on `/ipfs`: one missing block no longer fails a whole listing, a block in a codec the mount cannot decode reads back instead of refusing, and the `ipfs.cid` xattr answers with the CID from the path

Out of scope: a write through a file descriptor held open across the rename still goes to the descriptor opened from the old handle, which needs an atomic rename in boxo's MFS.


> [!IMPORTANT]
> Stacks on #11429, so the base is `fix/fuse-stable-inode-numbers` until that merges. The rename bugs all reproduce on master and are not regressions from it.
> I'm going to test Stacking feature  for this too.