### PR TITLE
fix: Ipfs-Uri gateway header (IPIP-548)

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@63450206cdde85c0060f78a17c90df850bbd86d2
         with:
           output: fixtures
 
@@ -93,7 +93,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
+        uses: ipfs/gateway-conformance/.github/actions/test@63450206cdde85c0060f78a17c90df850bbd86d2
         with:
           gateway-url: http://127.0.0.1:8080
           subdomain-url: http://localhost:8080
@@ -127,7 +127,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@63450206cdde85c0060f78a17c90df850bbd86d2
         with:
           output: fixtures
 
@@ -199,7 +199,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
+        uses: ipfs/gateway-conformance/.github/actions/test@63450206cdde85c0060f78a17c90df850bbd86d2
         with:
           gateway-url: http://127.0.0.1:8092
           args: --specs "trustless-gateway,-trustless-ipns-gateway" -skip 'TestGatewayCar/GET_response_for_application/vnd.ipld.car/Header_Content-Length'

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@63450206cdde85c0060f78a17c90df850bbd86d2
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.14
         with:
           output: fixtures
 
@@ -93,7 +93,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@63450206cdde85c0060f78a17c90df850bbd86d2
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.14
         with:
           gateway-url: http://127.0.0.1:8080
           subdomain-url: http://localhost:8080
@@ -127,7 +127,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@63450206cdde85c0060f78a17c90df850bbd86d2
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.14
         with:
           output: fixtures
 
@@ -199,7 +199,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@63450206cdde85c0060f78a17c90df850bbd86d2
+        uses: ipfs/gateway-conformance/.github/actions/test@v0.14
         with:
           gateway-url: http://127.0.0.1:8092
           args: --specs "trustless-gateway,-trustless-ipns-gateway" -skip 'TestGatewayCar/GET_response_for_application/vnd.ipld.car/Header_Content-Length'

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.13
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
         with:
           output: fixtures
 
@@ -93,7 +93,7 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.13
+        uses: ipfs/gateway-conformance/.github/actions/test@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
         with:
           gateway-url: http://127.0.0.1:8080
           subdomain-url: http://localhost:8080
@@ -127,7 +127,7 @@ jobs:
     steps:
       # 1. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.13
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
         with:
           output: fixtures
 
@@ -199,7 +199,7 @@ jobs:
 
       # 9. Run the gateway-conformance tests over libp2p
       - name: Run gateway-conformance tests over libp2p
-        uses: ipfs/gateway-conformance/.github/actions/test@v0.13
+        uses: ipfs/gateway-conformance/.github/actions/test@713bb9d95f5cc5e81fa1f16a55235ecfd8fff50a
         with:
           gateway-url: http://127.0.0.1:8092
           args: --specs "trustless-gateway,-trustless-ipns-gateway" -skip 'TestGatewayCar/GET_response_for_application/vnd.ipld.car/Header_Content-Length'

--- a/config/gateway.go
+++ b/config/gateway.go
@@ -8,6 +8,7 @@ const (
 	DefaultInlineDNSLink         = false
 	DefaultDeserializedResponses = true
 	DefaultDisableHTMLErrors     = false
+	DefaultDeprecatedXIpfsPath   = false
 	DefaultExposeRoutingAPI      = true
 	DefaultDiagnosticServiceURL  = "https://check.ipfs.network"
 	DefaultAllowCodecConversion  = false
@@ -83,6 +84,13 @@ type Gateway struct {
 	// DisableHTMLErrors disables pretty HTML pages when an error occurs. Instead, a `text/plain`
 	// page will be sent with the raw error message.
 	DisableHTMLErrors Flag
+
+	// DeprecatedXIpfsPath restores the deprecated X-Ipfs-Path response
+	// header, superseded by Ipfs-Uri (IPIP-0548). Unsafe: the legacy value
+	// cannot represent every UnixFS file name, so even when enabled the
+	// header is skipped when the value would include non-ASCII byte
+	// sequences. Enable only to facilitate migration to Ipfs-Uri.
+	DeprecatedXIpfsPath Flag
 
 	// PublicGateways configures behavior of known public gateways.
 	// Each key is a fully qualified domain name (FQDN).

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -44,7 +44,11 @@ func GatewayOption(paths ...string) ServeOption {
 		}
 
 		handler := gateway.NewHandler(config, backend)
-		handler = gateway.NewHeaders(headers).ApplyCors().Wrap(handler)
+		h := gateway.NewHeaders(headers)
+		if config.DeprecatedXIpfsPath {
+			h = h.WithDeprecatedXIpfsPath()
+		}
+		handler = h.ApplyCors().Wrap(handler)
 		if fn := newServerDomainAttrFn(n); fn != nil {
 			handler = withMetricLabels(handler, fn)
 		}
@@ -74,7 +78,11 @@ func HostnameOption() ServeOption {
 
 		var handler http.Handler
 		handler = gateway.NewHostnameHandler(config, backend, childMux)
-		handler = gateway.NewHeaders(headers).ApplyCors().Wrap(handler)
+		h := gateway.NewHeaders(headers)
+		if config.DeprecatedXIpfsPath {
+			h = h.WithDeprecatedXIpfsPath()
+		}
+		handler = h.ApplyCors().Wrap(handler)
 		if fn := newServerDomainAttrFn(n); fn != nil {
 			handler = withMetricLabels(handler, fn)
 		}
@@ -384,6 +392,7 @@ func getGatewayConfig(n *core.IpfsNode) (gateway.Config, map[string][]string, er
 		DeserializedResponses:   cfg.Gateway.DeserializedResponses.WithDefault(config.DefaultDeserializedResponses),
 		AllowCodecConversion:    cfg.Gateway.AllowCodecConversion.WithDefault(config.DefaultAllowCodecConversion),
 		DisableHTMLErrors:       cfg.Gateway.DisableHTMLErrors.WithDefault(config.DefaultDisableHTMLErrors),
+		DeprecatedXIpfsPath:     cfg.Gateway.DeprecatedXIpfsPath.WithDefault(config.DefaultDeprecatedXIpfsPath),
 		NoDNSLink:               cfg.Gateway.NoDNSLink,
 		PublicGateways:          map[string]*gateway.PublicGateway{},
 		RetrievalTimeout:        cfg.Gateway.RetrievalTimeout.WithDefault(config.DefaultRetrievalTimeout),

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -478,6 +478,28 @@ This release closes several memory-exhaustion and crash issues, some of them alr
 
 ### 🔦 Highlights
 
+#### 📁 `ipfs ls` can print readable sizes and sort by size
+
+Two new flags on `ipfs ls`, both off by default. `--human` (`-H`) prints sizes in SI units such as `3.0 kB` and `2.0 MB`, matching `ipfs repo stat -H`. `--sort-size` (`-S`) lists the biggest entries first, so you can find what fills a directory without piping through `sort`. Run `ipfs ls --help` for how they combine with `--stream`, `--size`, and the JSON response.
+
+#### 📌 Files on FUSE mounts keep their inode number
+
+A file on a mount made by `ipfs mount` used to get a new inode number roughly every second, whenever the kernel dropped and re-read its directory entry. Programs that check whether a file is still the same file read that as the file being replaced under them. Saving a file on `/mfs` with vim could fail with `E949: File changed while writing`, and `pwd`, `find` and backup tools could misbehave for the same reason.
+
+All three mounts now hand out stable numbers. On `/ipfs` the number comes from the CID, so the same content is the same object whichever path reaches it, and the same number comes back after a remount. On `/ipns` and `/mfs` an entry keeps its number for as long as it exists, including across a rename, while a name that is deleted and created again is numbered afresh; those numbers are assigned per mount and start over on the next one. Deleting through `ipfs files` rather than through the mount is the exception: the mount does not see it, so the name keeps its old number if it comes back.
+
+Smaller fixes come with it: mount points report an inode number instead of `0`, `ls -i` agrees with `stat`, the link count is `1` rather than the `0` POSIX gives to a deleted file, and `/ipns/<key>` directories show their real permissions instead of `d---------`.
+
+#### 🧹 FUSE mounts keep what you write after a rename
+
+Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry the rename had just taken away. `mv a b` followed by a write to `b` reported success and then quietly went back to the old contents a second later. A file created in a directory that had just been renamed vanished the same way, and the directory reappeared under the name it had been moved away from. Renaming over a directory that was not empty deleted everything in it, where POSIX asks for `ENOTEMPTY`.
+
+On `/ipfs`, a listing no longer fails in its entirety when one child's block is missing, an entry in a codec the mount cannot decode reads back the block rather than refusing, and the `ipfs.cid` xattr answers with the CID from the path instead of a re-encoded form of it.
+
+#### 🔐 `ipfs key export` writes are owner-only
+
+`ipfs key export` now writes the key file with owner-only permissions (`0600`), including when it overwrites an existing file with looser permissions. The export goes to a temporary file renamed over the target, so a failed export leaves the previous contents intact; character devices and pipes such as `/dev/null` are streamed to directly ([#11428](https://github.com/ipfs/kubo/pull/11428)).
+
 #### 🔗 Gateway `Ipfs-Uri` header replaces `X-Ipfs-Path` (IPIP-548)
 
 Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) with a canonical [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address of the requested content path ([IPIP-548](https://github.com/ipfs/specs/pull/548)). Every path segment is percent-encoded, so the address survives any file name, including names with spaces, `%`, `#`, and non-ASCII characters.
@@ -487,6 +509,7 @@ Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/htt
 
 #### 📦️ Dependency updates
 
+- update `boxo` to [v0.42.2](https://github.com/ipfs/boxo/releases/tag/v0.42.2)
 - update `gateway-conformance` to [v0.14.0](https://github.com/ipfs/gateway-conformance/releases/tag/v0.14.0)
 
 ### 📝 Changelog

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -5,6 +5,7 @@
 This release was brought to you by the [Shipyard](https://ipshipyard.com/) team.
 
 - [v0.43.0](#v0430)
+- [v0.43.1](#v0431)
 
 ## v0.43.0
 
@@ -472,3 +473,22 @@ This release closes several memory-exhaustion and crash issues, some of them alr
 | [@web3-bot](https://github.com/web3-bot) | 2 | +5/-4 | 3 |
 | [@laciferin2024](https://github.com/laciferin2024) | 1 | +1/-1 | 1 |
 | [@aarshkshah1992](https://github.com/aarshkshah1992) | 1 | +0/-2 | 1 |
+
+## v0.43.1
+
+### 🔦 Highlights
+
+#### 🔗 Gateway `Ipfs-Uri` header replaces `X-Ipfs-Path` (IPIP-548)
+
+Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) with a canonical [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address of the requested content path ([IPIP-548](https://github.com/ipfs/specs/pull/548)). Every path segment is percent-encoded, so the address survives any file name, including names with spaces, `%`, `#`, and non-ASCII characters.
+
+> [!IMPORTANT]
+> Kubo no longer sends the deprecated `X-Ipfs-Path` header. HTTP header values cannot carry non-ASCII bytes, so a path with such a file name arrives garbled. Clients that read `X-Ipfs-Path` must migrate to `Ipfs-Uri`; decoding it back into a content path takes a single percent-decode of each path segment. Operators who need time can temporarily restore the legacy header with [`Gateway.DeprecatedXIpfsPath`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaydeprecatedxipfspath); even then Kubo omits it when the value contains bytes that cannot appear in an HTTP header.
+
+#### 📦️ Dependency updates
+
+- update `gateway-conformance` to [v0.14.0](https://github.com/ipfs/gateway-conformance/releases/tag/v0.14.0)
+
+### 📝 Changelog
+
+### 👨‍👩‍👧‍👦 Contributors

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -507,6 +507,14 @@ Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/htt
 > [!IMPORTANT]
 > Kubo no longer sends the deprecated `X-Ipfs-Path` header. HTTP header values cannot carry non-ASCII bytes, so a path with such a file name arrives garbled. Clients that read `X-Ipfs-Path` must migrate to `Ipfs-Uri`; decoding it back into a content path takes a single percent-decode of each path segment. Operators who need time can temporarily restore the legacy header with [`Gateway.DeprecatedXIpfsPath`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaydeprecatedxipfspath); even then Kubo omits it when the value contains bytes that cannot appear in an HTTP header.
 
+#### 🔄 Bitswap sees peers connected before it starts
+
+A peer that was already connected when the node started stayed invisible to Bitswap: libp2p reports only connections opened after a notifier registers, so no want request was ever sent over such a connection. Nodes with other ways to find content usually masked it; a node relying on an already-connected peer could wait forever. Fixed in [boxo v0.42.2](https://github.com/ipfs/boxo/releases/tag/v0.42.2).
+
+#### 🤫 No more background pings to HTTP providers
+
+Bitswap over HTTP no longer probes every connected HTTP provider with `GET/HEAD /ipfs/bafkqaaa` every 5 seconds for the lifetime of the process. Idle HTTP peers now generate no background traffic; latency is measured from the connection probe and from real retrieval responses instead ([boxo v0.42.2](https://github.com/ipfs/boxo/releases/tag/v0.42.2)).
+
 #### 📦️ Dependency updates
 
 - update `boxo` to [v0.42.2](https://github.com/ipfs/boxo/releases/tag/v0.42.2)

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -41,7 +41,7 @@ On `/ipfs`, a listing no longer fails in its entirety when one child's block is 
 Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) with a canonical [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address of the requested content path ([IPIP-548](https://github.com/ipfs/specs/pull/548)). Every part of the address is percent-encoded, so it stays intact for any file name, including names with spaces, `%`, `#`, or non-ASCII characters that HTTP headers cannot carry raw.
 
 > [!IMPORTANT]
-> Using `X-Ipfs-Path` is not safe when non-ASCII filenames are involved: HTTP headers cannot carry such bytes, so values arrive garbled. Kubo no longer sends it. New projects must switch to the [`Ipfs-Uri`](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) header as soon as possible; decoding it back into a content path takes a single percent-decode of each path segment.
+> Using `X-Ipfs-Path` is not safe when non-ASCII filenames are involved: HTTP headers cannot carry such bytes, so values arrive garbled. Kubo no longer sends it. New projects must switch to the [`Ipfs-Uri`](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) header as soon as possible; decoding it back into a content path takes a single percent-decode of each path segment. Operators who need time to migrate can temporarily restore the legacy header with [`Gateway.DeprecatedXIpfsPath`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaydeprecatedxipfspath); even then it is skipped when the value would include non-ASCII byte sequences.
 
 #### 📦️ Dependency updates
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -6,38 +6,12 @@
 
 - [Overview](#overview)
 - [🔦 Highlights](#-highlights)
-  - [📁 `ipfs ls` can print readable sizes and sort by size](#-ipfs-ls-can-print-readable-sizes-and-sort-by-size)
-  - [📌 Files on FUSE mounts keep their inode number](#-files-on-fuse-mounts-keep-their-inode-number)
-  - [🧹 FUSE mounts keep what you write after a rename](#-fuse-mounts-keep-what-you-write-after-a-rename)
-  - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
 
 ### Overview
 
 ### 🔦 Highlights
-
-#### 📁 `ipfs ls` can print readable sizes and sort by size
-
-Two new flags on `ipfs ls`, both off by default. `--human` (`-H`) prints sizes in SI units such as `3.0 kB` and `2.0 MB`, matching `ipfs repo stat -H`. `--sort-size` (`-S`) lists the biggest entries first, so you can find what fills a directory without piping through `sort`. Run `ipfs ls --help` for how they combine with `--stream`, `--size`, and the JSON response.
-
-#### 📌 Files on FUSE mounts keep their inode number
-
-A file on a mount made by `ipfs mount` used to get a new inode number roughly every second, whenever the kernel dropped and re-read its directory entry. Programs that check whether a file is still the same file read that as the file being replaced under them. Saving a file on `/mfs` with vim could fail with `E949: File changed while writing`, and `pwd`, `find` and backup tools could misbehave for the same reason.
-
-All three mounts now hand out stable numbers. On `/ipfs` the number comes from the CID, so the same content is the same object whichever path reaches it, and the same number comes back after a remount. On `/ipns` and `/mfs` an entry keeps its number for as long as it exists, including across a rename, while a name that is deleted and created again is numbered afresh; those numbers are assigned per mount and start over on the next one. Deleting through `ipfs files` rather than through the mount is the exception: the mount does not see it, so the name keeps its old number if it comes back.
-
-Smaller fixes come with it: mount points report an inode number instead of `0`, `ls -i` agrees with `stat`, the link count is `1` rather than the `0` POSIX gives to a deleted file, and `/ipns/<key>` directories show their real permissions instead of `d---------`.
-
-#### 🧹 FUSE mounts keep what you write after a rename
-
-Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry the rename had just taken away. `mv a b` followed by a write to `b` reported success and then quietly went back to the old contents a second later. A file created in a directory that had just been renamed vanished the same way, and the directory reappeared under the name it had been moved away from. Renaming over a directory that was not empty deleted everything in it, where POSIX asks for `ENOTEMPTY`.
-
-On `/ipfs`, a listing no longer fails in its entirety when one child's block is missing, an entry in a codec the mount cannot decode reads back the block rather than refusing, and the `ipfs.cid` xattr answers with the CID from the path instead of a re-encoded form of it.
-
-#### 📦️ Dependency updates
-
-- update `boxo` to [v0.42.2](https://github.com/ipfs/boxo/releases/tag/v0.42.2)
 
 ### 📝 Changelog
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -46,6 +46,7 @@ Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/htt
 #### 📦️ Dependency updates
 
 - update `boxo` to [v0.42.2](https://github.com/ipfs/boxo/releases/tag/v0.42.2)
+- update `gateway-conformance` to [v0.14.0](https://github.com/ipfs/gateway-conformance/releases/tag/v0.14.0)
 
 ### 📝 Changelog
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -9,7 +9,6 @@
   - [📁 `ipfs ls` can print readable sizes and sort by size](#-ipfs-ls-can-print-readable-sizes-and-sort-by-size)
   - [📌 Files on FUSE mounts keep their inode number](#-files-on-fuse-mounts-keep-their-inode-number)
   - [🧹 FUSE mounts keep what you write after a rename](#-fuse-mounts-keep-what-you-write-after-a-rename)
-  - [🔗 Gateway responses carry an Ipfs-Uri header (IPIP-548)](#-gateway-responses-carry-an-ipfs-uri-header-ipip-548)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
@@ -36,17 +35,9 @@ Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry t
 
 On `/ipfs`, a listing no longer fails in its entirety when one child's block is missing, an entry in a codec the mount cannot decode reads back the block rather than refusing, and the `ipfs.cid` xattr answers with the CID from the path instead of a re-encoded form of it.
 
-#### 🔗 Gateway responses carry an `Ipfs-Uri` header (IPIP-548)
-
-Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) with a canonical [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address of the requested content path ([IPIP-548](https://github.com/ipfs/specs/pull/548)). Every part of the address is percent-encoded, so it stays intact for any file name, including names with spaces, `%`, `#`, or non-ASCII characters that HTTP headers cannot carry raw.
-
-> [!IMPORTANT]
-> Using `X-Ipfs-Path` is not safe when non-ASCII filenames are involved: HTTP headers cannot carry such bytes, so values arrive garbled. Kubo no longer sends it. New projects must switch to the [`Ipfs-Uri`](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) header as soon as possible; decoding it back into a content path takes a single percent-decode of each path segment. Operators who need time to migrate can temporarily restore the legacy header with [`Gateway.DeprecatedXIpfsPath`](https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaydeprecatedxipfspath); even then it is skipped when the value would include non-ASCII byte sequences.
-
 #### 📦️ Dependency updates
 
 - update `boxo` to [v0.42.2](https://github.com/ipfs/boxo/releases/tag/v0.42.2)
-- update `gateway-conformance` to [v0.14.0](https://github.com/ipfs/gateway-conformance/releases/tag/v0.14.0)
 
 ### 📝 Changelog
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -9,6 +9,7 @@
   - [📁 `ipfs ls` can print readable sizes and sort by size](#-ipfs-ls-can-print-readable-sizes-and-sort-by-size)
   - [📌 Files on FUSE mounts keep their inode number](#-files-on-fuse-mounts-keep-their-inode-number)
   - [🧹 FUSE mounts keep what you write after a rename](#-fuse-mounts-keep-what-you-write-after-a-rename)
+  - [🔗 Gateway responses carry an Ipfs-Uri header (IPIP-548)](#-gateway-responses-carry-an-ipfs-uri-header-ipip-548)
   - [📦️ Dependency updates](#-dependency-updates)
 - [📝 Changelog](#-changelog)
 - [👨‍👩‍👧‍👦 Contributors](#-contributors)
@@ -34,6 +35,13 @@ Smaller fixes come with it: mount points report an inode number instead of `0`, 
 Renaming on a mounted `/mfs` or `/ipns` left the kernel writing into the entry the rename had just taken away. `mv a b` followed by a write to `b` reported success and then quietly went back to the old contents a second later. A file created in a directory that had just been renamed vanished the same way, and the directory reappeared under the name it had been moved away from. Renaming over a directory that was not empty deleted everything in it, where POSIX asks for `ENOTEMPTY`.
 
 On `/ipfs`, a listing no longer fails in its entirety when one child's block is missing, an entry in a codec the mount cannot decode reads back the block rather than refusing, and the `ipfs.cid` xattr answers with the CID from the path instead of a re-encoded form of it.
+
+#### 🔗 Gateway responses carry an `Ipfs-Uri` header (IPIP-548)
+
+Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) with a canonical [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address of the requested content path ([IPIP-548](https://github.com/ipfs/specs/pull/548)). Every part of the address is percent-encoded, so it stays intact for any file name, including names with spaces, `%`, `#`, or non-ASCII characters that HTTP headers cannot carry raw.
+
+> [!IMPORTANT]
+> Using `X-Ipfs-Path` is not safe when non-ASCII filenames are involved: HTTP headers cannot carry such bytes, so values arrive garbled. Kubo no longer sends it. New projects must switch to the [`Ipfs-Uri`](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) header as soon as possible; decoding it back into a content path takes a single percent-decode of each path segment.
 
 #### 📦️ Dependency updates
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -65,6 +65,7 @@ config file at runtime.
     - [`Gateway.NoDNSLink`](#gatewaynodnslink)
     - [`Gateway.DeserializedResponses`](#gatewaydeserializedresponses)
     - [`Gateway.AllowCodecConversion`](#gatewayallowcodecconversion)
+    - [`Gateway.DeprecatedXIpfsPath`](#gatewaydeprecatedxipfspath)
     - [`Gateway.DisableHTMLErrors`](#gatewaydisablehtmlerrors)
     - [`Gateway.ExposeRoutingAPI`](#gatewayexposeroutingapi)
     - [`Gateway.RetrievalTimeout`](#gatewayretrievaltimeout)
@@ -1305,6 +1306,27 @@ Instead of relying on gateway-side conversion, fetch the raw block using
 - Allows clients to use any codec without waiting for gateway support
 - Enables ecosystem innovation without gateway operator coordination
 - Works with libraries like [@helia/verified-fetch](https://www.npmjs.com/package/@helia/verified-fetch) in JavaScript
+
+Default: `false`
+
+Type: `flag`
+
+### `Gateway.DeprecatedXIpfsPath`
+
+An optional flag to restore the deprecated `X-Ipfs-Path` response header,
+superseded by
+[`Ipfs-Uri`](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header)
+([IPIP-548](https://github.com/ipfs/specs/pull/548)).
+
+> [!IMPORTANT]
+> Using `X-Ipfs-Path` is not safe when non-ASCII filenames are involved: HTTP
+> headers cannot carry such bytes, so values arrive garbled. Enable this flag
+> only to facilitate migration to
+> [`Ipfs-Uri`](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header),
+> which carries an [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or
+> [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address that is safe for any
+> filename. Even when enabled, the legacy header is still skipped when the
+> value would include non-ASCII byte sequences.
 
 Default: `false`
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.42.2
+	github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.49.0
 	github.com/multiformats/go-multiaddr v0.16.1

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3
+	github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.49.0
 	github.com/multiformats/go-multiaddr v0.16.1

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -268,8 +268,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.2 h1:c/lP/MQ2ChmfQ5I0JokqK53bAZuMsNjGia9sHc/RkqU=
-github.com/ipfs/boxo v0.42.2/go.mod h1:Izfi844gxRpk7VYbgtMOufY811ohXciUvdgSwd+uPuo=
+github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 h1:blr5LXnbhy+rHnOyp1XpW/kCSLiojz2ZjQH5NTZG1Qg=
+github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -268,8 +268,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 h1:blr5LXnbhy+rHnOyp1XpW/kCSLiojz2ZjQH5NTZG1Qg=
-github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
+github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96 h1:8oZfkjCQcllUpAJFRskYHZbUiaMV6SqGCc+FJIuD93M=
+github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=

--- a/docs/production/reverse-proxy.md
+++ b/docs/production/reverse-proxy.md
@@ -55,7 +55,17 @@ collector.
 TODO:
 
 * Filtering requests
-* Checking the X-IPFS-Path header in responses to filter again after resolving.
+* Checking the [Ipfs-Uri](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header)
+  header in responses to filter again after resolving.
+
+> [!IMPORTANT]
+> Using `X-Ipfs-Path` is not safe when non-ASCII filenames are involved: HTTP
+> headers cannot carry such bytes, so values arrive garbled. Kubo no longer
+> sends it. New projects must switch to the
+> [`Ipfs-Uri`](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header)
+> header, which carries an [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or
+> [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address that is safe for any
+> filename.
 
 # Subdomain Gateway
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.42.2
+	github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3
 	github.com/ipfs/go-block-format v0.2.4
 	github.com/ipfs/go-cid v0.6.2
 	github.com/ipfs/go-cidutil v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3
+	github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96
 	github.com/ipfs/go-block-format v0.2.4
 	github.com/ipfs/go-cid v0.6.2
 	github.com/ipfs/go-cidutil v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 h1:blr5LXnbhy+rHnOyp1XpW/kCSLiojz2ZjQH5NTZG1Qg=
-github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
+github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96 h1:8oZfkjCQcllUpAJFRskYHZbUiaMV6SqGCc+FJIuD93M=
+github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.2 h1:c/lP/MQ2ChmfQ5I0JokqK53bAZuMsNjGia9sHc/RkqU=
-github.com/ipfs/boxo v0.42.2/go.mod h1:Izfi844gxRpk7VYbgtMOufY811ohXciUvdgSwd+uPuo=
+github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 h1:blr5LXnbhy+rHnOyp1XpW/kCSLiojz2ZjQH5NTZG1Qg=
+github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=

--- a/test/cli/gateway_test.go
+++ b/test/cli/gateway_test.go
@@ -242,6 +242,31 @@ func TestGateway(t *testing.T) {
 		assert.Contains(t, []int{302, 301}, resp.StatusCode)
 	})
 
+	t.Run("X-Ipfs-Path returns only with Gateway.DeprecatedXIpfsPath", func(t *testing.T) {
+		t.Parallel()
+
+		node := harness.NewT(t).NewNode().Init()
+		cidStr := node.IPFSAddStr("hello legacy header", "--cid-version=1")
+		node.StartDaemon()
+
+		resp := node.GatewayClient().Get("/ipfs/" + cidStr)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Equal(t, "ipfs://"+cidStr, resp.Headers.Get("Ipfs-Uri"))
+		assert.Empty(t, resp.Headers.Get("X-Ipfs-Path"))
+
+		node.StopDaemon()
+		node.UpdateConfig(func(cfg *config.Config) {
+			cfg.Gateway.DeprecatedXIpfsPath = config.True
+		})
+		node.StartDaemon()
+		defer node.StopDaemon()
+
+		resp = node.GatewayClient().Get("/ipfs/" + cidStr)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Equal(t, "ipfs://"+cidStr, resp.Headers.Get("Ipfs-Uri"))
+		assert.Equal(t, "/ipfs/"+cidStr, resp.Headers.Get("X-Ipfs-Path"))
+	})
+
 	t.Run("POST /api/v0/version succeeds", func(t *testing.T) {
 		t.Parallel()
 		resp := node.APIClient().Post("/api/v0/version", nil)

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 // indirect
+	github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.4 // indirect
 	github.com/ipfs/go-cid v0.6.2 // indirect

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.42.2 // indirect
+	github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.4 // indirect
 	github.com/ipfs/go-cid v0.6.2 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -299,8 +299,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 h1:blr5LXnbhy+rHnOyp1XpW/kCSLiojz2ZjQH5NTZG1Qg=
-github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
+github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96 h1:8oZfkjCQcllUpAJFRskYHZbUiaMV6SqGCc+FJIuD93M=
+github.com/ipfs/boxo v0.42.3-0.20260827015437-63cae36adc96/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -299,8 +299,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.2 h1:c/lP/MQ2ChmfQ5I0JokqK53bAZuMsNjGia9sHc/RkqU=
-github.com/ipfs/boxo v0.42.2/go.mod h1:Izfi844gxRpk7VYbgtMOufY811ohXciUvdgSwd+uPuo=
+github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3 h1:blr5LXnbhy+rHnOyp1XpW/kCSLiojz2ZjQH5NTZG1Qg=
+github.com/ipfs/boxo v0.42.3-0.20260823232042-919701685bd3/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=

--- a/test/sharness/t0112-gateway-cors.sh
+++ b/test/sharness/t0112-gateway-cors.sh
@@ -41,8 +41,9 @@ test_expect_success "GET response for Gateway resource looks good" '
   test_should_contain "< Access-Control-Expose-Headers: Content-Length" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Chunked-Output" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Stream-Output" curl_output &&
-  test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
-  test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output
+  test_should_contain "< Access-Control-Expose-Headers: Ipfs-Uri" curl_output &&
+  test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output &&
+  test_should_not_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output
 '
 # HTTP OPTIONS Request
 test_expect_success "OPTIONS to Gateway succeeds" '
@@ -64,8 +65,9 @@ test_expect_success "OPTIONS response for Gateway resource looks good" '
   test_should_contain "< Access-Control-Expose-Headers: Content-Length" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Chunked-Output" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Stream-Output" curl_output &&
-  test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
-  test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output
+  test_should_contain "< Access-Control-Expose-Headers: Ipfs-Uri" curl_output &&
+  test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output &&
+  test_should_not_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output
 '
 
 # HTTP OPTIONS Request on path → subdomain HTTP 301 redirect
@@ -104,8 +106,9 @@ test_expect_success "Access-Control-Allow-Headers extends the implicit list" '
   test_should_contain "< Access-Control-Allow-Headers: X-Custom1" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: Content-Range" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: Content-Length" curl_output &&
-  test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
+  test_should_contain "< Access-Control-Expose-Headers: Ipfs-Uri" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output &&
+  test_should_not_contain "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
   test_should_contain "< Access-Control-Expose-Headers: X-Custom2" curl_output
 '
 


### PR DESCRIPTION
## Problem

Legacy`X-Ipfs-Path` cannot carry every UnixFS file name: bytes outside visible ASCII are invalid in HTTP field values[^1], so names like `łódź.txt` reached clients garbled. ipfs/specs#548 deprecates it in favor of `Ipfs-Uri`, a percent-encoded `ipfs://` / `ipns://` address that survives any name.

## Fix

- bump boxo to ipfs/boxo#1209: gateway responses carry the canonical `Ipfs-Uri` header, and `X-Ipfs-Path` is no longer sent
- new opt-in `Gateway.DeprecatedXIpfsPath` restores the legacy header to ease migration; even then it is skipped when the value would include non-ASCII byte sequences
- CI runs the IPIP-548 conformance tests (ipfs/gateway-conformance#301) until a release ships; sharness CORS expectations updated to match
- v0.43.1 changelog, `docs/config.md`, and the reverse-proxy doc explain the migration

Draft until boxo cuts a release with ipfs/boxo#1209; the temporary `go.mod` pin then becomes a normal version bump.

[^1]: [RFC 9110, section 5.5](https://httpwg.org/specs/rfc9110.html#fields.values): field values are limited to HTAB, SP, and visible ASCII.