### PR TITLE
fix(stats): reject non-positive bandwidth polling intervals [skip changelog]

### DIFF
--- a/core/commands/stat.go
+++ b/core/commands/stat.go
@@ -125,6 +125,9 @@ Example:
 		if err != nil {
 			return err
 		}
+		if interval <= 0 {
+			return cmds.Errorf(cmds.ErrClient, "interval must be greater than zero")
+		}
 
 		doPoll, _ := req.Options[statPollOptionName].(bool)
 		for {

--- a/test/cli/stats_test.go
+++ b/test/cli/stats_test.go
@@ -11,6 +11,18 @@ import (
 func TestStats(t *testing.T) {
 	t.Parallel()
 
+	t.Run("stats bw rejects non-positive intervals", func(t *testing.T) {
+		t.Parallel()
+		node := harness.NewT(t).NewNode().Init().StartDaemon()
+		defer node.StopDaemon()
+
+		for _, interval := range []string{"0s", "-1s"} {
+			res := node.RunIPFS("stats", "bw", "--poll", "--interval="+interval)
+			assert.Equal(t, 1, res.ExitCode(), "interval %s should be rejected", interval)
+			assert.Contains(t, res.Stderr.Trimmed(), "interval must be greater than zero")
+		}
+	})
+
 	t.Run("stats dht", func(t *testing.T) {
 		t.Parallel()
 		nodes := harness.NewT(t).NewNodes(2).Init().StartDaemons().Connect()


### PR DESCRIPTION
## Summary

- Reject zero and negative polling intervals in `ipfs stats bw`.
- Add CLI regression coverage for `0s` and `-1s`.

## Motivation

`time.ParseDuration` accepts non-positive durations. With `--poll`, passing `--interval=0s` or `--interval=-1s` makes `time.After` immediately ready, causing `stats bw` to repeatedly collect and emit bandwidth statistics without waiting.

The command now returns:

    interval must be greater than zero

for non-positive intervals.

## Testing

- `make build`
- `go test ./test/cli -run '^TestStats$' -count=1 -v`
- `go test ./core/commands -run '^$'`
- `git diff --check`