### PR TITLE
test(fuse): mark mkdir as a test helper

### DIFF
--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func mkdir(t *testing.T, path string) {
+	t.Helper()
 	err := os.Mkdir(path, os.ModeDir|os.ModePerm)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!--
Please update docs/changelogs/ if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


The FUSE test `mkdir` helper currently reports setup failures from inside the shared helper. Marking it with `t.Helper()` attributes those failures to the calling test line instead, while leaving the filesystem operation and error handling unchanged.

Validated with `go test ./fuse/node -run TestExternalUnmount -count=1`. No changelog entry is needed because this only improves test diagnostics.