### PR TITLE
feat: manual TLS certificates for custom domain WSS listeners (RFC)

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -208,7 +208,7 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config, userResourceOverrides rcmgr.Part
 		fx.Provide(libp2p.SmuxTransport(cfg.Swarm.Transports)),
 		fx.Provide(libp2p.RelayTransport(enableRelayTransport)),
 		fx.Provide(libp2p.RelayService(enableRelayService, cfg.Swarm.RelayService)),
-		fx.Provide(libp2p.Transports(cfg.Swarm.Transports)),
+		fx.Provide(libp2p.Transports(cfg.Swarm.Transports, bcfg.Repo.Path())),
 		fx.Provide(libp2p.ListenOn(cfg.Addresses.Swarm)),
 		fx.Invoke(libp2p.SetupDiscovery(cfg.Discovery.MDNS.Enabled)),
 		fx.Provide(libp2p.ForceReachability(cfg.Internal.Libp2pForceReachability)),

--- a/core/node/libp2p/manualtls.go
+++ b/core/node/libp2p/manualtls.go
@@ -1,0 +1,98 @@
+package libp2p
+
+import (
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var manualTLSLog = logging.Logger("manualtls")
+
+// manualCertCache stores loaded certificates keyed by SNI hostname, with the
+// file modification time used to invalidate stale entries.
+type manualCertCache struct {
+	mu      sync.RWMutex
+	entries map[string]manualCertEntry
+}
+
+type manualCertEntry struct {
+	cert      tls.Certificate
+	certMtime time.Time
+	keyMtime  time.Time
+}
+
+// newManualCertCache creates a new, empty certificate cache.
+func newManualCertCache() *manualCertCache {
+	return &manualCertCache{entries: make(map[string]manualCertEntry)}
+}
+
+// loadManualCert reads the cert and key files for the given SNI hostname from
+// repoPath, returning a cached copy if the files have not changed since the
+// last load. It returns os.ErrNotExist-style errors when files are missing so
+// callers can distinguish "no manual cert" from "broken manual cert".
+func (c *manualCertCache) load(repoPath, sni string) (*tls.Certificate, error) {
+	if sni == "" {
+		return nil, nil
+	}
+
+	certPath := filepath.Join(repoPath, sni+".crt")
+	keyPath := filepath.Join(repoPath, sni+".key")
+
+	certFi, err := os.Stat(certPath)
+	if err != nil {
+		return nil, err // wraps os.ErrNotExist when file is absent
+	}
+	keyFi, err := os.Stat(keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.RLock()
+	if entry, ok := c.entries[sni]; ok && entry.certMtime.Equal(certFi.ModTime()) && entry.keyMtime.Equal(keyFi.ModTime()) {
+		c.mu.RUnlock()
+		return &entry.cert, nil
+	}
+	c.mu.RUnlock()
+
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.entries[sni] = manualCertEntry{
+		cert:      cert,
+		certMtime: certFi.ModTime(),
+		keyMtime:  keyFi.ModTime(),
+	}
+	c.mu.Unlock()
+
+	return &cert, nil
+}
+
+// manualCertGetter returns a GetCertificate callback that serves manual TLS
+// certificates from $IPFS_PATH/<sni>.crt and $IPFS_PATH/<sni>.key when present,
+// falling back to the provided fallback (e.g. p2p-forge's certmagic) otherwise.
+//
+// This lets an operator use WSS on a custom domain (e.g. example.net) by
+// placing certificate files in the IPFS repo, while AutoTLS continues to
+// handle *.libp2p.direct domains.
+func manualCertGetter(repoPath string, cache *manualCertCache, fallback func(*tls.ClientHelloInfo) (*tls.Certificate, error)) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		cert, err := cache.load(repoPath, hello.ServerName)
+		if err == nil && cert != nil {
+			return cert, nil
+		}
+		if err != nil && !os.IsNotExist(err) {
+			manualTLSLog.Errorf("loading manual cert for %q: %v", hello.ServerName, err)
+		}
+		if fallback != nil {
+			return fallback(hello)
+		}
+		return nil, err
+	}
+}

--- a/core/node/libp2p/manualtls_test.go
+++ b/core/node/libp2p/manualtls_test.go
@@ -1,0 +1,197 @@
+package libp2p
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateTestCert creates a self-signed certificate for the given hostname
+// and writes it (with its private key) to certPath and keyPath in PEM format.
+func generateTestCert(t *testing.T, host, certPath, keyPath string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		DNSNames:     []string{host},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	if err := writePEM(certPath, "CERTIFICATE", der); err != nil {
+		t.Fatalf("write cert file: %v", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	if err := writePEM(keyPath, "EC PRIVATE KEY", keyDER); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+}
+
+func writePEM(path, blockType string, der []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return pem.Encode(f, &pem.Block{Type: blockType, Bytes: der})
+}
+
+func TestManualCertCache_LoadAndCache(t *testing.T) {
+	tmp := t.TempDir()
+	host := "example.net"
+	certPath := filepath.Join(tmp, host+".crt")
+	keyPath := filepath.Join(tmp, host+".key")
+	generateTestCert(t, host, certPath, keyPath)
+
+	cache := newManualCertCache()
+
+	// First load reads from disk.
+	cert, err := cache.load(tmp, host)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("first load returned nil cert")
+	}
+
+	// Second load comes from cache (same mtime).
+	cert2, err := cache.load(tmp, host)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if cert2 == nil {
+		t.Fatal("second load returned nil cert")
+	}
+
+	// Touch the cert file to invalidate cache; next load reads from disk again.
+	now := time.Now().Add(time.Second)
+	if err := os.Chtimes(certPath, now, now); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	cert3, err := cache.load(tmp, host)
+	if err != nil {
+		t.Fatalf("third load after touch: %v", err)
+	}
+	if cert3 == nil {
+		t.Fatal("third load returned nil cert")
+	}
+}
+
+func TestManualCertCache_MissingFiles(t *testing.T) {
+	tmp := t.TempDir()
+	cache := newManualCertCache()
+
+	_, err := cache.load(tmp, "nonexistent.example")
+	if err == nil {
+		t.Fatal("expected error for missing cert files")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected os.ErrNotExist, got: %v", err)
+	}
+}
+
+func TestManualCertCache_EmptySNI(t *testing.T) {
+	tmp := t.TempDir()
+	cache := newManualCertCache()
+
+	cert, err := cache.load(tmp, "")
+	if err != nil {
+		t.Fatalf("empty SNI should not error: %v", err)
+	}
+	if cert != nil {
+		t.Fatal("empty SNI should return nil cert")
+	}
+}
+
+func TestManualCertGetter_ManualCertPresent(t *testing.T) {
+	tmp := t.TempDir()
+	host := "custom.example"
+	generateTestCert(t, host, filepath.Join(tmp, host+".crt"), filepath.Join(tmp, host+".key"))
+
+	cache := newManualCertCache()
+	called := false
+	fallback := func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		called = true
+		return nil, nil
+	}
+	getter := manualCertGetter(tmp, cache, fallback)
+
+	cert, err := getter(&tls.ClientHelloInfo{ServerName: host})
+	if err != nil {
+		t.Fatalf("getter: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("getter returned nil cert")
+	}
+	if called {
+		t.Fatal("fallback should not be called when manual cert is present")
+	}
+}
+
+func TestManualCertGetter_FallsBackToForge(t *testing.T) {
+	tmp := t.TempDir()
+	host := "libp2p.direct" // no manual cert files for this host
+
+	cache := newManualCertCache()
+	fallbackCert := &tls.Certificate{}
+	called := false
+	fallback := func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		called = true
+		return fallbackCert, nil
+	}
+	getter := manualCertGetter(tmp, cache, fallback)
+
+	cert, err := getter(&tls.ClientHelloInfo{ServerName: host})
+	if err != nil {
+		t.Fatalf("getter: %v", err)
+	}
+	if cert != fallbackCert {
+		t.Fatal("expected fallback cert")
+	}
+	if !called {
+		t.Fatal("fallback should be called when no manual cert exists")
+	}
+}
+
+func TestManualCertGetter_NoFallbackNoCert(t *testing.T) {
+	tmp := t.TempDir()
+	host := "nonexistent.example"
+
+	cache := newManualCertCache()
+	getter := manualCertGetter(tmp, cache, nil)
+
+	_, err := getter(&tls.ClientHelloInfo{ServerName: host})
+	if err == nil {
+		t.Fatal("expected error when no manual cert and no fallback")
+	}
+}

--- a/core/node/libp2p/transport.go
+++ b/core/node/libp2p/transport.go
@@ -1,6 +1,7 @@
 package libp2p
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 
@@ -17,7 +18,7 @@ import (
 	"go.uber.org/fx"
 )
 
-func Transports(tptConfig config.Transports) any {
+func Transports(tptConfig config.Transports, repoPath string) any {
 	return func(params struct {
 		fx.In
 		Fprint   PNetFingerprint         `optional:"true"`
@@ -34,10 +35,23 @@ func Transports(tptConfig config.Transports) any {
 		}
 
 		if wsEnabled {
+			cache := newManualCertCache()
 			if params.ForgeMgr == nil {
-				opts.Opts = append(opts.Opts, libp2p.Transport(websocket.New))
+				// No AutoTLS: only serve TLS when manual cert files are present
+				// for the requested SNI. Connections to domains without a
+				// matching cert file will fail the TLS handshake, which is the
+				// expected behaviour for a missing certificate.
+				tlsCfg := &tls.Config{
+					GetCertificate: manualCertGetter(repoPath, cache, nil),
+				}
+				opts.Opts = append(opts.Opts, libp2p.Transport(websocket.New, websocket.WithTLSConfig(tlsCfg)))
 			} else {
-				opts.Opts = append(opts.Opts, libp2p.Transport(websocket.New, websocket.WithTLSConfig(params.ForgeMgr.TLSConfig())))
+				// AutoTLS is enabled: check manual cert files first, then fall
+				// back to p2p-forge's certmagic for *.libp2p.direct domains.
+				forgeTLS := params.ForgeMgr.TLSConfig()
+				tlsCfg := forgeTLS.Clone()
+				tlsCfg.GetCertificate = manualCertGetter(repoPath, cache, forgeTLS.GetCertificate)
+				opts.Opts = append(opts.Opts, libp2p.Transport(websocket.New, websocket.WithTLSConfig(tlsCfg)))
 			}
 		}
 

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -19,4 +19,6 @@
 
 ### 📝 Changelog
 
+- Added support for manual TLS certificates for custom domain WSS (`/wss`) listeners. Place `$IPFS_PATH/<domain>.crt` and `$IPFS_PATH/<domain>.key` files in the IPFS repo to serve WSS on your own domain without a reverse proxy. Coexists with `AutoTLS` (manual certs take precedence for matching SNI hostnames). See [`docs/config.md`](../config.md#manual-tls-certificates-for-custom-domain-wss).
+
 ### 👨‍👩‍👧‍👦 Contributors

--- a/docs/config.md
+++ b/docs/config.md
@@ -880,6 +880,31 @@ Default: [certmagic.LetsEncryptProductionCA](https://pkg.go.dev/github.com/caddy
 
 Type: `optionalString`
 
+### Manual TLS Certificates for Custom Domain WSS
+
+Kubo supports manual TLS certificates for [Secure WebSocket](https://github.com/libp2p/specs/blob/master/websockets/README.md) (`/wss`) listeners on custom domains, complementing the automatic [`AutoTLS`](#autotls) feature which only covers `*.libp2p.direct` domains.
+
+To use a custom domain (e.g. `example.net`), place a certificate and its private key in the IPFS repo directory using the SNI hostname as the filename:
+
+```
+$IPFS_PATH/example.net.crt   # PEM-encoded certificate (chain)
+$IPFS_PATH/example.net.key   # PEM-encoded private key
+```
+
+Then add a `/dns/example.net/.../wss` (or `/dns/example.net/.../tls/sni/example.net/ws`) address to [`Addresses.Swarm`](#addressesswarm).
+
+When a TLS client connects and sends the SNI hostname `example.net`, Kubo loads the matching `.crt`/`.key` files and serves that certificate. Loaded certificates are cached in memory and automatically reloaded when the files change on disk.
+
+This feature coexists with `AutoTLS`:
+- If manual cert files exist for the requested SNI hostname, they are used.
+- Otherwise, if `AutoTLS` is enabled, the p2p-forge certificate (for `*.libp2p.direct`) is used.
+- If neither is available, the TLS handshake fails for that hostname.
+
+This follows the same file-convention approach as the [private network `swarm.key`](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmrelayclientenabled) — no explicit config flag is needed; the feature is active only when cert files are present.
+
+> [!NOTE]
+> This is useful when you already have a TLS certificate for your own domain (e.g. from your own ACME client or a commercial CA) and want to serve WSS directly from Kubo without a reverse proxy like nginx or Caddy.
+
 ## `Bitswap`
 
 High level client and server configuration of the [Bitswap Protocol](https://specs.ipfs.tech/bitswap-protocol/) over libp2p.


### PR DESCRIPTION
## Summary

Draft / RFC PR to drive design discussion for #11460.

Adds support for manual TLS certificate/key files for WSS (`/wss`) listeners on custom domains, complementing the existing [`AutoTLS`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotls) feature which only covers `*.libp2p.direct` domains.

### Motivation

This addresses the remaining review concern from @lidel on #8740 (now superseded by #10521):

> What if we do the same thing we did for private swarm and if one adds `/dns/example.net/.../wss` addr, check if `$IPFS_PATH/example.net.crt` and `$IPFS_PATH/example.net.key` exist and use them if present? (and if not, do ACME)

Currently, operators who want WSS on their own domain (e.g. `example.net`) must run a reverse proxy (nginx, Caddy, etc.) in front of Kubo. This PR lets them serve WSS directly from Kubo using their own certificates.

### Design

Follows the **file convention** approach (same as `swarm.key` for private networks):

1. Operator places `$IPFS_PATH/<domain>.crt` and `$IPFS_PATH/<domain>.key` in the IPFS repo
2. Adds a `/dns/example.net/.../wss` address to `Addresses.Swarm`
3. When a TLS client connects with SNI `example.net`, Kubo loads the matching cert/key files
4. Loaded certificates are cached in memory and reloaded when files change on disk

**Coexistence with AutoTLS:**
- Manual certs take precedence for matching SNI hostnames
- If no manual cert exists for the SNI, falls back to p2p-forge's certmagic (for `*.libp2p.direct`)
- If neither is available, the TLS handshake fails for that hostname

### Implementation

- `core/node/libp2p/manualtls.go` — cert cache + `GetCertificate` callback that checks manual files first, falls back to p2p-forge
- `core/node/libp2p/transport.go` — wires the manual cert getter into the websocket transport's TLS config
- `core/node/groups.go` — passes repo path to `Transports()`
- `docs/config.md` — documents the file convention
- `docs/changelogs/v0.44.md` — changelog entry
- `core/node/libp2p/manualtls_test.go` — unit tests for cache, loading, fallback, and edge cases

### Open questions for reviewers

1. **File location:** Files in repo root (`$IPFS_PATH/<domain>.crt`) vs. a subdirectory (`$IPFS_PATH/wss-certs/<domain>.crt`)? The repo root follows the `swarm.key` precedent but could get cluttered with many domains.
2. **Config option:** Should this also have an explicit config flag (e.g. `Swarm.Transports.Network.Websocket.ManualTLS`), or is the file convention sufficient as an implicit opt-in?
3. **Security:** Should we restrict cert file permissions (e.g. warn if key is world-readable)?
4. **Wildcard certs:** Should we support wildcard matching (e.g. `*.example.net.crt` matching `foo.example.net`)?

Closes #11460.

#### Test plan

- [x] `go build ./core/... ./cmd/...` passes
- [x] `go vet ./core/node/...` passes
- [x] `gofmt` clean
- [x] Unit tests pass: `go test ./core/node/libp2p/ -run TestManualCert -v`
- [ ] Integration test: start daemon with manual cert files, verify WSS handshake
- [ ] Integration test: verify AutoTLS fallback when no manual cert exists

Generated with [Devin](https://devin.ai)
