### PR TITLE
fix: pollEndpoint always reports success due to shadowed err variable

### DIFF
--- a/test/dependencies/pollEndpoint/main.go
+++ b/test/dependencies/pollEndpoint/main.go
@@ -44,8 +44,9 @@ func main() {
 	log.Debugf("starting at %s, tries: %d, timeout: %s, addr: %s", start, *tries, *timeout, addr)
 
 	connTries := *tries
+	var c manet.Conn
 	for connTries > 0 {
-		c, err := manet.Dial(addr)
+		c, err = manet.Dial(addr)
 		if err == nil {
 			log.Debugf("ok -  endpoint reachable with %d tries remaining, took %s", *tries, time.Since(start))
 			c.Close()


### PR DESCRIPTION
## Summary

`pollEndpoint` (the sharness test helper that waits for an HTTP endpoint to be reachable) always returned exit 0 when the multiaddr was valid, even if every dial attempt failed. This made the daemon-readiness check in sharness tests unreliable.

### Root cause

Variable shadowing in the dial loop:

```go
addr, err := ma.NewMultiaddr(*host)  // err in function scope
...
for connTries > 0 {
    c, err := manet.Dial(addr)       // := creates a NEW err in loop scope
    ...
}
if err != nil {                      // checks the OUTER err (from NewMultiaddr), not dial err
    goto Fail
}
```

Since `NewMultiaddr` succeeds, the outer `err` is always `nil`. The `:=` on the dial line creates a separate `err` in the loop body scope, shadowing the outer one. The post-loop check sees the outer `nil` and never goes to `Fail`.

### Fix

Declare `c` before the loop and use `=` (assignment) instead of `:=` (declaration), so the dial error writes to the outer `err`:

```go
var c manet.Conn
for connTries > 0 {
    c, err = manet.Dial(addr)
    ...
}
```

### Verification

**Before the fix** — unreachable port incorrectly returns success:
```
$ pollEndpoint -host=/ip4/127.0.0.1/tcp/59999 -tries=3 -tout=100ms -v
connect failed: dial tcp4 127.0.0.1:59999: connect: connection refused
connect failed: dial tcp4 127.0.0.1:59999: connect: connection refused
connect failed: dial tcp4 127.0.0.1:59999: connect: connection refused
EXIT: 0  ← wrong
```

**After the fix** — correctly fails:
```
$ pollEndpoint -host=/ip4/127.0.0.1/tcp/59999 -tries=3 -tout=100ms -v
connect failed: dial tcp4 127.0.0.1:59999: connect: connection refused
connect failed: dial tcp4 127.0.0.1:59999: connect: connection refused
connect failed: dial tcp4 127.0.0.1:59999: connect: connection refused
failed
EXIT: 1  ← correct
```

**Reachable endpoint still works:**
```
$ pollEndpoint -host=/ip4/127.0.0.1/tcp/5772 -tries=5 -tout=1s -v
ok -  endpoint reachable with 5 tries remaining, took 1.9ms
EXIT: 0
```

**Sharness `t0152-profile.sh`**: 26/26 pass (darwin/arm64, Go 1.26.6).

#### Test plan
- [x] `pollEndpoint` against unreachable port returns exit 1 (was exit 0)
- [x] `pollEndpoint` against reachable port returns exit 0
- [x] `t0152-profile.sh` passes 26/26
- [ ] CI green

Generated with [Devin](https://devin.ai)