### PR TITLE
fix: daemon exit on RPC shutdown with --enable-gc

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -1308,7 +1308,16 @@ func maybeRunGC(req *cmds.Request, node *core.IpfsNode) (<-chan error, error) {
 
 	errc := make(chan error)
 	go func() {
-		errc <- corerepo.PeriodicGC(req.Context, node)
+		// Stop the GC loop on either context. The RPC "ipfs shutdown"
+		// command closes the node without cancelling req.Context, while
+		// node.Context() ends only after the OnStop hooks ran, so
+		// req.Context is what aborts an in-flight sweep on a signal
+		// before the datastore closes.
+		ctx, cancel := context.WithCancel(req.Context)
+		defer cancel()
+		stop := context.AfterFunc(node.Context(), cancel)
+		defer stop()
+		errc <- corerepo.PeriodicGC(ctx, node)
 		close(errc)
 	}()
 	return errc, nil

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -502,6 +502,10 @@ On `/ipfs`, a listing no longer fails in its entirety when one child's block is 
 
 `ipfs key export` now writes the key file with owner-only permissions (`0600`), including when it overwrites an existing file with looser permissions. The export goes to a temporary file renamed over the target, so a failed export leaves the previous contents intact; character devices and pipes such as `/dev/null` are streamed to directly ([#11428](https://github.com/ipfs/kubo/pull/11428)).
 
+#### 🛑 `ipfs shutdown` exits a daemon started with `--enable-gc`
+
+A daemon started with `--enable-gc` closed its repo on `ipfs shutdown` (`POST /api/v0/shutdown`) but the process never exited, because the periodic garbage collection loop only stopped on a signal. Supervisors that stop Kubo over the RPC API waited forever. The loop now also stops when the node closes; `SIGINT` and `SIGTERM` behave as before ([#11424](https://github.com/ipfs/kubo/issues/11424)).
+
 #### 🔗 Gateway `Ipfs-Uri` header replaces `X-Ipfs-Path` (IPIP-548)
 
 Gateway responses now include an [`Ipfs-Uri` header](https://specs.ipfs.tech/http-gateways/path-gateway/#ipfs-uri-response-header) with a canonical [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) or [`ipns://`](https://specs.ipfs.tech/ipns-uri/) address of the requested content path ([IPIP-548](https://github.com/ipfs/specs/pull/548)). Every path segment is percent-encoded, so the address survives any file name, including names with spaces, `%`, `#`, and non-ASCII characters.

--- a/test/cli/daemon_rpc_shutdown_test.go
+++ b/test/cli/daemon_rpc_shutdown_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// rpcShutdownExitBound is how long the daemon process may take to exit after
+// "ipfs shutdown" returns. A clean shutdown finishes in a few seconds; hitting
+// this bound means the daemon wedged after closing the node.
+const rpcShutdownExitBound = 15 * time.Second
+
+// TestDaemonRPCShutdown covers supervisors that stop the daemon over the RPC
+// API ("ipfs shutdown") instead of sending a signal. The process must exit on
+// its own. The harness StopDaemon sends SIGTERM, which would hide a hang, so
+// the assertion waits on the process directly.
+func TestDaemonRPCShutdown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "without gc", args: nil},
+		{name: "with --enable-gc", args: []string{"--enable-gc"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			node := harness.NewT(t).NewNode().Init()
+			node.StartDaemon(tc.args...)
+
+			type waitResult struct {
+				state *os.ProcessState
+				err   error
+			}
+			exited := make(chan waitResult, 1)
+			go func() {
+				state, err := node.Daemon.Cmd.Process.Wait()
+				exited <- waitResult{state, err}
+			}()
+
+			node.IPFS("shutdown")
+
+			select {
+			case res := <-exited:
+				require.NoError(t, res.err)
+				require.True(t, res.state.Success(), "daemon exited with %s", res.state)
+			case <-time.After(rpcShutdownExitBound):
+				// Kill so the harness cleanup does not wait on a wedged daemon.
+				_ = node.Daemon.Cmd.Process.Kill()
+				t.Fatalf("daemon did not exit within %s after RPC shutdown", rpcShutdownExitBound)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A daemon started with `--enable-gc` answered `ipfs shutdown` (`POST /api/v0/shutdown`) by closing the node and then never exited: the periodic GC loop waited on the command's request context, which only a signal cancels, so `daemonFunc` never finished draining its error channels. Supervisors that stop Kubo over the RPC API waited on the process forever, and `Internal.ShutdownTimeout` could not help because its watchdog arms only after that drain. Present since #1495.

## Fix

- derive the GC context from `req.Context` and cancel it when `node.Context()` ends too, so the loop stops on node close; a signal still aborts an in-flight sweep before the OnStop hooks close the datastore (rationale in `maybeRunGC`)
- `TestDaemonRPCShutdown` stops a daemon over RPC, with and without `--enable-gc`, and waits on the process; the harness `StopDaemon` sends SIGTERM and would have hidden this

Out of scope: on the RPC path a running sweep still overlaps `app.Stop` until the node context ends, and the shutdown watchdog still does not cover the RPC path.

- Closes #11424 cc @Rinse12