### PR TITLE
fix(daemon): keep gateway up when --mount fails

### DIFF
--- a/cmd/ipfs/kubo/daemon.go
+++ b/cmd/ipfs/kubo/daemon.go
@@ -632,13 +632,21 @@ take effect.
 	}
 	if mount {
 		if err := mountFuse(req, cctx); err != nil {
-			return err
+			// A FUSE mount failure (missing or unusable mount points, no FUSE
+			// support, permission errors, etc.) must not prevent the rest of
+			// the daemon — in particular the HTTP gateway — from starting.
+			// Warn and continue without FUSE mounts instead of aborting.
+			// See https://github.com/ipfs/kubo/issues/8977.
+			fmt.Fprintf(os.Stderr, "Warning: --mount failed; continuing without FUSE mounts: %s\n", err)
+			log.Warnf("--mount failed; continuing without FUSE mounts: %s", err)
+			mount = false
+		} else {
+			defer func() {
+				if _err != nil {
+					nodeMount.Unmount(node)
+				}
+			}()
 		}
-		defer func() {
-			if _err != nil {
-				nodeMount.Unmount(node)
-			}
-		}()
 	}
 
 	// repo blockstore GC - if --enable-gc flag is present

--- a/docs/changelogs/v0.44.md
+++ b/docs/changelogs/v0.44.md
@@ -13,6 +13,10 @@
 
 ### 🔦 Highlights
 
+#### 🌐 `ipfs daemon` stays up as a gateway when `--mount` fails
+
+When `ipfs daemon --mount` was requested but the FUSE mount failed (missing or unusable mount points, no FUSE support, permission errors, etc.), the daemon used to abort before starting the HTTP gateway, so the node silently stopped acting as a gateway with no clear indication why ([#8977](https://github.com/ipfs/kubo/issues/8977)). The daemon now prints a warning and continues without FUSE mounts, keeping the gateway and the rest of the daemon running.
+
 #### 📦️ Dependency updates
 
 - update `go-ds-pebble` to [v0.5.13](https://github.com/ipfs/go-ds-pebble/releases/tag/v0.5.13)

--- a/test/cli/daemon_mount_test.go
+++ b/test/cli/daemon_mount_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/kubo/test/cli/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDaemonGatewayUpWhenMountFails is a regression test for
+// https://github.com/ipfs/kubo/issues/8977: when --mount is requested but the
+// FUSE mount fails, the daemon used to abort before starting the HTTP gateway,
+// so the node silently stopped acting as a gateway. The daemon must now warn
+// and continue, keeping the gateway (and the rest of the daemon) up.
+func TestDaemonGatewayUpWhenMountFails(t *testing.T) {
+	t.Parallel()
+	node := harness.NewT(t).NewNode().Init()
+
+	// Force a FUSE mount failure without requiring FUSE support on the host:
+	// --mount-ipfs points at a path that does not exist, so mountFuse fails at
+	// checkFusePath before any FUSE syscall. --mount is rejected in offline
+	// mode, so the daemon runs online.
+	node.StartDaemon(
+		"--mount",
+		"--mount-ipfs=/ipfs-kubo-mount-does-not-exist-8977",
+		"--mount-ipns=/ipns-kubo-mount-does-not-exist-8977",
+		"--mount-mfs=/mfs-kubo-mount-does-not-exist-8977",
+	)
+	t.Cleanup(func() { node.StopDaemon() })
+
+	// The daemon stayed up: StartDaemon's WaitOnAPI already returned, and the
+	// gateway address file was written by serveHTTPGateway.
+	cid := node.IPFSAddStr("hello from a daemon whose mount failed")
+
+	client := node.GatewayClient()
+	client.TemplateData = map[string]string{"CID": cid}
+
+	t.Run("gateway still serves content", func(t *testing.T) {
+		resp := client.Get("/ipfs/{{.CID}}")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NotNil(t, resp.Body)
+		assert.Equal(t, "hello from a daemon whose mount failed", resp.Body)
+	})
+
+	t.Run("mount failure was reported on stderr", func(t *testing.T) {
+		stderr := node.Daemon.Stderr.String()
+		assert.Contains(t, stderr, "--mount failed")
+		assert.Contains(t, stderr, "continuing without FUSE mounts")
+		// Sanity check: we did not silently mount anything.
+		assert.False(t, strings.Contains(stderr, "IPFS mounted at:"))
+	})
+}


### PR DESCRIPTION
## What

Fixes #8977.

When `ipfs daemon --mount` was requested but the FUSE mount failed (missing or unusable mount points, no FUSE support, permission errors, etc.), the daemon aborted before reaching `serveHTTPGateway`, so the node silently stopped acting as a gateway. The startup output did not even mention the gateway.

## Why

The startup sequence in `cmd/ipfs/kubo/daemon.go` ordered the FUSE mount (`mountFuse`) before `serveHTTPGateway`:

```go
if mount {
    if err := mountFuse(req, cctx); err != nil {
        return err          // <-- daemon exits here
    }
    ...
}
...
gwErrc, err := serveHTTPGateway(req, cctx)   // <-- never reached
```

A FUSE mount is an optional, experimental feature. Its failure should not take down the HTTP gateway the operator asked the daemon to serve, nor the rest of the daemon (GC, libp2p gateway, metrics, MFS pinning).

## Change

When `mountFuse` fails, print a warning to stderr and via the log, then continue without FUSE mounts so the rest of the daemon — including the HTTP gateway — starts normally. The unmount cleanup `defer` only runs when the mount actually succeeded.

This is a bug fix for the `kind/bug`/`help wanted` issue #8977; it does not touch the `/api/v0/` RPC API, the HTTP gateway contract, the CID recipe, or any wire behavior.

## Verification

- `go build ./cmd/ipfs/` and `go vet ./cmd/ipfs/ ./test/cli/` pass.
- New regression test `TestDaemonGatewayUpWhenMountFails` in `test/cli/daemon_mount_test.go`:
  - starts the daemon with `--mount` and non-existent mount paths (forces `mountFuse` to fail at `checkFusePath`, no FUSE support needed on the host),
  - asserts the gateway still serves content (`GET /ipfs/<cid>` → 200),
  - asserts the mount failure is reported on stderr and nothing was silently mounted.
- Test passes locally.

```
=== RUN   TestDaemonGatewayUpWhenMountFails
--- PASS: TestDaemonGatewayUpWhenMountFails (2.87s)
    --- PASS: TestDaemonGatewayUpWhenMountFails/gateway_still_serves_content (0.00s)
    --- PASS: TestDaemonGatewayUpWhenMountFails/mount_failure_was_reported_on_stderr (0.00s)
PASS
```

## Changelog

Added a highlight to `docs/changelogs/v0.44.md`.

Generated with [Devin](https://devin.ai)