### PR TITLE
fix: empty Bootstrap list no longer dials stale backup peers

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,9 +22,11 @@ import (
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
 	routinghelpers "github.com/libp2p/go-libp2p-routing-helpers"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pstore "github.com/libp2p/go-libp2p/core/peerstore"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitialization(t *testing.T) {
@@ -228,84 +231,45 @@ func TestHasActiveDHTClient(t *testing.T) {
 	})
 }
 
-// TestBootstrapWithEmptyPeerListAndStaleBackupPeers is a kubo-level regression
-// test for https://github.com/ipfs/kubo/issues/11452: when no bootstrap peers
-// are configured, the bootstrap process must not dial stale backup peers
-// persisted from previous runs under TempBootstrapPeersKey.
-//
-// The dialing behavior itself is fixed and unit-tested in boxo
-// (bootstrap.bootstrapRound skips the backup list when BootstrapPeers() is
-// empty). This test verifies the kubo wiring end to end: IpfsNode.Bootstrap
-// runs without error with an empty Bootstrap config and a populated
-// TempBootstrapPeersKey, and starts a bootstrapper (the periodic process runs,
-// but each round is a no-op for the backup list).
-func TestBootstrapWithEmptyPeerListAndStaleBackupPeers(t *testing.T) {
-	ctx := context.Background()
+// TestBootstrapEmptyListSkipsBackupPeers covers the Bootstrap: null config
+// path. A node that once ran with bootstrap peers keeps a backup peer list
+// under TempBootstrapPeersKey; with the configured list now empty, that
+// backup list must not be dialed. See https://github.com/ipfs/kubo/issues/11452
+func TestBootstrapEmptyListSkipsBackupPeers(t *testing.T) {
+	ctx := t.Context()
+
+	mn := mocknet.New()
+	t.Cleanup(func() { _ = mn.Close() })
+	h, err := mn.GenPeer()
+	require.NoError(t, err)
+	backup, err := mn.GenPeer()
+	require.NoError(t, err)
+	require.NoError(t, mn.LinkAll())
 
 	ds := syncds.MutexWrap(datastore.NewMapDatastore())
+	saved := []peer.AddrInfo{{ID: backup.ID(), Addrs: backup.Addrs()}}
+	savedBytes, err := json.Marshal(config.BootstrapPeerStrings(saved))
+	require.NoError(t, err)
+	require.NoError(t, ds.Put(ctx, TempBootstrapPeersKey, savedBytes))
 
-	// Seed the datastore with stale backup peers, as if left over from a
-	// previous run that had bootstrap peers configured. These are the peers
-	// that were dialed every 30s in the original bug. We write the JSON
-	// []string form that saveTempBootstrapPeers produces.
-	staleBytes := []byte(`["/dns4/bootstrap.libp2p.io/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN","/dns4/ams-1.routing.cloudflare.ipfs.team/tcp/443/https/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"]`)
-	if err := ds.Put(ctx, TempBootstrapPeersKey, staleBytes); err != nil {
-		t.Fatalf("failed to seed stale backup peers: %v", err)
-	}
-
-	c := config.Config{}
-	c.Identity = testIdentity
-	c.Bootstrap = nil // no bootstrap peers configured
-	c.Routing.Type = config.NewOptionalString("none")
-
-	r := &repo.Mock{
-		C: c,
-		D: ds,
-	}
-
-	// IpfsNode.Bootstrap calls bootstrap.Bootstrap, which needs a real host.
-	h, err := golib.New(golib.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
-	if err != nil {
-		t.Fatalf("failed to create libp2p host: %v", err)
-	}
-	t.Cleanup(func() { _ = h.Close() })
-
-	peerID, err := peer.Decode(testIdentity.PeerID)
-	if err != nil {
-		t.Fatalf("failed to decode peer ID: %v", err)
-	}
+	c := config.Config{Identity: testIdentity}
+	c.Bootstrap = nil
+	c.AutoConf.Enabled = config.False
 
 	node := &IpfsNode{
-		Identity: peerID,
+		Identity: h.ID(),
 		PeerHost: h,
 		Routing: routinghelpers.NewComposableParallel([]*routinghelpers.ParallelRouter{
 			{Router: routinghelpers.Null{}, IgnoreError: true},
 		}),
-		Repo: r,
+		Repo: &repo.Mock{C: c, D: ds},
 	}
 
-	// Explicitly pass an empty bootstrap peer function so loadBootstrapPeers
-	// (which would consult config) is not used; we want the empty-list path.
-	// BootstrapConfigWithPeers gives us sane defaults (Period, etc.).
-	cfg := bootstrap.BootstrapConfigWithPeers(nil)
-	cfg.BootstrapPeers = func() []peer.AddrInfo { return nil }
-	if err := node.Bootstrap(cfg); err != nil {
-		t.Fatalf("Bootstrap returned error with empty peer list and stale backup peers: %v", err)
-	}
-	if node.Bootstrapper == nil {
-		t.Fatal("Bootstrapper should be set (the periodic process runs; rounds are no-ops for the backup list)")
-	}
+	// BootstrapPeers is left nil so the (empty) list is read from config.
+	require.NoError(t, node.Bootstrap(bootstrap.DefaultBootstrapConfig))
 	t.Cleanup(func() { _ = node.Bootstrapper.Close() })
 
-	// The stale backup peers must still be present in the datastore (we did
-	// not dial them, and the save process only runs after the first round
-	// completes and only saves currently-connected peers, of which there are
-	// none). This confirms we did not corrupt or clear the key.
-	got, err := ds.Get(ctx, TempBootstrapPeersKey)
-	if err != nil {
-		t.Fatalf("TempBootstrapPeersKey missing after Bootstrap: %v", err)
-	}
-	if string(got) != string(staleBytes) {
-		t.Errorf("TempBootstrapPeersKey modified by Bootstrap: got %q, want %q", string(got), string(staleBytes))
-	}
+	// Bootstrap returns after the first round has run.
+	require.Equal(t, network.NotConnected, h.Network().Connectedness(backup.ID()),
+		"backup peer was dialed although no bootstrap peers are configured")
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ipfs/kubo/repo"
 
+	"github.com/ipfs/boxo/bootstrap"
 	"github.com/ipfs/boxo/filestore"
 	"github.com/ipfs/boxo/keystore"
 	datastore "github.com/ipfs/go-datastore"
@@ -225,4 +226,86 @@ func TestHasActiveDHTClient(t *testing.T) {
 			t.Error("Expected true for valid accelerated DHT client")
 		}
 	})
+}
+
+// TestBootstrapWithEmptyPeerListAndStaleBackupPeers is a kubo-level regression
+// test for https://github.com/ipfs/kubo/issues/11452: when no bootstrap peers
+// are configured, the bootstrap process must not dial stale backup peers
+// persisted from previous runs under TempBootstrapPeersKey.
+//
+// The dialing behavior itself is fixed and unit-tested in boxo
+// (bootstrap.bootstrapRound skips the backup list when BootstrapPeers() is
+// empty). This test verifies the kubo wiring end to end: IpfsNode.Bootstrap
+// runs without error with an empty Bootstrap config and a populated
+// TempBootstrapPeersKey, and starts a bootstrapper (the periodic process runs,
+// but each round is a no-op for the backup list).
+func TestBootstrapWithEmptyPeerListAndStaleBackupPeers(t *testing.T) {
+	ctx := context.Background()
+
+	ds := syncds.MutexWrap(datastore.NewMapDatastore())
+
+	// Seed the datastore with stale backup peers, as if left over from a
+	// previous run that had bootstrap peers configured. These are the peers
+	// that were dialed every 30s in the original bug. We write the JSON
+	// []string form that saveTempBootstrapPeers produces.
+	staleBytes := []byte(`["/dns4/bootstrap.libp2p.io/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN","/dns4/ams-1.routing.cloudflare.ipfs.team/tcp/443/https/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"]`)
+	if err := ds.Put(ctx, TempBootstrapPeersKey, staleBytes); err != nil {
+		t.Fatalf("failed to seed stale backup peers: %v", err)
+	}
+
+	c := config.Config{}
+	c.Identity = testIdentity
+	c.Bootstrap = nil // no bootstrap peers configured
+	c.Routing.Type = config.NewOptionalString("none")
+
+	r := &repo.Mock{
+		C: c,
+		D: ds,
+	}
+
+	// IpfsNode.Bootstrap calls bootstrap.Bootstrap, which needs a real host.
+	h, err := golib.New(golib.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	if err != nil {
+		t.Fatalf("failed to create libp2p host: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Close() })
+
+	peerID, err := peer.Decode(testIdentity.PeerID)
+	if err != nil {
+		t.Fatalf("failed to decode peer ID: %v", err)
+	}
+
+	node := &IpfsNode{
+		Identity: peerID,
+		PeerHost: h,
+		Routing: routinghelpers.NewComposableParallel([]*routinghelpers.ParallelRouter{
+			{Router: routinghelpers.Null{}, IgnoreError: true},
+		}),
+		Repo: r,
+	}
+
+	// Explicitly pass an empty bootstrap peer function so loadBootstrapPeers
+	// (which would consult config) is not used; we want the empty-list path.
+	// BootstrapConfigWithPeers gives us sane defaults (Period, etc.).
+	cfg := bootstrap.BootstrapConfigWithPeers(nil)
+	cfg.BootstrapPeers = func() []peer.AddrInfo { return nil }
+	if err := node.Bootstrap(cfg); err != nil {
+		t.Fatalf("Bootstrap returned error with empty peer list and stale backup peers: %v", err)
+	}
+	if node.Bootstrapper == nil {
+		t.Fatal("Bootstrapper should be set (the periodic process runs; rounds are no-ops for the backup list)")
+	}
+	t.Cleanup(func() { _ = node.Bootstrapper.Close() })
+
+	// The stale backup peers must still be present in the datastore (we did
+	// not dial them, and the save process only runs after the first round
+	// completes and only saves currently-connected peers, of which there are
+	// none). This confirms we did not corrupt or clear the key.
+	got, err := ds.Get(ctx, TempBootstrapPeersKey)
+	if err != nil {
+		t.Fatalf("TempBootstrapPeersKey missing after Bootstrap: %v", err)
+	}
+	if string(got) != string(staleBytes) {
+		t.Errorf("TempBootstrapPeersKey modified by Bootstrap: got %q, want %q", string(got), string(staleBytes))
+	}
 }

--- a/docs/changelogs/v0.43.md
+++ b/docs/changelogs/v0.43.md
@@ -480,6 +480,14 @@ This release closes several memory-exhaustion and crash issues, some of them alr
 
 ### 🔦 Highlights
 
+#### 🔇 Empty `Bootstrap` list disables all bootstrap dialing
+
+Setting `Bootstrap` to `[]` now stops the node from dialing bootstrap peers of any kind, including the backup peers it saved from earlier runs. Until now, a node that had once run with the default bootstrappers kept dialing those saved peers every 30 seconds, even with an empty list and `Routing.Type=none`.
+
+The result is a node that connects only to peers you chose: [`Peering.Peers`](https://github.com/ipfs/kubo/blob/master/docs/config.md#peeringpeers), `ipfs swarm connect`, and peers found on the local network through [mDNS](https://github.com/ipfs/kubo/blob/master/docs/config.md#discoverymdnsenabled). For no outbound traffic at all, also set [`Routing.Type`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingtype) to `none` and disable [`AutoConf`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autoconfenabled).
+
+Backup peers still work when `Bootstrap` has at least one entry: the node dials the configured peers first and falls back to saved peers only while it stays below the minimum peer count.
+
 #### 📁 `ipfs ls` can print readable sizes and sort by size
 
 Two new flags on `ipfs ls`, both off by default. `--human` (`-H`) prints sizes in SI units such as `3.0 kB` and `2.0 MB`, matching `ipfs repo stat -H`. `--sort-size` (`-S`) lists the biggest entries first, so you can find what fills a directory without piping through `sort`. Run `ipfs ls --help` for how they combine with `--stream`, `--size`, and the JSON response.
@@ -529,7 +537,7 @@ For writers that need `Data`-first output (streaming readers can then parse HAMT
 
 #### 📦️ Dependency updates
 
-- update `boxo` to [v0.42.3-0.20260904132258-02026ddcf262](https://github.com/ipfs/boxo/commit/02026ddcf262) (includes [ipfs/boxo#1212](https://github.com/ipfs/boxo/pull/1212)) <!-- TODO: switch to a tagged boxo release before kubo v0.43.1 is tagged -->
+- update `boxo` to [v0.42.3-0.20260907225511-2edf737db3aa](https://github.com/ipfs/boxo/commit/2edf737db3aa) (includes [ipfs/boxo#1212](https://github.com/ipfs/boxo/pull/1212) and [ipfs/boxo#1213](https://github.com/ipfs/boxo/pull/1213)) <!-- TODO: switch to a tagged boxo release before kubo v0.43.1 is tagged -->
 - update `go-libp2p-kad-dht` to [v0.42.2](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.42.2)
 - update `gateway-conformance` to [v0.14.1](https://github.com/ipfs/gateway-conformance/releases/tag/v0.14.1)
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -15,7 +15,11 @@
 
 #### Empty `Bootstrap` list disables all bootstrap dialing
 
-An empty `Bootstrap` list now turns off all bootstrap dialing, including backup peers saved from earlier runs. `Peering.Peers` and mDNS are separate settings and still dial.
+Setting `Bootstrap` to `[]` now stops the node from dialing bootstrap peers of any kind, including the backup peers it saved from earlier runs. Until now, a node that had once run with the default bootstrappers kept dialing those saved peers every 30 seconds, even with an empty list and `Routing.Type=none`.
+
+The result is a node that connects only to peers you chose: [`Peering.Peers`](https://github.com/ipfs/kubo/blob/master/docs/config.md#peeringpeers), `ipfs swarm connect`, and peers found on the local network through [mDNS](https://github.com/ipfs/kubo/blob/master/docs/config.md#discoverymdnsenabled). For no outbound traffic at all, also set [`Routing.Type`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingtype) to `none` and disable [`AutoConf`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autoconfenabled).
+
+Backup peers still work when `Bootstrap` has at least one entry: the node dials the configured peers first and falls back to saved peers only while it stays below the minimum peer count.
 
 #### 📦️ Dependency updates
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -15,7 +15,7 @@
 
 #### Empty `Bootstrap` list disables all bootstrap dialing
 
-An empty `Bootstrap` list now fully disables the bootstrap process. Previously, even with no bootstrap peers configured, the node still loaded backup peers persisted from previous runs and dialed them every 30 seconds, causing unwanted external DNS resolution and connection attempts. This affected users who explicitly disabled routing (for example `Routing.Type=none` or `ipfs daemon --routing=none`) to run a local-only/offline node. With this change, no configured bootstrap peers means nothing to recover from, so the backup list is not consulted. Nodes that configure explicit `Bootstrap` peers are unaffected; `Peering.Peers` and mDNS are independent of `Bootstrap` and may still dial peers.
+An empty `Bootstrap` list now turns off all bootstrap dialing, including backup peers saved from earlier runs. `Peering.Peers` and mDNS are separate settings and still dial.
 
 #### 📦️ Dependency updates
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -13,14 +13,6 @@
 
 ### 🔦 Highlights
 
-#### Empty `Bootstrap` list disables all bootstrap dialing
-
-Setting `Bootstrap` to `[]` now stops the node from dialing bootstrap peers of any kind, including the backup peers it saved from earlier runs. Until now, a node that had once run with the default bootstrappers kept dialing those saved peers every 30 seconds, even with an empty list and `Routing.Type=none`.
-
-The result is a node that connects only to peers you chose: [`Peering.Peers`](https://github.com/ipfs/kubo/blob/master/docs/config.md#peeringpeers), `ipfs swarm connect`, and peers found on the local network through [mDNS](https://github.com/ipfs/kubo/blob/master/docs/config.md#discoverymdnsenabled). For no outbound traffic at all, also set [`Routing.Type`](https://github.com/ipfs/kubo/blob/master/docs/config.md#routingtype) to `none` and disable [`AutoConf`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autoconfenabled).
-
-Backup peers still work when `Bootstrap` has at least one entry: the node dials the configured peers first and falls back to saved peers only while it stays below the minimum peer count.
-
 #### 📦️ Dependency updates
 
 - update `go-ds-pebble` to [v0.5.13](https://github.com/ipfs/go-ds-pebble/releases/tag/v0.5.13)

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -13,6 +13,10 @@
 
 ### 🔦 Highlights
 
+#### Empty `Bootstrap` list disables all bootstrap dialing
+
+An empty `Bootstrap` list now fully disables the bootstrap process. Previously, even with no bootstrap peers configured, the node still loaded backup peers persisted from previous runs and dialed them every 30 seconds, causing unwanted external DNS resolution and connection attempts. This affected users who explicitly disabled routing (for example `Routing.Type=none` or `ipfs daemon --routing=none`) to run a local-only/offline node. With this change, no configured bootstrap peers means nothing to recover from, so the backup list is not consulted. Nodes that configure explicit `Bootstrap` peers are unaffected; `Peering.Peers` and mDNS are independent of `Bootstrap` and may still dial peers.
+
 #### 📦️ Dependency updates
 
 - update `go-ds-pebble` to [v0.5.13](https://github.com/ipfs/go-ds-pebble/releases/tag/v0.5.13)

--- a/docs/config.md
+++ b/docs/config.md
@@ -919,6 +919,8 @@ The special value `"auto"` automatically uses curated, up-to-date bootstrap peer
 - **Automatic updates**: New bootstrap peers are added as the network evolves
 - **Custom control**: Add your own trusted peers alongside or instead of the defaults
 
+An empty list disables all bootstrap dialing, including saved backup peers from previous runs. This is the way to make a node fully local-only/offline (for example together with `Routing.Type=none` or `ipfs daemon --routing=none`): no configured bootstrap peers means nothing to recover from, so the backup list is not consulted. Note that `Peering.Peers` and mDNS are independent of `Bootstrap` and may still dial peers.
+
 Default: `["auto"]`
 
 Type: `array[string]` ([multiaddrs][multiaddr] or `"auto"`)

--- a/docs/config.md
+++ b/docs/config.md
@@ -919,7 +919,7 @@ The special value `"auto"` automatically uses curated, up-to-date bootstrap peer
 - **Automatic updates**: New bootstrap peers are added as the network evolves
 - **Custom control**: Add your own trusted peers alongside or instead of the defaults
 
-An empty list disables all bootstrap dialing, including saved backup peers from previous runs. This is the way to make a node fully local-only/offline (for example together with `Routing.Type=none` or `ipfs daemon --routing=none`): no configured bootstrap peers means nothing to recover from, so the backup list is not consulted. Note that `Peering.Peers` and mDNS are independent of `Bootstrap` and may still dial peers.
+An empty list turns off all bootstrap dialing, including backup peers saved from earlier runs. `Peering.Peers` and mDNS are separate and still dial.
 
 Default: `["auto"]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -919,7 +919,7 @@ The special value `"auto"` automatically uses curated, up-to-date bootstrap peer
 - **Automatic updates**: New bootstrap peers are added as the network evolves
 - **Custom control**: Add your own trusted peers alongside or instead of the defaults
 
-An empty list turns off all bootstrap dialing, including backup peers saved from earlier runs. `Peering.Peers` and mDNS are separate and still dial.
+An empty list turns off all bootstrap dialing, including backup peers saved from earlier runs. The node then connects only to `Peering.Peers`, peers found through mDNS, and peers you connect manually. Backup peers are dialed only after the configured peers, when those leave the node below the minimum peer count.
 
 Default: `["auto"]`
 

--- a/docs/examples/kubo-as-a-library/go.mod
+++ b/docs/examples/kubo-as-a-library/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 replace github.com/ipfs/kubo => ./../../..
 
 require (
-	github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262
+	github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa
 	github.com/ipfs/kubo v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.49.0
 	github.com/multiformats/go-multiaddr v0.16.1

--- a/docs/examples/kubo-as-a-library/go.sum
+++ b/docs/examples/kubo-as-a-library/go.sum
@@ -268,8 +268,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262 h1:ccv4Wuz0qtHE52U0r4r2+NpnFbPYJp8riL6vTX6i3ic=
-github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
+github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa h1:VoLDM25b+1HvjfJ8SpfHAECK457CqJpU2u4nT0XCLf4=
+github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=

--- a/go.mod
+++ b/go.mod
@@ -277,3 +277,5 @@ exclude (
 	github.com/ipfs/go-ipfs-cmds v2.0.1+incompatible
 	github.com/libp2p/go-libp2p v6.0.23+incompatible
 )
+
+replace github.com/ipfs/boxo => github.com/karawitan/boxo v0.42.3-0.20260907071254-76cf61a1f633

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/ipfs-shipyard/nopfs v0.0.14
 	github.com/ipfs-shipyard/nopfs/ipfs v0.25.0
-	github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262
+	github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa
 	github.com/ipfs/go-block-format v0.2.4
 	github.com/ipfs/go-cid v0.6.2
 	github.com/ipfs/go-cidutil v0.1.2
@@ -277,5 +277,3 @@ exclude (
 	github.com/ipfs/go-ipfs-cmds v2.0.1+incompatible
 	github.com/libp2p/go-libp2p v6.0.23+incompatible
 )
-
-replace github.com/ipfs/boxo => github.com/karawitan/boxo v0.42.3-0.20260907201906-df6852a09b58

--- a/go.mod
+++ b/go.mod
@@ -278,4 +278,4 @@ exclude (
 	github.com/libp2p/go-libp2p v6.0.23+incompatible
 )
 
-replace github.com/ipfs/boxo => github.com/karawitan/boxo v0.42.3-0.20260907071254-76cf61a1f633
+replace github.com/ipfs/boxo => github.com/karawitan/boxo v0.42.3-0.20260907201906-df6852a09b58

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,6 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262 h1:ccv4Wuz0qtHE52U0r4r2+NpnFbPYJp8riL6vTX6i3ic=
-github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -441,6 +439,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
+github.com/karawitan/boxo v0.42.3-0.20260907071254-76cf61a1f633 h1:NcN03Kibfy8T3ivuyUtW7xwIXVRNjT9h70QSmKfXyE4=
+github.com/karawitan/boxo v0.42.3-0.20260907071254-76cf61a1f633/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.sum
+++ b/go.sum
@@ -439,8 +439,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
-github.com/karawitan/boxo v0.42.3-0.20260907071254-76cf61a1f633 h1:NcN03Kibfy8T3ivuyUtW7xwIXVRNjT9h70QSmKfXyE4=
-github.com/karawitan/boxo v0.42.3-0.20260907071254-76cf61a1f633/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
+github.com/karawitan/boxo v0.42.3-0.20260907201906-df6852a09b58 h1:4IMBY2Elx3w3miITzjIbvJ29LIKCH3fmiwTrxrsQOOA=
+github.com/karawitan/boxo v0.42.3-0.20260907201906-df6852a09b58/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.sum
+++ b/go.sum
@@ -340,6 +340,8 @@ github.com/ipfs-shipyard/nopfs/ipfs v0.25.0 h1:OqNqsGZPX8zh3eFMO8Lf8EHRRnSGBMqcd
 github.com/ipfs-shipyard/nopfs/ipfs v0.25.0/go.mod h1:BxhUdtBgOXg1B+gAPEplkg/GpyTZY+kCMSfsJvvydqU=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
+github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa h1:VoLDM25b+1HvjfJ8SpfHAECK457CqJpU2u4nT0XCLf4=
+github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=
@@ -439,8 +441,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
-github.com/karawitan/boxo v0.42.3-0.20260907201906-df6852a09b58 h1:4IMBY2Elx3w3miITzjIbvJ29LIKCH3fmiwTrxrsQOOA=
-github.com/karawitan/boxo v0.42.3-0.20260907201906-df6852a09b58/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/test/cli/backup_bootstrap_test.go
+++ b/test/cli/backup_bootstrap_test.go
@@ -10,11 +10,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestBackupBootstrapPeers covers a node whose configured bootstrap peers are
+// unreachable: it falls back to peers saved from an earlier run. Nothing
+// listens on the bootstrap address below, so every dial to it fails.
 func TestBackupBootstrapPeers(t *testing.T) {
+	const unreachableBootstrapPeer = "/ip4/127.0.0.1/tcp/1/p2p/12D3KooWAr43wwcGtURU6Ck6R7cbvfii2unzaK2moqNYQmBQwWgN"
+
 	nodes := harness.NewT(t).NewNodes(3).Init()
 	nodes.ForEachPar(func(n *harness.Node) {
 		n.UpdateConfig(func(cfg *config.Config) {
-			cfg.Bootstrap = []string{}
+			cfg.Bootstrap = []string{unreachableBootstrapPeer}
 			cfg.Addresses.Swarm = []string{fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", harness.NewRandPort())}
 			cfg.Discovery.MDNS.Enabled = false
 			cfg.Internal.BackupBootstrapInterval = config.NewOptionalDuration(250 * time.Millisecond)

--- a/test/dependencies/go.mod
+++ b/test/dependencies/go.mod
@@ -136,7 +136,7 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/bbloom v0.1.0 // indirect
-	github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262 // indirect
+	github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.4 // indirect
 	github.com/ipfs/go-cid v0.6.2 // indirect

--- a/test/dependencies/go.sum
+++ b/test/dependencies/go.sum
@@ -299,8 +299,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/bbloom v0.1.0 h1:nIWwfIE3AaG7RCDQIsrUonGCOTp7qSXzxH7ab/ss964=
 github.com/ipfs/bbloom v0.1.0/go.mod h1:lDy3A3i6ndgEW2z1CaRFvDi5/ZTzgM1IxA/pkL7Wgts=
-github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262 h1:ccv4Wuz0qtHE52U0r4r2+NpnFbPYJp8riL6vTX6i3ic=
-github.com/ipfs/boxo v0.42.3-0.20260904132258-02026ddcf262/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
+github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa h1:VoLDM25b+1HvjfJ8SpfHAECK457CqJpU2u4nT0XCLf4=
+github.com/ipfs/boxo v0.42.3-0.20260907225511-2edf737db3aa/go.mod h1:TCEs4l6Q6kfd1SUdYEzcxvC8JE1gc+6dObSs/6kOsb8=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.2.4 h1:pgsT9i8zB4YQkBIQRrBwqbQiXPogRCiQnfxd2bC4koI=


### PR DESCRIPTION
## Summary

Rework of this PR per @lidel's review in [#11453 (review)](https://github.com/ipfs/kubo/pull/11453#pullrequestreview-5127196673). The fix belongs in boxo (`bootstrap.bootstrapRound` skips the backup list when no bootstrap peers are configured), not behind a `Routing.Type=none` guard in kubo. This PR is now the **companion kubo PR** for [ipfs/boxo#1213](https://github.com/ipfs/boxo/pull/1213).

### What changed here

- **`go.mod` / `go.sum`**: pin the boxo fix via a temporary `replace` directive pointing at the boxo PR branch (`karawitan/boxo@76cf61a`). Once [ipfs/boxo#1213](https://github.com/ipfs/boxo/pull/1213) merges, this repoints at boxo `main` and converts to a pseudo-version pin.
- **`core/core_test.go`**: add `TestBootstrapWithEmptyPeerListAndStaleBackupPeers`, a kubo-level regression test for [#11452](https://github.com/ipfs/kubo/issues/11452). It verifies `IpfsNode.Bootstrap` runs without error with an empty `Bootstrap` config and a populated `TempBootstrapPeersKey` (stale backup peers from a previous run), and starts a bootstrapper whose rounds are no-ops for the backup list. The dialing behavior itself is fixed and unit-tested in boxo.
- **`docs/config.md`**: document under `Bootstrap` that an empty list disables all bootstrap dialing, including saved backup peers. Note that `Peering.Peers` and mDNS are independent and may still dial. (Reverts the overpromising `Routing.Type=none` wording from the original PR — `Peering.Peers` and mDNS still dial regardless.)
- **`docs/changelogs/v0.44.md`**: add a v0.44 highlight. Drops the v0.43 entry (already released) and the broken emoji from the original PR.

### What was removed from the original PR

- The `Routing.Type=none` guard in `core/core.go` is gone. Per lidel: `Routing.Type` and `Bootstrap` are separate settings; some users run `Routing.Type=none` with their own `Bootstrap` peers (private/static swarms), and the guard would silently break those. The guard also missed `ipfs daemon --routing=none`, which overrides routing at runtime without changing the config file.
- The `TestBootstrapSkippedWhenRoutingNone` test is replaced by `TestBootstrapWithEmptyPeerListAndStaleBackupPeers`.

### Behavior change

Previously, a node with default routing and an empty `Bootstrap` list would still dial backup peers persisted from previous runs. After this change (boxo fix), it does not. This aligns behavior with operator intent: an empty `Bootstrap` list now means "no bootstrap dialing at all, including saved backup peers." Nodes that configure explicit `Bootstrap` peers are unaffected; the backup-list fallback still runs when those peers fail to connect.

## Test plan

- [x] `go test ./core/ -run TestBootstrapWithEmptyPeerListAndStaleBackupPeers -v -count=1` passes
- [x] `go test ./core/ -count=1` passes (all existing core tests green)
- [x] `go vet ./core/...` passes
- [x] `gofmt -l core/` clean
- [x] `make mod_tidy` run (all three go.mod files tidied)
- [ ] Kubo CI green (this PR is a draft while it pins the unmerged boxo branch [ipfs/boxo#1213](https://github.com/ipfs/boxo/pull/1213))

## References

- Closes https://github.com/ipfs/kubo/issues/11452
- Companion boxo PR: https://github.com/ipfs/boxo/pull/1213
- Original review directing this approach: https://github.com/ipfs/kubo/pull/11453#pullrequestreview-5127196673
- https://discuss.ipfs.tech/t/how-can-i-disable-dht-in-kubo/19249

Generated with [Devin](https://devin.ai)
